### PR TITLE
Use LDFLAGS for tests executables, too

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -228,7 +228,7 @@ build/%.o: %.c $(HEADERS) | build
 	$(QUIET_CC) $(CC) $(CFLAGS) $(INCS) -c $< -o $@;
 
 build/test/%$(EXEEXT): test/%.c $(HEADERS) test_helpers.o | build/test
-	$(QUIET_CC) $(CC) $(CFLAGS) $(INCS) test_helpers.o $< -o $@ $(LIBS)
+	$(QUIET_CC) $(CC) $(CFLAGS) $(INCS) $(LDFLAGS) test_helpers.o $< -o $@ $(LIBS)
 
 build/test:
 	mkdir -p build/test
@@ -243,7 +243,7 @@ build/interfaces/NTL-interface.o: interfaces/NTL-interface.cpp NTL-interface.h
 	$(QUIET_CXX) $(CXX) $(CXXFLAGS) $(INCS) -c $< -o $@
 
 build/interfaces/test/t-NTL-interface$(EXEEXT): interfaces/test/t-NTL-interface.cpp build/interfaces/NTL-interface.o
-	$(QUIET_CXX) $(CXX) $(CXXFLAGS) $(INCS) $< build/interfaces/NTL-interface.o -o $@ $(LIBS)
+	$(QUIET_CXX) $(CXX) $(CXXFLAGS) $(INCS) $(LDFLAGS) $< build/interfaces/NTL-interface.o -o $@ $(LIBS)
 
 print-%:
 	@echo '$*=$($*)'


### PR DESCRIPTION
Sage bug: http://trac.sagemath.org/ticket/19790