### PR TITLE
Resolved bug #111, added copyright header in n_is_prime_pocklington which was unintentionally removed in earlier commits.

### DIFF
--- a/ulong_extras/factor_partial.c
+++ b/ulong_extras/factor_partial.c
@@ -47,6 +47,12 @@ mp_limb_t n_factor_partial(n_factor_t * factors, mp_limb_t n, mp_limb_t limit, i
 
    cofactor = n_factor_trial_partial(factors, n, &prod, FLINT_FACTOR_TRIAL_PRIMES, limit);
    if (prod > limit) return cofactor;
+
+   if ( cofactor == 1 )
+   {
+      return cofactor;
+   }
+
    if (is_prime2(cofactor, proved)) 
    {
       n_factor_insert(factors, cofactor, UWORD(1));

--- a/ulong_extras/is_prime_pocklington.c
+++ b/ulong_extras/is_prime_pocklington.c
@@ -1,3 +1,29 @@
+/*=============================================================================
+
+    This file is part of FLINT.
+
+    FLINT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    FLINT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2008 Peter Shrimpton
+    Copyright (C) 2009 William Hart
+    Copyright (C) 2015 Kushagra Singh
+
+******************************************************************************/
 #include <gmp.h>
 #define ulong ulongxx /* interferes with system includes */
 #include <math.h>
@@ -68,7 +94,7 @@ n_is_prime_pocklington(mp_limb_t n, ulong iterations)
         mp_limb_t exp = n1 / factors.p[i];
         pass = 0;
 
-        for (j = 2; j < iterations && pass == 0 && factors.p[i]!=1; j++)
+        for (j = 2; j < iterations && pass == 0; j++)
         {
             b = n_powmod2_preinv(j, exp, n, ninv);
             if (n_powmod2_ui_preinv(b, factors.p[i], n, ninv) != UWORD(1))


### PR DESCRIPTION
Hey,

- I removed the hack which was used in the pockligton implementation, and updated it factor_partial so that it no longer returns 1 in the factor struct. 

- Both n_is_prime_pocklington and n_factor_partial are passing tests.