### PR TITLE
Fix Mac OS X install_name (aka soname)

### DIFF
--- a/configure
+++ b/configure
@@ -446,7 +446,7 @@ if [ -z "$FLINT_LIB" ]; then
    case "$OS" in
       Darwin)
          FLINT_LIBNAME="libflint.dylib"
-         FLINT_LIB="libflint-$FLINT_MAJOR.$FLINT_MINOR.$FLINT_PATCH.dylib"
+         FLINT_LIB="libflint-$FLINT_MAJOR.dylib"
          EXTRA_SHARED_FLAGS="-install_name $PREFIX/lib/$FLINT_LIB"
          EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -compatibility_version $FLINT_MAJOR.$FLINT_MINOR"
          EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -current_version $FLINT_MAJOR.$FLINT_MINOR.$FLINT_PATCH"

--- a/configure
+++ b/configure
@@ -167,7 +167,7 @@ while [ "$1" != "" ]; do
          REENTRANT=1
          ;;
       --with-gc)
-	 WANT_GC=1
+         WANT_GC=1
          if [ ! -z "$VALUE" ]; then
             GC_DIR="$VALUE"
          fi
@@ -355,7 +355,7 @@ if [ -z "$BUILD" ]; then
       if [ "$(ARCH)" = "x86_64" ]; then
          OS="MINGW64"
       else
-	 OS="MINGW32"
+         OS="MINGW32"
       fi
    elif [ "$(uname | cut -d_ -f1)" = "MINGW32" ]; then
       if [ "$ABI" = "64" ]; then

--- a/configure
+++ b/configure
@@ -447,17 +447,31 @@ if [ -z "$FLINT_LIB" ]; then
       Darwin)
          FLINT_LIBNAME="libflint.dylib"
          FLINT_LIB="libflint-$FLINT_MAJOR.$FLINT_MINOR.$FLINT_PATCH.dylib"
-         EXTRA_SHARED_FLAGS="-install_name $PREFIX/lib/$FLINT_LIB -compatibility_version $FLINT_MAJOR.$FLINT_MINOR -current_version $FLINT_MAJOR.$FLINT_MINOR.$FLINT_PATCH -Wl,-rpath,$GMP_LIB_DIR -Wl,-rpath,$MPFR_LIB_DIR";;
+         EXTRA_SHARED_FLAGS="-install_name $PREFIX/lib/$FLINT_LIB"
+         EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -compatibility_version $FLINT_MAJOR.$FLINT_MINOR"
+         EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -current_version $FLINT_MAJOR.$FLINT_MINOR.$FLINT_PATCH"
+         EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -Wl,-rpath,$GMP_LIB_DIR"
+         EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -Wl,-rpath,$MPFR_LIB_DIR"
+         ;;
       CYGWIN* | MINGW*)
          FLINT_LIBNAME="libflint.dll"
          FLINT_LIB="libflint-$FLINT_MAJOR.dll"
-         EXTRA_SHARED_FLAGS="-static-libgcc -shared -Wl,--export-all-symbols -Wl,-soname,libflint-$FLINT_MAJOR.dll.$FLINT_MINOR.$FLINT_PATCH -Wl,-rpath,$GMP_LIB_DIR -Wl,-rpath,$MPFR_LIB_DIR"
-         FLINT_DLL=1;;
+         EXTRA_SHARED_FLAGS="-static-libgcc"
+         EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -shared"
+         EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -Wl,--export-all-symbols"
+         EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -Wl,-soname,libflint-$FLINT_MAJOR.dll.$FLINT_MINOR.$FLINT_PATCH"
+         EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -Wl,-rpath,$GMP_LIB_DIR"
+         EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -Wl,-rpath,$MPFR_LIB_DIR"
+         FLINT_DLL=1
+         ;;
       *)
-	 FLINT_LIBNAME="libflint.so"
+         FLINT_LIBNAME="libflint.so"
          FLINT_LIB="libflint.so.$FLINT_MAJOR.$FLINT_MINOR.$FLINT_PATCH"
-         EXTRA_SHARED_FLAGS="-Wl,-soname,libflint.so.$FLINT_MAJOR -Wl,-rpath,$GMP_LIB_DIR -Wl,-rpath,$MPFR_LIB_DIR"
-	 FLINT_SOLIB=1
+         EXTRA_SHARED_FLAGS="-Wl,-soname,libflint.so.$FLINT_MAJOR"
+         EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -Wl,-rpath,$GMP_LIB_DIR"
+         EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -Wl,-rpath,$MPFR_LIB_DIR"
+         FLINT_SOLIB=1
+         ;;
    esac
 fi
 


### PR DESCRIPTION
This PR first cleans up the configure script a bit, then it changes the `install_name` on Mac OS X to a sane value. The previous one encoded the full version, including minor and patchlevel, into the `install_name`, makign it essentially impossible to upgrade binaries linked against flint to newer flint versions without a recompile.

This PR of course also breaks compatibility with previous versions; but given that this was the case with every patch level so far anyway, I don't think that's an issue. If you are concerned about it, it could easily be rectified with a symlink (or three, one each for 2.5.0, 2.5.1, 2.5.2).