### PR TITLE
Added Howell form and strong echelon form for nmod_mat

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -107,7 +107,7 @@ Weiferich prime search. (Funded by the Nuffield Foundation)
 
 $\bullet$ Brian Gladman -- MSVC support
 
-$\bullet$ Dana Jacobsen -- test BPSW primality code up to $2^64$ against
+$\bullet$ Dana Jacobsen -- test BPSW primality code up to $2^{64}$ against
 Feitma's tables and sped up and corrected \code{n_is_prime} and
 \code{n_is_probabprime}. Improvements to \code{n_nextprime} and
 \code{n_isprime}.

--- a/doc/latex/flint-manual.bib
+++ b/doc/latex/flint-manual.bib
@@ -482,3 +482,30 @@
     journal = {SIAM Journal on Computing},
     year = {1973}
 }
+
+@incollection {StoMul1998,
+    author = {Storjohann, Arne and Mulders, Thom},
+    title = {Fast algorithms for linear algebra modulo {$N$}},
+    booktitle = {Algorithms---{ESA} '98 ({V}enice)},
+    series = {Lecture Notes in Comput. Sci.},
+    volume = {1461},
+    pages = {139--150},
+    publisher = {Springer},
+    year = {1998},
+    doi = {10.1007/3-540-68530-8_12},
+    url = {http://dx.doi.org/10.1007/3-540-68530-8_12},
+}
+
+@article {FieHof2014,
+    author = {Fieker, Claus and Hofmann, Tommy},
+    title = {Computing in quotients of rings of integers},
+    journal = {LMS J. Comput. Math.},
+    fjournal = {LMS Journal of Computation and Mathematics},
+    volume = {17},
+    year = {2014},
+    number = {suppl. A},
+    pages = {349--365},
+    ISSN = {1461-1570},
+    doi = {10.1112/S1461157014000291},
+    url = {http://dx.doi.org/10.1112/S1461157014000291},
+}

--- a/nmod_mat.h
+++ b/nmod_mat.h
@@ -268,7 +268,7 @@ FLINT_DLL slong nmod_mat_nullspace(nmod_mat_t X, const nmod_mat_t A);
 
 FLINT_DLL void nmod_mat_strong_echelon_form(nmod_mat_t A);
 
-FLINT_DLL int nmod_mat_howell_form(nmod_mat_t A);
+FLINT_DLL slong nmod_mat_howell_form(nmod_mat_t A);
 
 /* Tuning parameters *********************************************************/
 

--- a/nmod_mat.h
+++ b/nmod_mat.h
@@ -134,6 +134,13 @@ FLINT_DLL void nmod_mat_zero(nmod_mat_t mat);
 FLINT_DLL int nmod_mat_is_zero(const nmod_mat_t mat);
 
 NMOD_MAT_INLINE
+int
+nmod_mat_is_zero_row(const nmod_mat_t mat, slong i)
+{
+    return _nmod_vec_is_zero(mat->rows[i], mat->c);
+}
+
+NMOD_MAT_INLINE
 int nmod_mat_is_empty(const nmod_mat_t mat)
 {
     return (mat->r == 0) || (mat->c == 0);
@@ -198,6 +205,31 @@ FLINT_DLL slong nmod_mat_rank(const nmod_mat_t A);
 
 FLINT_DLL int nmod_mat_inv(nmod_mat_t B, const nmod_mat_t A);
 
+/* Permutations */
+
+NMOD_MAT_INLINE
+void nmod_mat_swap_rows(nmod_mat_t mat, slong * perm, slong r, slong s)
+{
+    if (r != s)
+    {
+        mp_ptr u;
+        slong t;
+
+        if (perm)
+        {
+            t = perm[s];
+            perm[s] = perm[r];
+            perm[r] = t;
+        }
+
+        u = mat->rows[s];
+        mat->rows[s] = mat->rows[r];
+        mat->rows[r] = u;
+    }
+}
+
+FLINT_DLL void nmod_mat_apply_permutation(nmod_mat_t A, slong * P, slong n);
+
 /* Triangular solving */
 
 FLINT_DLL void nmod_mat_solve_tril(nmod_mat_t X, const nmod_mat_t L, const nmod_mat_t B, int unit);
@@ -232,6 +264,11 @@ FLINT_DLL slong _nmod_mat_rref_storjohann(nmod_mat_t A, slong * pivots_nonpivots
 
 FLINT_DLL slong nmod_mat_nullspace(nmod_mat_t X, const nmod_mat_t A);
 
+/* Howell form */
+
+FLINT_DLL void nmod_mat_strong_echelon_form(nmod_mat_t A);
+
+FLINT_DLL int nmod_mat_howell_form(nmod_mat_t A);
 
 /* Tuning parameters *********************************************************/
 

--- a/nmod_mat/doc/nmod_mat.txt
+++ b/nmod_mat/doc/nmod_mat.txt
@@ -557,15 +557,20 @@ slong nmod_mat_nullspace(nmod_mat_t X, const nmod_mat_t A)
 
 *******************************************************************************
 
-slong nmod_mat_strong_echelon_form(nmod_mat_t A)
+void nmod_mat_strong_echelon_form(nmod_mat_t A)
 
-    Puts $A$ into strong echelon form.
+    Puts $A$ into strong echelon form. The Howell form and the strong echelon
+    form are equal up to permutation of the rows, see \cite{FieHof2014} for a
+    definition of the strong echelon form and the algorithm used here.
 
     $A$ must have at least as many rows as columns.
 
 slong nmod_mat_howell_form(nmod_mat_t A)
 
-    Puts $A$ into Howell form.
+    Puts $A$ into Howell form and returns the number of non-zero rows.
+    For a definition of the Howell form see \cite{StoMul1998}. The Howell form
+    is computed by first putting $A$ into strong echelon form and then ordering
+    the rows.
 
     $A$ must have at least as many rows as columns.
 

--- a/nmod_mat/doc/nmod_mat.txt
+++ b/nmod_mat/doc/nmod_mat.txt
@@ -550,3 +550,22 @@ slong nmod_mat_nullspace(nmod_mat_t X, const nmod_mat_t A)
 
     This function computes the reduced row echelon form and then reads
     off the basis vectors.
+    
+*******************************************************************************
+
+    Strong echelon form and Howell form
+
+*******************************************************************************
+
+slong nmod_mat_strong_echelon_form(nmod_mat_t A)
+
+    Puts $A$ into strong echelon form.
+
+    $A$ must have at least as many rows as columns.
+
+slong nmod_mat_howell_form(nmod_mat_t A)
+
+    Puts $A$ into Howell form.
+
+    $A$ must have at least as many rows as columns.
+

--- a/nmod_mat/howell_form.c
+++ b/nmod_mat/howell_form.c
@@ -1,0 +1,60 @@
+/*=============================================================================
+
+    This file is part of FLINT.
+
+    FLINT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    FLINT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2015 Tommy Hofmann
+
+******************************************************************************/
+
+#include <stdlib.h>
+#include "flint.h"
+#include "nmod_vec.h"
+#include "nmod_mat.h"
+#include "ulong_extras.h"
+
+int
+nmod_mat_howell_form(nmod_mat_t A)
+{
+    slong i, j, n;
+    slong k;
+
+    n = A->r;
+    k = n;
+    nmod_mat_strong_echelon_form(A);
+
+    for (i = 0; i < n; i++)
+    {
+        if (nmod_mat_is_zero_row(A, i))
+        {
+            k--;
+            for (j = i + 1; j < n; j++)
+            {
+                if (!nmod_mat_is_zero_row(A, j))
+                {
+                    nmod_mat_swap_rows(A, NULL, i, j);
+                    j = n;
+                    k++;
+                }
+            }
+        }
+    }
+    return k;
+}
+

--- a/nmod_mat/howell_form.c
+++ b/nmod_mat/howell_form.c
@@ -29,7 +29,7 @@
 #include "nmod_mat.h"
 #include "ulong_extras.h"
 
-int
+slong
 nmod_mat_howell_form(nmod_mat_t A)
 {
     slong i, j, n;

--- a/nmod_mat/strong_echelon_form.c
+++ b/nmod_mat/strong_echelon_form.c
@@ -1,0 +1,234 @@
+/*=============================================================================
+
+    This file is part of FLINT.
+
+    FLINT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    FLINT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2015 Tommy Hofmann
+
+******************************************************************************/
+
+#include <stdlib.h>
+#include "flint.h"
+#include "nmod_vec.h"
+#include "nmod_mat.h"
+#include "ulong_extras.h"
+
+static __inline__ int
+_nmod_mat_pivot(nmod_mat_t A, slong start_row, slong col)
+{
+    slong j;
+    mp_ptr u;
+
+    if (nmod_mat_entry(A, start_row, col) != 0)
+        return 1;
+
+    for (j = start_row + 1; j < A->r; j++)
+    {
+        if (nmod_mat_entry(A, j, col) != 0)
+        {
+            u = A->rows[j];
+            A->rows[j] = A->rows[start_row];
+            A->rows[start_row] = u;
+
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static void
+_n_ppio(mp_ptr ppi, mp_ptr ppo, mp_limb_t a, mp_limb_t b)
+{
+    mp_limb_t c, n, g;
+
+    c = n_gcd_full(a, b);
+    n = a/c;
+    g = n_gcd_full(c, n);
+    while( g != 1 )
+    {
+        c = c * g;
+        n = n/g;
+        g = n_gcd_full(c, n);
+    }
+    *ppi = c;
+    *ppo = n;
+}
+
+static mp_limb_t
+_n_stab(mp_limb_t a, mp_limb_t b, nmod_t N)
+{
+    mp_limb_t g, s, t;
+    g = n_gcd_full(a, b);
+    b = n_gcd_full(g, N.n);
+    _n_ppio(&s, &t, N.n/b, a/b);
+    return t;
+}
+
+static mp_limb_t
+_n_unit(mp_limb_t a, nmod_t N)
+{
+    mp_limb_t g, s, t, l, d;
+
+    g = n_xgcd(&s, &t, a, N.n);
+
+    if (g == 1)
+    {
+        return s;
+    }
+    else
+    {
+        l = N.n/g;
+        d = _n_stab(s, l, N);
+        return nmod_add(s, nmod_mul(d, l, N), N);
+    }
+}
+
+void
+nmod_mat_strong_echelon_form(nmod_mat_t A)
+{
+    mp_limb_t s, t, u, v, q, t1, t2, g;
+    mp_limb_t temp;
+    slong m, n, row, col, i, k, l;
+    mp_limb_t **r;
+    nmod_t mod;
+    mp_ptr extra_row;
+
+    n = A->r;
+    m = A->c;
+    r = A->rows;
+    mod = A->mod;
+
+    extra_row = _nmod_vec_init(m);
+
+    row = col = 0;
+
+    while (row < n && col < m)
+    {
+        if (_nmod_mat_pivot(A, row, col) == 0)
+        {
+            col++;
+            continue;
+        }
+        for (i = row + 1; i < n; i++)
+        {
+            if (nmod_mat_entry(A, row, col) >= nmod_mat_entry(A, i, col))
+            {
+                g = n_xgcd(&s, &t, nmod_mat_entry(A, row, col), nmod_mat_entry(A, i, col));
+            }
+            else
+            {
+                g = n_xgcd(&s, &t, nmod_mat_entry(A, i, col), nmod_mat_entry(A, row, col));
+                temp = s;
+                s = t;
+                t = temp;
+            }
+
+
+            /* now g = a*x - b*y 
+             a,b < x < mod.n */
+            t = nmod_neg(t, mod);
+            u = (nmod_mat_entry(A, i, col))/g;
+            u = nmod_neg(u, mod);
+            v = (nmod_mat_entry(A, row, col))/g;
+            /* now g = a*x + b*y and 0 = sv - tu = 1 modulo mod.n */
+            
+            for (k = col; k < m; k++)
+            {
+                t1 = nmod_add(nmod_mul(s, nmod_mat_entry(A, row, k), mod), nmod_mul(t, nmod_mat_entry(A, i, k), mod), mod);
+                t2 = nmod_add(nmod_mul(u, nmod_mat_entry(A, row, k), mod), nmod_mul(v, nmod_mat_entry(A, i, k), mod), mod);
+                nmod_mat_entry(A, row, k) = t1;
+                nmod_mat_entry(A, i, k) = t2;
+            }
+        }
+        row++;
+        col++;
+    }
+    
+    for (col = 0; col < m; col++)
+    {
+        if (nmod_mat_entry(A, col, col) != 0)
+        {
+            u = _n_unit(nmod_mat_entry(A, col, col), mod);
+            for (k = col; k < m; k++)
+            {
+                nmod_mat_entry(A, col, k) = nmod_mul(u, nmod_mat_entry(A, col, k), mod);
+            }
+            for (row = 0; row < col ; row++)
+            {
+                
+                
+                q = nmod_mat_entry(A, row, col)/nmod_mat_entry(A, col, col);
+
+                for (l = row; l< m; l++)
+                {
+                    s = nmod_sub(nmod_mat_entry(A, row, l), nmod_mul(q, nmod_mat_entry(A, col, l), mod), mod);
+                    nmod_mat_entry(A, row, l) = s;
+                }
+            }
+
+            g = n_gcd_full(mod.n, nmod_mat_entry(A, col, col));
+            if (g == 1)
+            {
+                continue;
+
+            }
+            g = mod.n/g;
+            _nmod_vec_scalar_mul_nmod(extra_row, r[col], m, g, mod);
+        }
+        else
+        {
+          _nmod_vec_set(extra_row, r[col], m);
+        }
+
+        for (row = col + 1; row < m; row++)
+        {
+            if(nmod_mat_entry(A, row, row) >= extra_row[row])
+            {
+                g = n_xgcd(&s, &t, nmod_mat_entry(A, row, row), extra_row[row]);
+            }
+            else
+            {
+                g = n_xgcd(&s, &t, extra_row[row], nmod_mat_entry(A, row, row));
+                temp = s;
+                s = t;
+                t = temp;
+
+            }
+            if (g == 0)
+            {
+                continue;
+            }
+            t = nmod_neg(t, mod);
+            u = extra_row[row]/g;
+            u = nmod_neg(u, mod);
+            v = (nmod_mat_entry(A, row, row))/g;
+            /* now g = a*x + b*y and 0 = sv - tu = 1 modulo mod.n */
+            
+            for (k = row; k < m; k++)
+            {
+                t1 = nmod_add(nmod_mul(s, nmod_mat_entry(A, row, k), mod), nmod_mul(t, extra_row[k], mod), mod);
+                t2 = nmod_add(nmod_mul(u, nmod_mat_entry(A, row, k), mod), nmod_mul(v, extra_row[k], mod), mod);
+                nmod_mat_entry(A, row, k) = t1;
+                extra_row[k] = t2;
+
+            }
+        }
+    }
+    _nmod_vec_clear(extra_row);
+}

--- a/nmod_mat/strong_echelon_form.c
+++ b/nmod_mat/strong_echelon_form.c
@@ -103,7 +103,6 @@ void
 nmod_mat_strong_echelon_form(nmod_mat_t A)
 {
     mp_limb_t s, t, u, v, q, t1, t2, g;
-    mp_limb_t temp;
     slong m, n, row, col, i, k, l;
     mp_limb_t **r;
     nmod_t mod;
@@ -133,12 +132,8 @@ nmod_mat_strong_echelon_form(nmod_mat_t A)
             }
             else
             {
-                g = n_xgcd(&s, &t, nmod_mat_entry(A, i, col), nmod_mat_entry(A, row, col));
-                temp = s;
-                s = t;
-                t = temp;
+                g = n_xgcd(&t, &s, nmod_mat_entry(A, i, col), nmod_mat_entry(A, row, col));
             }
-
 
             /* now g = a*x - b*y 
              a,b < x < mod.n */
@@ -186,7 +181,6 @@ nmod_mat_strong_echelon_form(nmod_mat_t A)
             if (g == 1)
             {
                 continue;
-
             }
             g = mod.n/g;
             _nmod_vec_scalar_mul_nmod(extra_row, r[col], m, g, mod);
@@ -204,11 +198,7 @@ nmod_mat_strong_echelon_form(nmod_mat_t A)
             }
             else
             {
-                g = n_xgcd(&s, &t, extra_row[row], nmod_mat_entry(A, row, row));
-                temp = s;
-                s = t;
-                t = temp;
-
+                g = n_xgcd(&t, &s, extra_row[row], nmod_mat_entry(A, row, row));
             }
             if (g == 0)
             {

--- a/nmod_mat/test/t-howell_form.c
+++ b/nmod_mat/test/t-howell_form.c
@@ -1,0 +1,254 @@
+/*=============================================================================
+
+    This file is part of FLINT.
+
+    FLINT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    FLINT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2015 Tommy Hofmann
+
+******************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <gmp.h>
+#include "flint.h"
+#include "nmod_vec.h"
+#include "nmod_mat.h"
+#include "ulong_extras.h"
+#include "perm.h"
+
+int
+nmod_mat_is_in_howell_form(const nmod_mat_t A)
+{
+    slong *pivots;
+    slong i, j, r;
+    int numberpivots = 0;
+    int prevrowzero = 0;
+    mp_ptr extra_row;
+    mp_limb_t g;
+
+    pivots = flint_malloc(A->r * sizeof(slong));
+
+    if (!nmod_mat_is_zero_row(A, 0))
+    {
+        for (j = 0; j < A->c; j++)
+        {
+            if (nmod_mat_entry(A, 0, j))
+            {
+                if ((A->mod).n % nmod_mat_entry(A, 0, j))
+                {
+                    flint_free(pivots);
+                    return 0;
+                }
+                pivots[numberpivots] = j;
+                numberpivots++;
+                break;
+            }
+        }
+    }
+    else
+    {
+        prevrowzero = 1;
+    }
+    
+
+    for (i = 1; i < A->r; i++)
+    {
+        if (!nmod_mat_is_zero_row(A, i))
+        {
+            if (prevrowzero)
+            {  
+                flint_free(pivots);
+                return 0;
+            }
+            for (j = 0; j < A->c; j++)
+            {
+                if (nmod_mat_entry(A, i, j))
+                {
+                    if (j <= pivots[numberpivots - 1])
+                    {
+                        flint_free(pivots);
+                        return 0;
+                    }
+                    if ((A->mod).n % nmod_mat_entry(A, i, j))
+                    {
+                        flint_free(pivots);
+                        return 0;
+                    }
+                    pivots[numberpivots] = j;
+                    numberpivots++;
+                    j = A->c;
+                }
+            }
+        }
+        else
+        {
+            prevrowzero = 1;
+        }
+    }
+    for (i = 1; i < numberpivots; i++)
+    {
+        for (j = 0; j < i; j++)
+        {
+            if (nmod_mat_entry(A, j, pivots[i]) >= nmod_mat_entry(A, i, pivots[i]))
+            {
+                flint_free(pivots);
+                return 0;
+            }
+        }
+    }
+    extra_row = _nmod_vec_init(A->c);
+
+    for (i = 0; i < numberpivots; i++)
+    {
+        g = n_gcd(A->mod.n, nmod_mat_entry(A, i, pivots[i]));
+        g = A->mod.n/g;
+        _nmod_vec_scalar_mul_nmod(extra_row, A->rows[i], A->c, g, A->mod);
+        
+        for ( j = pivots[i] + 1; j < A->c; j++)
+        {
+            if (extra_row[j])
+            {
+                for ( r = i; r < numberpivots; r++)
+                {
+                    if (pivots[r] == j)
+                    {
+                        if(!(extra_row[j] % nmod_mat_entry(A, r, pivots[r])))
+                        {
+                            g = extra_row[j]/nmod_mat_entry(A, r, pivots[r]);
+                            _nmod_vec_scalar_addmul_nmod(extra_row, A->rows[r],
+                                A->c, nmod_neg(g, A->mod), A->mod);
+                        }
+                       
+                    }
+                }
+            }
+        }
+        if (!_nmod_vec_is_zero(extra_row, A->c))
+        {
+            _nmod_vec_clear(extra_row);
+            flint_free(pivots);
+            return 0; 
+        }
+    }
+    _nmod_vec_clear(extra_row);
+    flint_free(pivots);
+    return 1;
+}
+
+int
+main(void)
+{
+    slong i;
+
+    FLINT_TEST_INIT(state);
+
+    flint_printf("howell_form....");
+
+    for (i = 0; i < 10000*flint_test_multiplier(); i++)
+    {
+        nmod_mat_t A, B, D;
+        mp_limb_t mod;
+        slong j, k, m, n, r1, r2;
+        slong *perm;
+        int equal;
+        mp_limb_t c;
+
+        mod = n_randtest_not_zero(state);
+
+        do { m = n_randint(state, 20); } while (m == 0);
+        do { n = n_randint(state, 20); } while (n > m);
+
+        perm = _perm_init(2*m);
+
+        nmod_mat_init(A, m, n, mod);
+        nmod_mat_init(D, 2*m, n, mod);
+
+        nmod_mat_randtest(A, state);
+        nmod_mat_init_set(B, A);
+
+        r1 = nmod_mat_howell_form(B);
+
+
+        if (!nmod_mat_is_in_howell_form(B))
+        {
+            flint_printf("FAIL (malformed Howell form)\n");
+            nmod_mat_print_pretty(A); flint_printf("\n\n");
+            nmod_mat_print_pretty(B); flint_printf("\n\n");
+            abort();
+        }
+
+
+        _perm_randtest(perm, 2 * m, state);
+
+        /* Concatenate the original matrix with the Howell form, scramble the rows,
+           and check that the Howell form is the same */
+
+        for (j = 0; j < m; j++)
+        {
+            do { c = n_randint(state, mod); } while ( n_gcd(c, mod) != 1);
+            for (k = 0; k < n; k++)
+                nmod_mat_entry(D, perm[j], k) =
+                    nmod_mul(nmod_mat_entry(A, j, k), c, A->mod);
+        }
+
+        for (j = 0; j < m; j++)
+        {
+            do { c = n_randint(state, mod); } while ( n_gcd(c, mod) != 1);
+            for (k = 0; k < n; k++)
+                nmod_mat_entry(D, perm[m + j], k) =
+                    nmod_mul(nmod_mat_entry(B, j, k), c, A->mod);
+        }
+
+        r2 = nmod_mat_howell_form(D);
+
+        equal = (r1 == r2);
+
+        if (equal)
+        {
+            for (j = 0; j < r1; j++)
+                for (k = 0; k < n; k++)
+                    equal = equal && (nmod_mat_entry(B, j, k) ==
+                                        nmod_mat_entry(D, j, k));
+            for (j = r1; j < 2*m; j++)
+                for (k = 0; k < n; k++)
+                    equal = equal && (nmod_mat_entry(D, j, k) == 0);
+        }
+
+        if (!equal)
+        {
+            flint_printf("FAIL (r1 = %wd, r2 = %wd)!\n", r1, r2);
+            nmod_mat_print_pretty(A); flint_printf("\n\n");
+            nmod_mat_print_pretty(B); flint_printf("\n\n");
+            nmod_mat_print_pretty(D); flint_printf("\n\n");
+            abort();
+        }
+
+        _perm_clear(perm);
+
+        nmod_mat_clear(A);
+        nmod_mat_clear(B);
+        nmod_mat_clear(D);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+    
+    flint_printf("PASS\n");
+    return 0;
+}
+


### PR DESCRIPTION
We had the code for the last few months in fieker/antic and use it in hecke for Hermite normal form computations. I have now added tests and documentation.

The Howell form is derived from the so-called strong echelon form, see [Fieker, Hofmann, Computing in quotients of ring of integers](http://dx.doi.org/10.1112/S1461157014000291). The algorithm is essentially the classical algorithm of Storjohann & Mulders.

The functions have the restriction that the matrix should have more rows then columns. This is no real restriction as one can just add zero-rows at the bottom. Since this has a bad memory footprint, I don't do it in the algorithm. Probably there is clever way I didn't found.

I have a correspdoning fmpz_mat_mod_howell_form ready (apart from test and documentation). Once I have merged both I will add a modular Hermite normal form which accepts a multiple of the largest elementary divisor (this is the overall goal).

I know that the implementation can be improved, but I don't have time for it (at the moment).

Edit: The failing travis test is due to mpfr.org begin down (not my fault!).