### PR TITLE
Fix some small documentation typos

### DIFF
--- a/fmpz/doc/fmpz.txt
+++ b/fmpz/doc/fmpz.txt
@@ -1022,7 +1022,7 @@ int fmpz_popcnt(const fmpz_t a)
 
     The following functions can be used to reconstruct an integer from its
     residues modulo a set of small (word-size) prime numbers. The first two
-    functions, \code{fmpz_CRT_ui} and \code{fmpz_CRT_ui_unsigned}, are easy
+    functions, \code{fmpz_CRT_ui} and \code{fmpz_CRT}, are easy
     to use and allow building the result one residue at a time, which is
     useful when the number of needed primes is not known in advance.
 

--- a/nmod_poly/doc/nmod_poly.txt
+++ b/nmod_poly/doc/nmod_poly.txt
@@ -1321,7 +1321,7 @@ void nmod_poly_evaluate_mat_paterson_stockmeyer(nmod_mat_t dest,
     and stores the result in \code{dest}. The dimension and modulus of
     \code{dest} is assumed to be same as that of \code{c}. \code{dest} and 
     \code{c} may be aliased. Paterson-Stockmeyer algorithm is used to compute
-    the result. The algorithm is described in \cite{Paterson73}.
+    the result. The algorithm is described in \cite{Paterson1973}.
 
 void nmod_poly_evaluate_mat(nmod_mat_t dest, const nmod_poly_t poly,
                         const nmod_mat_t c)
@@ -1330,7 +1330,7 @@ void nmod_poly_evaluate_mat(nmod_mat_t dest, const nmod_poly_t poly,
     and stores the result in \code{dest}. The dimension and modulus of
     \code{dest} is assumed to be same as that of \code{c}. \code{dest} and 
     \code{c} may be aliased. This function automatically switches between
-    horner's method and paterson_stockmeyer algorithm.
+    Horner's method and the Paterson-Stockmeyer algorithm.
 
 *******************************************************************************
 


### PR DESCRIPTION
I fixed a few typos in the LaTeX documentation, including one that was making `make` fail in `doc/latex`.