### PR TITLE
Adjust test to allow empty matrices in howell form 

### DIFF
--- a/fmpz_mat/test/t-howell_form_mod.c
+++ b/fmpz_mat/test/t-howell_form_mod.c
@@ -181,7 +181,7 @@ main(void)
 
         do { fmpz_randtest_unsigned(mod, state, 10); } while (fmpz_is_zero(mod));
 
-        do { m = n_randint(state, 20); } while (m == 0);
+        m = n_randint(state, 20);
         do { n = n_randint(state, 20); } while (n > m);
 
         perm = _perm_init(2*m);

--- a/nmod_mat/test/t-howell_form.c
+++ b/nmod_mat/test/t-howell_form.c
@@ -174,7 +174,7 @@ main(void)
 
         mod = n_randtest_not_zero(state);
 
-        do { m = n_randint(state, 20); } while (m == 0);
+        m = n_randint(state, 20);
         do { n = n_randint(state, 20); } while (n > m);
 
         perm = _perm_init(2*m);


### PR DESCRIPTION
By the way, is travis disabled?