### PR TITLE
Avoiding conditional directives that split up parts of statements.

### DIFF
--- a/fmpz/set_mpf.c
+++ b/fmpz/set_mpf.c
@@ -32,11 +32,13 @@
 void
 fmpz_set_mpf(fmpz_t f, const mpf_t x)
 {
+    int check;
 #if defined(__MPIR_VERSION)
-    if (mpf_fits_si_p(x))
+    check = mpf_fits_si_p(x);
 #else
-    if (flint_mpf_fits_slong_p(x))
+    check = flint_mpf_fits_slong_p(x);
 #endif
+    if (check)
     {
         slong cx = flint_mpf_get_si(x);
         fmpz_set_si(f, cx);


### PR DESCRIPTION
   A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

    https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
    https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.