### PR TITLE
Fix define in arith.h

### DIFF
--- a/arith.h
+++ b/arith.h
@@ -195,7 +195,7 @@ void arith_landau_function_vec(fmpz * res, slong len);
 /* Dedekind sums *************************************************************/
 
 #define arith_dedekind_sum_naive fmpq_dedekind_sum_naive
-#define arith_dedekind_sum_coprime_d d_dedekind_sum_coprime
+#define arith_dedekind_sum_coprime_d fmpq_dedekind_sum_coprime_d
 #define arith_dedekind_sum_coprime_large fmpq_dedekind_sum_coprime_large
 #define arith_dedekind_sum_coprime fmpq_dedekind_sum_coprime
 #define arith_dedekind_sum fmpq_dedekind_sum


### PR DESCRIPTION
arith_dedekind_sum_coprime_d had an incorrect define, which made
tests with --enable-cxx fail.

With this, my #82 patch, gmp 6.0.0, mpfr 3.1.2.p8 and gcc 4.9.0 on an x86_64 system, make check with --enable-cxx completes successfully.