### PR TITLE
Fix build error of t-NTL-interface regardless of --disable-{shared,static}

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -226,13 +226,13 @@ build/interfaces:
 	mkdir -p build/interfaces
 
 build/interfaces/NTL-interface.lo: interfaces/NTL-interface.cpp NTL-interface.h
-	$(QUIET_CXX) $(CXX) $(PIC_FLAG) $(CFLAGS) $(INCS) -c $< -o $@;
+	$(QUIET_CXX) $(CXX) $(PIC_FLAG) $(CFLAGS) $(INCS) -c $< -o $@
 
 build/interfaces/NTL-interface.o: interfaces/NTL-interface.cpp NTL-interface.h
-	$(QUIET_CXX) $(CXX) $(CFLAGS) $(INCS) -c $< -o $@;
+	$(QUIET_CXX) $(CXX) $(CFLAGS) $(INCS) -c $< -o $@
 
-build/interfaces/test/t-NTL-interface$(EXEEXT): interfaces/test/t-NTL-interface.cpp
-	$(QUIET_CXX) $(CXX) $(CFLAGS) $(INCS) $< build/interfaces/NTL-interface.lo -o $@ $(LIBS);
+build/interfaces/test/t-NTL-interface$(EXEEXT): interfaces/test/t-NTL-interface.cpp build/interfaces/NTL-interface.o
+	$(QUIET_CXX) $(CXX) $(CFLAGS) $(INCS) $< build/interfaces/NTL-interface.o -o $@ $(LIBS)
 
 print-%:
 	@echo '$*=$($*)'


### PR DESCRIPTION
Let `t-NTL-interface$(EXEEXT)` depend on the object file it gets linked with,
such that the latter gets built in case it doesn't exist already.
Also remove *a few* of the superfluous semicolons... ;-)

(The previous fix just renamed the object file, such that the build succeeded with `--disable-static`, but then in turn failed with `--disable-shared`.)
