### PR TITLE
Add Darwin to the list of OS settin /dev/null for LDCONFIG

### DIFF
--- a/configure
+++ b/configure
@@ -427,7 +427,7 @@ echo "Configuring...${MACHINE}-${OS}"
 
 # sometimes LDCONFIG is not to be found in the path. Look at some common places.
 case "$OS" in
-   MINGW*|CYGWIN*)
+   MINGW*|CYGWIN*|Darwin)
       LDCONFIG="/dev/null";;
    *)
       if [ -z "$LDCONFIG" ]; then


### PR DESCRIPTION
As discussed in #180. Tested to work on OS X too.