### PR TITLE
Fix for issue #178. Always create the link FLINT_LIBNAME to FLINT_LIB…

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -116,9 +116,8 @@ $(FLINT_LIB): $(LOBJS) $(LIB_SOURCES) $(EXT_SOURCES) $(HEADERS) $(EXT_HEADERS) |
 	fi
 	$(AT)if [ "$(FLINT_SOLIB)" -eq "1" ]; then \
 		$(LDCONFIG) -n "$(CURDIR)"; \
-	else \
-		ln -sf "$(CURDIR)/$(FLINT_LIB)" "$(CURDIR)/$(FLINT_LIBNAME)"; \
 	fi
+	ln -sf "$(FLINT_LIB)" "$(FLINT_LIBNAME)"; \
 
 libflint.a: $(OBJS) $(LIB_SOURCES) $(EXT_SOURCES) $(HEADERS) $(EXT_HEADERS) | build build/interfaces
 	$(AT)$(foreach ext, $(EXTENSIONS), $(foreach dir, $(filter-out %templates, $(patsubst $(ext)/%.h, %, $(wildcard $(ext)/*.h))), mkdir -p build/$(dir); BUILD_DIR=$(CURDIR)/build/$(dir); export BUILD_DIR; MOD_DIR=$(dir); export MOD_DIR; $(MAKE) -f $(CURDIR)/Makefile.subdirs -C $(ext)/$(dir) static || exit $$?;))


### PR DESCRIPTION
… as ldconfig doesn't actually do this (or at least not always).