### PR TITLE
Fix bug with empty matrices in the Howell form

### DIFF
--- a/fmpz_mat/hnf_modular_eldiv.c
+++ b/fmpz_mat/hnf_modular_eldiv.c
@@ -32,6 +32,9 @@ fmpz_mat_hnf_modular_eldiv(fmpz_mat_t A, const fmpz_t D)
     mp_limb_t Dlimbt;
     nmod_mat_t AmodD;
 
+    if (fmpz_mat_is_empty(A))
+        return;
+
     if (fmpz_abs_fits_ui(D))
     {
         Dlimbt = fmpz_get_ui(D);
@@ -53,7 +56,5 @@ fmpz_mat_hnf_modular_eldiv(fmpz_mat_t A, const fmpz_t D)
             fmpz_set(fmpz_mat_entry(A, i, i), D);
         }
     }
-    
-
 }
     

--- a/fmpz_mat/howell_form_mod.c
+++ b/fmpz_mat/howell_form_mod.c
@@ -31,6 +31,9 @@ fmpz_mat_howell_form_mod(fmpz_mat_t A, const fmpz_t mod)
     slong i, j, n;
     slong k;
 
+    if (fmpz_mat_is_empty(A))
+        return 0;
+
     n = A->r;
     k = n;
     fmpz_mat_strong_echelon_form_mod(A, mod);

--- a/fmpz_mat/strong_echelon_form_mod.c
+++ b/fmpz_mat/strong_echelon_form_mod.c
@@ -145,6 +145,9 @@ fmpz_mat_strong_echelon_form_mod(fmpz_mat_t A, const fmpz_t mod)
     fmpz  ** r;
     fmpz * extra_row;
 
+    if (fmpz_mat_is_empty(A))
+        return;
+
     fmpz_init(s);
     fmpz_init(t);
     fmpz_init(q);

--- a/fmpz_mat/test/t-howell_form_mod.c
+++ b/fmpz_mat/test/t-howell_form_mod.c
@@ -40,6 +40,8 @@ fmpz_mat_mod_is_in_howell_form(const fmpz_mat_t A, const fmpz_t mod)
     fmpz * extra_row;
     fmpz_t g;
 
+    if (fmpz_mat_is_empty(A))
+        return 1;
 
     pivots = flint_malloc(A->r * sizeof(slong));
 
@@ -194,7 +196,6 @@ main(void)
 
         if (!fmpz_mat_mod_is_in_howell_form(B, mod))
         {
-            flint_printf("done\n");
             flint_printf("FAIL (malformed Howell form)\n");
             fmpz_mat_print_pretty(A); flint_printf("\n\n");
             fmpz_mat_print_pretty(B); flint_printf("\n\n");

--- a/nmod_mat/howell_form.c
+++ b/nmod_mat/howell_form.c
@@ -37,6 +37,10 @@ nmod_mat_howell_form(nmod_mat_t A)
 
     n = A->r;
     k = n;
+
+    if (nmod_mat_is_empty(A))
+        return 0;
+
     nmod_mat_strong_echelon_form(A);
 
     for (i = 0; i < n; i++)

--- a/nmod_mat/strong_echelon_form.c
+++ b/nmod_mat/strong_echelon_form.c
@@ -108,6 +108,9 @@ nmod_mat_strong_echelon_form(nmod_mat_t A)
     nmod_t mod;
     mp_ptr extra_row;
 
+    if (nmod_mat_is_empty(A))
+        return;
+
     n = A->r;
     m = A->c;
     r = A->rows;

--- a/nmod_mat/test/t-howell_form.c
+++ b/nmod_mat/test/t-howell_form.c
@@ -42,6 +42,9 @@ nmod_mat_is_in_howell_form(const nmod_mat_t A)
     mp_ptr extra_row;
     mp_limb_t g;
 
+    if (nmod_mat_is_zero(A))
+        return 1;
+
     pivots = flint_malloc(A->r * sizeof(slong));
 
     if (!nmod_mat_is_zero_row(A, 0))


### PR DESCRIPTION
After some fun with if (..); return; and if(...) return;, here is a fix. I hope this solves the Windows problem.