### PR TITLE
MAINT: add flint_test_multiplier to factor refinement

### DIFF
--- a/fmpz_factor/refine.c
+++ b/fmpz_factor/refine.c
@@ -444,6 +444,7 @@ fmpz_factor_refine(fmpz_factor_t res, const fmpz_factor_t f)
     slong i, len;
     fmpz * b;
     ulong e;
+    fr_node_ptr * qsort_arr;
 
     /* check the sign of f without requiring canonical form */
     s = _fmpz_factor_sgn(f);
@@ -469,7 +470,6 @@ fmpz_factor_refine(fmpz_factor_t res, const fmpz_factor_t f)
     len = fr_node_list_length(L);
 
     /* make a sorted array of pointers to the refined factor nodes */
-    fr_node_ptr * qsort_arr;
     qsort_arr = flint_malloc(sizeof(fr_node_ptr) * len);
     for (i = 0, curr = L; i < len; i++, curr = curr->next)
     {

--- a/fmpz_factor/test/t-refine.c
+++ b/fmpz_factor/test/t-refine.c
@@ -128,7 +128,7 @@ int main(void)
     flint_printf("refine....");
     fflush(stdout);
 
-    for (iter = 0; iter < 1000; iter++)
+    for (iter = 0; iter < 100 * flint_test_multiplier(); iter++)
     {
         int i;
         fmpz_factor_t f, g;


### PR DESCRIPTION
Also fixes a compiler warning about where variables are declared within a function. Addresses https://github.com/wbhart/flint2/pull/206#issuecomment-194411632.