### PR TITLE
Power sums for nmod_poly_t

### DIFF
--- a/fmpq_poly/power_sums_to_poly.c
+++ b/fmpq_poly/power_sums_to_poly.c
@@ -45,7 +45,10 @@ _fmpq_poly_power_sums_to_poly(fmpz * res, const fmpz * poly, const fmpz_t den,
     fmpz_one(f);
     for (k = 1; k <= d; k++)
     {
-        fmpz_mul(res + d - k, poly + k, f);
+        if(k < len)
+			fmpz_mul(res + d - k, poly + k, f);
+		else
+			fmpz_zero(res + d - k);
         for (i = 1; i < FLINT_MIN(k, len); i++)
             fmpz_addmul(res + d - k, res + d - k + i, poly + i);
 

--- a/fmpq_poly/test/t-power_sums.c
+++ b/fmpq_poly/test/t-power_sums.c
@@ -190,6 +190,7 @@ main(void)
         fmpq_poly_clear(a);
         fmpq_poly_clear(b);
         fmpq_poly_clear(c);
+        fmpq_poly_clear(d);
     }
 
     FLINT_TEST_CLEANUP(state);

--- a/fmpz_poly/power_sums_to_poly.c
+++ b/fmpz_poly/power_sums_to_poly.c
@@ -46,13 +46,12 @@ _fmpz_poly_power_sums_to_poly(fmpz * res, const fmpz * poly, slong len)
     }
     for (k = len; k <= d; k++)
     {
-        fmpz_set(res + d - k, poly + k);
+        fmpz_zero(res + d - k);
         for (i = 1; i < len; i++)
             fmpz_addmul(res + d - k, res + d - k + i, poly + i);
         fmpz_divexact_si(res + d - k, res + d - k, k);
         fmpz_neg(res + d - k, res + d - k);
     }
-
 }
 
 void

--- a/nmod_poly.h
+++ b/nmod_poly.h
@@ -1143,6 +1143,32 @@ FLINT_DLL int _nmod_poly_sqrt(mp_ptr s, mp_srcptr p, slong len, nmod_t mod);
 
 FLINT_DLL int nmod_poly_sqrt(nmod_poly_t b, const nmod_poly_t a);
 
+/* Power sums ****************************************************************/
+
+FLINT_DLL void _nmod_poly_power_sums_naive(mp_ptr res, mp_srcptr poly, slong len, slong n, nmod_t mod);
+
+FLINT_DLL void nmod_poly_power_sums_naive(nmod_poly_t res, const nmod_poly_t poly, slong n);
+
+FLINT_DLL void _nmod_poly_power_sums_schoenhage(mp_ptr res, mp_srcptr poly, slong len, slong n, nmod_t mod);
+
+FLINT_DLL void nmod_poly_power_sums_schoenhage(nmod_poly_t res, const nmod_poly_t poly, slong n);
+
+FLINT_DLL void _nmod_poly_power_sums(mp_ptr res, mp_srcptr poly, slong len, slong n, nmod_t mod);
+
+FLINT_DLL void nmod_poly_power_sums(nmod_poly_t res, const nmod_poly_t poly, slong n);
+
+FLINT_DLL void _nmod_poly_power_sums_to_poly_naive(mp_ptr res, mp_srcptr poly, slong len, nmod_t mod);
+
+FLINT_DLL void nmod_poly_power_sums_to_poly_naive(nmod_poly_t res, const nmod_poly_t Q);
+
+FLINT_DLL void _nmod_poly_power_sums_to_poly_schoenhage(mp_ptr res, mp_srcptr poly, slong len, nmod_t mod);
+
+FLINT_DLL void nmod_poly_power_sums_to_poly_schoenhage(nmod_poly_t res, const nmod_poly_t Q);
+
+FLINT_DLL void _nmod_poly_power_sums_to_poly(mp_ptr res, mp_srcptr poly, slong len, nmod_t mod);
+
+FLINT_DLL void nmod_poly_power_sums_to_poly(nmod_poly_t res, const nmod_poly_t Q);
+
 /* Transcendental functions **************************************************/
 
 FLINT_DLL void _nmod_poly_atan_series(mp_ptr g, mp_srcptr h, slong n, nmod_t mod);

--- a/nmod_poly/doc/nmod_poly.txt
+++ b/nmod_poly/doc/nmod_poly.txt
@@ -2429,7 +2429,7 @@ void _nmod_poly_power_sums_schoenhage(mp_ptr res, mp_srcptr poly, slong len, slo
 void nmod_poly_power_sums_schoenhage(nmod_poly_t res, const nmod_poly_t poly, slong n)
 
     Compute the (truncated) power sums series of the polynomial
-    \code{(poly,len)} up to length $n$ using a series expansion
+    \code{poly} up to length $n$ using a series expansion
     (a formula due to Schoenhage).
 
 void _nmod_poly_power_sums(mp_ptr res, mp_srcptr poly, slong len, slong n, nmod_t mod)
@@ -2440,7 +2440,7 @@ void _nmod_poly_power_sums(mp_ptr res, mp_srcptr poly, slong len, slong n, nmod_
 void nmod_poly_power_sums(nmod_poly_t res, const nmod_poly_t poly, slong n)
 
     Compute the (truncated) power sums series of the polynomial
-    \code{(poly,len)} up to length $n$.
+    \code{poly} up to length $n$.
 
 void _nmod_poly_power_sums_to_poly_naive(mp_ptr res, mp_srcptr poly, slong len, nmod_t mod)
 
@@ -2450,7 +2450,7 @@ void _nmod_poly_power_sums_to_poly_naive(mp_ptr res, mp_srcptr poly, slong len, 
 void nmod_poly_power_sums_to_poly_naive(nmod_poly_t res, const nmod_poly_t Q)
 
     Compute the (monic) polynomial given by its power sums series
-    \code{(poly,len)} using Newton identities.
+    \code{Q} using Newton identities.
 
 void _nmod_poly_power_sums_to_poly_schoenhage(mp_ptr res, mp_srcptr poly, slong len, nmod_t mod)
 
@@ -2460,7 +2460,7 @@ void _nmod_poly_power_sums_to_poly_schoenhage(mp_ptr res, mp_srcptr poly, slong 
 void nmod_poly_power_sums_to_poly_schoenhage(nmod_poly_t res, const nmod_poly_t Q)
 
     Compute the (monic) polynomial given by its power sums series
-    \code{(poly,len)} using series expansion (a formula due to Schoenhage).
+    \code{Q} using series expansion (a formula due to Schoenhage).
 
 void _nmod_poly_power_sums_to_poly(mp_ptr res, mp_srcptr poly, slong len, nmod_t mod)
 
@@ -2470,7 +2470,7 @@ void _nmod_poly_power_sums_to_poly(mp_ptr res, mp_srcptr poly, slong len, nmod_t
 void nmod_poly_power_sums_to_poly(nmod_poly_t res, const nmod_poly_t Q)
 
      Compute the (monic) polynomial given by its power sums series
-    \code{(poly,len)}.
+    \code{Q}.
 
 *******************************************************************************
 

--- a/nmod_poly/doc/nmod_poly.txt
+++ b/nmod_poly/doc/nmod_poly.txt
@@ -145,7 +145,9 @@ void _nmod_poly_reverse(mp_ptr output, mp_srcptr input, slong len, slong m)
     \code{len}, but thinking of it as a polynomial of length~\code{m},
     notionally zero-padded if necessary. The length~\code{m} must be
     non-negative, but there are no other restrictions. The polynomial
-    \code{output} must have space for \code{m} coefficients.
+    \code{output} must have space for \code{m} coefficients. Supports
+    aliasing of \code{output} and \code{input}, but the behaviour is
+    undefined in case of partial overlap.
 
 void nmod_poly_reverse(nmod_poly_t output, const nmod_poly_t input, slong m)
 
@@ -1299,7 +1301,7 @@ void _nmod_poly_integral(mp_ptr x_int, mp_srcptr x, slong len, nmod_t mod)
     The constant term of \code{x_int} is set to zero.
     It is assumed that \code{len > 0}. The result is only well-defined
     if the modulus is a prime number strictly larger than the degree of
-    \code{x}.
+    \code{x}. Supports aliasing between the two polynomials.
 
 void nmod_poly_integral(nmod_poly_t x_int, const nmod_poly_t x)
 
@@ -2401,6 +2403,74 @@ int nmod_poly_sqrt(nmod_poly_t s, const nmod_poly_t p)
 
     If $p$ is a perfect square, sets $s$ to a square root of $p$
     and returns 1. Otherwise returns 0.
+
+*******************************************************************************
+
+    Power sums
+
+*******************************************************************************
+
+void _nmod_poly_power_sums_naive(mp_ptr res, mp_srcptr poly, slong len, slong n, nmod_t mod)
+
+    Compute the (truncated) power sums series of the polynomial
+    \code{(poly,len)} up to length $n$ using Newton identities.
+
+void nmod_poly_power_sums_naive(nmod_poly_t res, const nmod_poly_t poly, slong n)
+
+    Compute the (truncated) power sum series of the polynomial
+    \code{poly} up to length $n$ using Newton identities.
+
+void _nmod_poly_power_sums_schoenhage(mp_ptr res, mp_srcptr poly, slong len, slong n, nmod_t mod)
+
+    Compute the (truncated) power sums series of the polynomial
+    \code{(poly,len)} up to length $n$ using a series expansion
+    (a formula due to Schoenhage).
+
+void nmod_poly_power_sums_schoenhage(nmod_poly_t res, const nmod_poly_t poly, slong n)
+
+    Compute the (truncated) power sums series of the polynomial
+    \code{(poly,len)} up to length $n$ using a series expansion
+    (a formula due to Schoenhage).
+
+void _nmod_poly_power_sums(mp_ptr res, mp_srcptr poly, slong len, slong n, nmod_t mod)
+
+    Compute the (truncated) power sums series of the polynomial
+    \code{(poly,len)} up to length $n$.
+
+void nmod_poly_power_sums(nmod_poly_t res, const nmod_poly_t poly, slong n)
+
+    Compute the (truncated) power sums series of the polynomial
+    \code{(poly,len)} up to length $n$.
+
+void _nmod_poly_power_sums_to_poly_naive(mp_ptr res, mp_srcptr poly, slong len, nmod_t mod)
+
+    Compute the (monic) polynomial given by its power sums series
+    \code{(poly,len)} using Newton identities.
+
+void nmod_poly_power_sums_to_poly_naive(nmod_poly_t res, const nmod_poly_t Q)
+
+    Compute the (monic) polynomial given by its power sums series
+    \code{(poly,len)} using Newton identities.
+
+void _nmod_poly_power_sums_to_poly_schoenhage(mp_ptr res, mp_srcptr poly, slong len, nmod_t mod)
+
+    Compute the (monic) polynomial given by its power sums series
+    \code{(poly,len)} using series expansion (a formula due to Schoenhage).
+
+void nmod_poly_power_sums_to_poly_schoenhage(nmod_poly_t res, const nmod_poly_t Q)
+
+    Compute the (monic) polynomial given by its power sums series
+    \code{(poly,len)} using series expansion (a formula due to Schoenhage).
+
+void _nmod_poly_power_sums_to_poly(mp_ptr res, mp_srcptr poly, slong len, nmod_t mod)
+
+    Compute the (monic) polynomial given by its power sums series
+    \code{(poly,len)}.
+
+void nmod_poly_power_sums_to_poly(nmod_poly_t res, const nmod_poly_t Q)
+
+     Compute the (monic) polynomial given by its power sums series
+    \code{(poly,len)}.
 
 *******************************************************************************
 

--- a/nmod_poly/power_sums.c
+++ b/nmod_poly/power_sums.c
@@ -1,0 +1,98 @@
+/*=============================================================================
+
+    This file is part of FLINT.
+
+    FLINT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    FLINT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Vincent Delecroix
+
+******************************************************************************/
+
+#include <gmp.h>
+#include "flint.h"
+#include "nmod_vec.h"
+#include "nmod_poly.h"
+
+void
+_nmod_poly_power_sums(mp_ptr res, mp_srcptr poly, slong len, slong n,
+                      nmod_t mod)
+{
+    if (10 * n >= len + 75)
+        _nmod_poly_power_sums_schoenhage(res, poly, len, n, mod);
+    else
+        _nmod_poly_power_sums_naive(res, poly, len, n, mod);
+}
+
+void
+nmod_poly_power_sums(nmod_poly_t res, const nmod_poly_t poly, slong n)
+{
+    slong len = poly->length;
+
+    if (len == 0)
+    {
+        flint_printf
+            ("Exception (nmod_poly_power_sums_naive). Zero polynomial.\n");
+        abort();
+    }
+    size_t i = 0;
+    while (poly->coeffs[i] == 0)
+        i++;
+
+    if (n <= 0 || len == 1)
+        nmod_poly_zero(res);
+    else if (len == i + 1)
+    {
+        nmod_poly_fit_length(res, 1);
+        _nmod_poly_set_length(res, 1);
+        NMOD_RED(res->coeffs[0], len - 1, poly->mod);
+    }
+    else
+    {
+        if (*nmod_poly_lead(poly) != 1)
+        {
+            nmod_poly_t t;
+            nmod_poly_init_preinv(t, poly->mod.n, poly->mod.ninv);
+            nmod_poly_make_monic(t, poly);
+            nmod_poly_fit_length(res, n);
+            _nmod_poly_power_sums(res->coeffs, t->coeffs + i,
+                                  len - i, n, t->mod);
+            nmod_poly_clear(t);
+        }
+        else if (poly == res)
+        {
+            nmod_poly_t t;
+            nmod_poly_init_preinv(t, poly->mod.n, poly->mod.ninv);
+            nmod_poly_fit_length(t, n);
+            _nmod_poly_power_sums(t->coeffs, poly->coeffs + i,
+                                  len - i, n, t->mod);
+            nmod_poly_swap(t, res);
+            nmod_poly_clear(t);
+        }
+        else
+        {
+            nmod_poly_fit_length(res, n);
+            _nmod_poly_power_sums(res->coeffs, poly->coeffs + i,
+                                  len - i, n, poly->mod);
+        }
+        if (i)
+            NMOD_RED(res->coeffs[0], len - 1, poly->mod);
+        _nmod_poly_set_length(res, n);
+        _nmod_poly_normalise(res);
+    }
+
+}

--- a/nmod_poly/power_sums_naive.c
+++ b/nmod_poly/power_sums_naive.c
@@ -1,0 +1,103 @@
+/*=============================================================================
+
+    This file is part of FLINT.
+
+    FLINT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    FLINT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Vincent Delecroix
+
+******************************************************************************/
+
+#include <gmp.h>
+#include "flint.h"
+#include "nmod_vec.h"
+#include "nmod_poly.h"
+
+void
+_nmod_poly_power_sums_naive(mp_ptr res, mp_srcptr poly, slong len, slong n,
+                            nmod_t mod)
+{
+    slong i, k;
+    mp_limb_t tmp;
+
+    NMOD_RED(res[0], len - 1, mod);
+    for (k = 1; k < FLINT_MIN(n, len); k++)
+    {
+        res[k] = nmod_mul(poly[len - 1 - k], k, mod);
+        for (i = 1; i < k; i++)
+            res[k] =
+                nmod_add(res[k], nmod_mul(poly[len - 1 - k + i], res[i], mod),
+                         mod);
+        res[k] = nmod_neg(res[k], mod);
+    }
+    for (k = len; k < n; k++)
+    {
+        res[k] = 0;
+        for (i = k - len + 1; i < k; i++)
+            res[k] =
+                nmod_add(res[k], nmod_mul(poly[len - 1 - k + i], res[i], mod),
+                         mod);
+        res[k] = nmod_neg(res[k], mod);
+    }
+}
+
+void
+nmod_poly_power_sums_naive(nmod_poly_t res, const nmod_poly_t poly, slong n)
+{
+    if (poly->length == 0)
+    {
+        flint_printf
+            ("Exception (nmod_poly_power_sums_naive). Zero polynomial.\n");
+        abort();
+    }
+    else if (n <= 0 || poly->length == 1)
+    {
+        nmod_poly_zero(res);
+    }
+    else
+    {
+        if (*nmod_poly_lead(poly) != 1)
+        {
+            nmod_poly_t t;
+            nmod_poly_init_preinv(t, poly->mod.n, poly->mod.ninv);
+            nmod_poly_make_monic(t, poly);
+            nmod_poly_fit_length(res, n);
+            _nmod_poly_power_sums_naive(res->coeffs, t->coeffs,
+                                        t->length, n, t->mod);
+            nmod_poly_clear(t);
+        }
+        else if (poly == res)
+        {
+            nmod_poly_t t;
+            nmod_poly_init_preinv(t, poly->mod.n, poly->mod.ninv);
+            nmod_poly_fit_length(t, n);
+            _nmod_poly_power_sums_naive(t->coeffs, poly->coeffs,
+                                        poly->length, n, t->mod);
+            nmod_poly_swap(t, res);
+            nmod_poly_clear(t);
+        }
+        else
+        {
+            nmod_poly_fit_length(res, n);
+            _nmod_poly_power_sums_naive(res->coeffs, poly->coeffs,
+                                        poly->length, n, poly->mod);
+        }
+        _nmod_poly_set_length(res, n);
+        _nmod_poly_normalise(res);
+    }
+}

--- a/nmod_poly/power_sums_schoenhage.c
+++ b/nmod_poly/power_sums_schoenhage.c
@@ -1,0 +1,94 @@
+/*=============================================================================
+
+    This file is part of FLINT.
+
+    FLINT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    FLINT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Vincent Delecroix
+
+******************************************************************************/
+
+#include <gmp.h>
+#include "flint.h"
+#include "nmod_vec.h"
+#include "nmod_poly.h"
+
+void
+_nmod_poly_power_sums_schoenhage(mp_ptr res, mp_srcptr poly, slong len,
+                                 slong n, nmod_t mod)
+{
+    mp_ptr a, b;
+
+    a = (mp_ptr) flint_malloc((2 * len - 1) * sizeof(mp_limb_t));
+    b = a + len;
+
+    _nmod_poly_reverse(a, poly, len, len);
+    _nmod_poly_derivative(b, poly, len, mod);
+    _nmod_poly_reverse(b, b, len - 1, len - 1);
+
+    _nmod_poly_div_series(res, b, len - 1, a, len, n, mod);
+
+    flint_free(a);
+}
+
+void
+nmod_poly_power_sums_schoenhage(nmod_poly_t res, const nmod_poly_t poly,
+                                slong n)
+{
+    if (poly->length == 0)
+    {
+        flint_printf
+            ("Exception (nmod_poly_power_sums_schoenhage). Zero polynomial.\n");
+        abort();
+    }
+    else if ((n <= 0) || (poly->length == 1))
+    {
+        nmod_poly_zero(res);
+    }
+    else
+    {
+        if (*nmod_poly_lead(poly) != 1)
+        {
+            nmod_poly_t t;
+            nmod_poly_init_preinv(t, poly->mod.n, poly->mod.ninv);
+            nmod_poly_make_monic(t, poly);
+            nmod_poly_fit_length(res, n);
+            _nmod_poly_power_sums_schoenhage(res->coeffs, t->coeffs,
+                                             t->length, n, t->mod);
+            nmod_poly_clear(t);
+        }
+        else if (poly == res)
+        {
+            nmod_poly_t t;
+            nmod_poly_init_preinv(t, poly->mod.n, poly->mod.ninv);
+            nmod_poly_fit_length(t, n);
+            _nmod_poly_power_sums_schoenhage(t->coeffs, poly->coeffs,
+                                             poly->length, n, t->mod);
+            nmod_poly_swap(t, res);
+            nmod_poly_clear(t);
+        }
+        else
+        {
+            nmod_poly_fit_length(res, n);
+            _nmod_poly_power_sums_schoenhage(res->coeffs, poly->coeffs,
+                                             poly->length, n, poly->mod);
+        }
+        _nmod_poly_set_length(res, n);
+        _nmod_poly_normalise(res);
+    }
+}

--- a/nmod_poly/power_sums_to_poly.c
+++ b/nmod_poly/power_sums_to_poly.c
@@ -1,0 +1,72 @@
+/*=============================================================================
+
+    This file is part of FLINT.
+
+    FLINT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    FLINT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Vincent Delecroix
+
+******************************************************************************/
+
+#include <gmp.h>
+#include "flint.h"
+#include "nmod_vec.h"
+#include "nmod_poly.h"
+
+void
+_nmod_poly_power_sums_to_poly(mp_ptr res, mp_srcptr poly, slong len,
+                              nmod_t mod)
+{
+    if (len <= 10)
+        _nmod_poly_power_sums_to_poly_naive(res, poly, len, mod);
+    else
+        _nmod_poly_power_sums_to_poly_schoenhage(res, poly, len, mod);
+}
+
+void
+nmod_poly_power_sums_to_poly(nmod_poly_t res, const nmod_poly_t Q)
+{
+    if (Q->length == 0)
+    {
+        nmod_poly_fit_length(res, 1);
+        res->coeffs[0] = 1;
+        _nmod_poly_set_length(res, 1);
+    }
+    else
+    {
+        slong d = Q->coeffs[0];
+        if (Q == res)
+        {
+            nmod_poly_t t;
+            nmod_poly_init_preinv(t, Q->mod.n, Q->mod.ninv);
+            nmod_poly_fit_length(t, d + 1);
+            _nmod_poly_power_sums_to_poly(t->coeffs, Q->coeffs, Q->length,
+                                          Q->mod);
+            nmod_poly_swap(res, t);
+            nmod_poly_clear(t);
+        }
+        else
+        {
+            nmod_poly_fit_length(res, d + 1);
+            _nmod_poly_power_sums_to_poly(res->coeffs, Q->coeffs, Q->length,
+                                          Q->mod);
+        }
+        _nmod_poly_set_length(res, d + 1);
+        _nmod_poly_normalise(res);
+    }
+}

--- a/nmod_poly/power_sums_to_poly.c
+++ b/nmod_poly/power_sums_to_poly.c
@@ -32,7 +32,7 @@ void
 _nmod_poly_power_sums_to_poly(mp_ptr res, mp_srcptr poly, slong len,
                               nmod_t mod)
 {
-    if (len <= 10)
+    if (mod.n <= 12 || poly[0] <= 10)
         _nmod_poly_power_sums_to_poly_naive(res, poly, len, mod);
     else
         _nmod_poly_power_sums_to_poly_schoenhage(res, poly, len, mod);

--- a/nmod_poly/power_sums_to_poly_naive.c
+++ b/nmod_poly/power_sums_to_poly_naive.c
@@ -1,0 +1,88 @@
+/*=============================================================================
+
+    This file is part of FLINT.
+
+    FLINT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    FLINT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Vincent Delecroix
+
+******************************************************************************/
+
+#include <gmp.h>
+#include "flint.h"
+#include "nmod_vec.h"
+#include "nmod_poly.h"
+
+void
+_nmod_poly_power_sums_to_poly_naive(mp_ptr res, mp_srcptr poly, slong len,
+                                    nmod_t mod)
+{
+    slong i, k;
+    slong d = poly[0];
+
+    res[d] = 1;
+    for (k = 1; k < FLINT_MIN(d + 1, len); k++)
+    {
+        res[d - k] = poly[k];
+        for (i = 1; i < k; i++)
+            res[d - k] += nmod_mul(res[d - k + i], poly[i], mod);
+        res[d - k] = nmod_div(res[d - k], k, mod);
+        res[d - k] = nmod_neg(res[d - k], mod);
+    }
+    for (k = len; k <= d; k++)
+    {
+        res[d - k] = 0;
+        for (i = 1; i < len; i++)
+            res[d - k] += nmod_mul(res[d - k + i], poly[i], mod);
+        res[d - k] = nmod_div(res[d - k], k, mod);
+        res[d - k] = nmod_neg(res[d - k], mod);
+    }
+}
+
+void
+nmod_poly_power_sums_to_poly_naive(nmod_poly_t res, const nmod_poly_t Q)
+{
+    if (Q->length == 0)
+    {
+        nmod_poly_fit_length(res, 1);
+        res->coeffs[0] = 1;
+        _nmod_poly_set_length(res, 1);
+    }
+    else
+    {
+        slong d = Q->coeffs[0];
+        if (Q == res)
+        {
+            nmod_poly_t t;
+            nmod_poly_init_preinv(t, Q->mod.n, Q->mod.ninv);
+            nmod_poly_fit_length(t, d + 1);
+            _nmod_poly_power_sums_to_poly_naive(t->coeffs, Q->coeffs,
+                                                Q->length, Q->mod);
+            nmod_poly_swap(res, t);
+            nmod_poly_clear(t);
+        }
+        else
+        {
+            nmod_poly_fit_length(res, d + 1);
+            _nmod_poly_power_sums_to_poly_naive(res->coeffs, Q->coeffs,
+                                                Q->length, Q->mod);
+        }
+        _nmod_poly_set_length(res, d + 1);
+        _nmod_poly_normalise(res);
+    }
+}

--- a/nmod_poly/power_sums_to_poly_schoenhage.c
+++ b/nmod_poly/power_sums_to_poly_schoenhage.c
@@ -1,0 +1,82 @@
+/*=============================================================================
+
+    This file is part of FLINT.
+
+    FLINT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    FLINT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Vincent Delecroix
+
+******************************************************************************/
+
+#include <gmp.h>
+#include "flint.h"
+#include "nmod_vec.h"
+#include "nmod_poly.h"
+
+void
+_nmod_poly_power_sums_to_poly_schoenhage(mp_ptr res, mp_srcptr poly, slong len,
+                                         nmod_t mod)
+{
+    mp_ptr t;
+    slong d = poly[0];
+
+    if (len >= d + 1)
+        len = d + 1;
+
+    t = flint_malloc(len * sizeof(mp_limb_t));
+
+    _nmod_vec_neg(t, poly + 1, len - 1, mod);
+    _nmod_poly_integral(t, t, len, mod);
+    _nmod_poly_exp_series_basecase(res, t, len, d + 1, mod);
+    _nmod_poly_reverse(res, res, d + 1, d + 1);
+
+    flint_free(t);
+}
+
+void
+nmod_poly_power_sums_to_poly_schoenhage(nmod_poly_t res, const nmod_poly_t Q)
+{
+    if (Q->length == 0)
+    {
+        nmod_poly_fit_length(res, 1);
+        (res->coeffs)[0] = 1;
+        _nmod_poly_set_length(res, 1);
+    }
+    else
+    {
+        slong d = (Q->coeffs)[0];
+        if (Q == res)
+        {
+            nmod_poly_t t;
+            nmod_poly_init_preinv(t, Q->mod.n, Q->mod.ninv);
+            nmod_poly_fit_length(t, d + 1);
+            _nmod_poly_power_sums_to_poly_schoenhage(t->coeffs, Q->coeffs,
+                                                     Q->length, Q->mod);
+            nmod_poly_swap(res, t);
+            nmod_poly_clear(t);
+        }
+        else
+        {
+            nmod_poly_fit_length(res, d + 1);
+            _nmod_poly_power_sums_to_poly_schoenhage(res->coeffs, Q->coeffs,
+                                                     Q->length, Q->mod);
+        }
+        _nmod_poly_set_length(res, d + 1);
+        _nmod_poly_normalise(res);
+    }
+}

--- a/nmod_poly/test/t-power_sums.c
+++ b/nmod_poly/test/t-power_sums.c
@@ -40,7 +40,7 @@ main(void)
     {
         mp_limb_t n;
         nmod_poly_t a, b, c, d, e;
-        n = 53;                 /* TODO: a random number not divisible by small primes! */
+        n = n_randprime(state, 10, 1);
 
         nmod_poly_init(a, n);
         nmod_poly_init(b, n);

--- a/nmod_poly/test/t-power_sums.c
+++ b/nmod_poly/test/t-power_sums.c
@@ -1,0 +1,102 @@
+/*=============================================================================
+
+    This file is part of FLINT.
+
+    FLINT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    FLINT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Vincent Delecroix
+
+******************************************************************************/
+
+#include <gmp.h>
+#include "flint.h"
+#include "nmod_poly.h"
+
+int
+main(void)
+{
+    int i, result;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("power_sums....");
+
+    /* Check that the different version coincide and aliasing in nmod_poly_power_sums */
+    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    {
+        mp_limb_t n;
+        nmod_poly_t a, b, c, d, e;
+        n = 53;                 /* TODO: a random number not divisible by small primes! */
+
+        nmod_poly_init(a, n);
+        nmod_poly_init(b, n);
+        nmod_poly_init(c, n);
+        nmod_poly_init(d, n);
+        nmod_poly_init(e, n);
+
+        nmod_poly_randtest_not_zero(a, state, 1 + n_randint(state, 10));
+
+        nmod_poly_power_sums_naive(b, a, 20);
+        nmod_poly_power_sums_schoenhage(c, a, 20);
+        nmod_poly_power_sums(d, a, 20);
+
+        nmod_poly_set(e, a);
+        nmod_poly_power_sums(e, e, 20);
+
+        result = nmod_poly_equal(b, c) && nmod_poly_equal(b, d) &&
+            nmod_poly_equal(b, e);
+        if (!result)
+        {
+            flint_printf
+                ("FAIL: PowerSums(p1 p2) = PowerSums(p1) + PowerSums(p2)\n");
+            flint_printf("a = "), nmod_poly_print(a), flint_printf("\n");
+            flint_printf("b = "), nmod_poly_print(b), flint_printf("\n");
+            flint_printf("c = "), nmod_poly_print(c), flint_printf("\n");
+            flint_printf("d = "), nmod_poly_print(d), flint_printf("\n");
+            flint_printf("e = "), nmod_poly_print(e), flint_printf("\n");
+            abort();
+        }
+
+        nmod_poly_make_monic(a, a);
+
+        nmod_poly_power_sums_to_poly_schoenhage(b, b);
+        nmod_poly_power_sums_to_poly(d, c);
+        nmod_poly_power_sums_to_poly(c, c);
+        result = nmod_poly_equal(a, b) && nmod_poly_equal(a, c) &&
+            nmod_poly_equal(a, d);
+        if (!result)
+        {
+            flint_printf("FAIL: power_sums_to_poly\n");
+            flint_printf("e = "), nmod_poly_print(e), flint_printf("\n");
+            flint_printf("a = "), nmod_poly_print(a), flint_printf("\n");
+            flint_printf("b = "), nmod_poly_print(b), flint_printf("\n");
+            flint_printf("c = "), nmod_poly_print(c), flint_printf("\n");
+            abort();
+        }
+
+        nmod_poly_clear(a);
+        nmod_poly_clear(b);
+        nmod_poly_clear(c);
+        nmod_poly_clear(d);
+        nmod_poly_clear(e);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+
+    flint_printf("PASS\n");
+    return 0;
+}

--- a/nmod_poly/test/t-power_sums_naive.c
+++ b/nmod_poly/test/t-power_sums_naive.c
@@ -1,0 +1,199 @@
+/*=============================================================================
+
+    This file is part of FLINT.
+
+    FLINT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    FLINT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Vincent Delecroix
+
+******************************************************************************/
+
+#include <gmp.h>
+#include "flint.h"
+#include "nmod_poly.h"
+
+int
+main(void)
+{
+    int l, result;
+    mp_limb_t i, j, k, tot;
+    nmod_t mod;
+    mp_limb_t n;
+
+    FLINT_TEST_INIT(state);
+
+    flint_printf("power_sums_naive....");
+
+    /* Check that it is valid in degree 3 with integer roots, ie */
+    /* for polynomials of the form (x-i)(x-j)(x-k)               */
+    n = 101;                    /* TODO: a random number not divisible by small primes! */
+    nmod_init(&mod, n);
+    for (i = 0; i < 4; i++)
+        for (j = 0; j < 4; j++)
+            for (k = 0; k < 4; k++)
+            {
+                nmod_poly_t a, b, c, d;
+                nmod_poly_init(a, n);
+                nmod_poly_init(b, n);
+                nmod_poly_init(c, n);
+                nmod_poly_init(d, n);
+
+                nmod_poly_set_coeff_ui(a, 0, n - i * j * k);
+                nmod_poly_set_coeff_ui(a, 1, i * j + i * k + j * k);
+                nmod_poly_set_coeff_ui(a, 2, n - i - j - k);
+                nmod_poly_set_coeff_ui(a, 3, 1);
+
+                nmod_poly_power_sums_naive(b, a, 20);
+                nmod_poly_set(d, a);
+                nmod_poly_power_sums_naive(d, d, 20);
+
+                for (l = 0; l < FLINT_MIN(20, nmod_poly_length(b)); l++)
+                {
+                    tot = nmod_add(nmod_pow_ui(i, l, mod),
+                                   nmod_pow_ui(j, l, mod), mod);
+                    tot = nmod_add(tot, nmod_pow_ui(k, l, mod), mod);
+
+                    result = nmod_poly_get_coeff_ui(b, l) == tot &&
+                        nmod_poly_get_coeff_ui(d, l) == tot;
+                    if (!result)
+                    {
+                        flint_printf("FAIL: power sums integral root\n");
+                        flint_printf("%d %d %d %d\n", i, j, k, l);
+                        flint_printf("a = "), nmod_poly_print(a),
+                            flint_printf("\n");
+                        flint_printf("b = "), nmod_poly_print(b),
+                            flint_printf("\n");
+                        flint_printf("d = "), nmod_poly_print(d),
+                            flint_printf("\n");
+                        abort();
+                    }
+                }
+
+                nmod_poly_power_sums_to_poly_naive(c, b);
+                nmod_poly_set(d, b);
+                nmod_poly_power_sums_to_poly_naive(d, d);
+                result = nmod_poly_equal(a, c) && nmod_poly_equal(a, d);
+                if (!result)
+                {
+                    flint_printf("FAIL: power sums to poly naive\n");
+                    flint_printf("a = "), nmod_poly_print(a),
+                        flint_printf("\n\n");
+                    flint_printf("b = "), nmod_poly_print(b),
+                        flint_printf("\n\n");
+                    flint_printf("c = "), nmod_poly_print(c),
+                        flint_printf("\n\n");
+                    flint_printf("d = "), nmod_poly_print(c),
+                        flint_printf("\n\n");
+                    abort();
+                }
+
+                nmod_poly_clear(a);
+                nmod_poly_clear(b);
+                nmod_poly_clear(c);
+                nmod_poly_clear(d);
+            }
+
+    /* Check that going back and forth between the power sums representation gives the identity */
+    for (i = 0; i < 50 * flint_test_multiplier(); i++)
+    {
+        nmod_poly_t a, b, c, d;
+        n = 5003;               /* TODO: a random number not divisible by small primes! */
+
+        nmod_poly_init(a, n);
+        nmod_poly_init(b, n);
+        nmod_poly_init(c, n);
+        nmod_poly_init(d, n);
+
+        nmod_poly_randtest_not_zero(a, state, 1 + n_randint(state, 20));
+        nmod_poly_make_monic(a, a);
+
+        nmod_poly_power_sums_naive(b, a, 30);
+        nmod_poly_power_sums_to_poly_naive(c, b);
+
+        nmod_poly_set(d, a);
+        nmod_poly_power_sums_naive(d, d, 30);
+        nmod_poly_power_sums_to_poly_naive(d, d);
+
+        result = nmod_poly_equal(a, c) && nmod_poly_equal(a, d);
+        if (!result)
+        {
+            flint_printf("FAIL: power sums - power sums to poly\n");
+            flint_printf("a = "), nmod_poly_print(a), flint_printf("\n\n");
+            flint_printf("b = "), nmod_poly_print(b), flint_printf("\n\n");
+            flint_printf("c = "), nmod_poly_print(c), flint_printf("\n\n");
+            flint_printf("d = "), nmod_poly_print(c), flint_printf("\n\n");
+            abort();
+        }
+
+        nmod_poly_clear(a);
+        nmod_poly_clear(b);
+        nmod_poly_clear(c);
+        nmod_poly_clear(d);
+    }
+
+
+    /* Check that the product of polynomials correspond to the sum of Power sums series */
+    for (i = 0; i < 20 * flint_test_multiplier(); i++)
+    {
+        nmod_poly_t a, b, c, d;
+        n = 5003;               /* TODO: a random number not divisible by small primes! */
+
+        nmod_poly_init(a, n);
+        nmod_poly_init(b, n);
+        nmod_poly_init(c, n);
+        nmod_poly_init(d, n);
+
+        nmod_poly_randtest_not_zero(a, state, 1 + n_randint(state, 10));
+        nmod_poly_randtest_not_zero(b, state, 1 + n_randint(state, 10));
+
+        nmod_poly_mul(c, a, b);
+        nmod_poly_power_sums_naive(c, c, 20);
+
+        /* NOTE: the code path is not the same if the polynomial is monic. We let only a be monic */
+        nmod_poly_make_monic(a, a);
+        nmod_poly_power_sums_naive(a, a, 20);
+        nmod_poly_power_sums_naive(b, b, 20);
+        nmod_poly_add(d, a, b);
+
+        result = nmod_poly_equal(c, d);
+        if (!result)
+        {
+            flint_printf
+                ("FAIL: PowerSums(p1 p2) = PowerSums(p1) + PowerSums(p2)\n");
+            flint_printf("a = ");
+            nmod_poly_print(a), flint_printf("\n");
+            flint_printf("b = ");
+            nmod_poly_print(b), flint_printf("\n");
+            flint_printf("c = ");
+            nmod_poly_print(c), flint_printf("\n");
+            flint_printf("d = ");
+            nmod_poly_print(d), flint_printf("\n");
+            abort();
+        }
+
+        nmod_poly_clear(a);
+        nmod_poly_clear(b);
+        nmod_poly_clear(c);
+        nmod_poly_clear(d);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+
+    flint_printf("PASS\n");
+    return 0;
+}

--- a/nmod_poly/test/t-power_sums_naive.c
+++ b/nmod_poly/test/t-power_sums_naive.c
@@ -32,8 +32,6 @@ main(void)
 {
     int l, result;
     mp_limb_t i, j, k, tot;
-    nmod_t mod;
-    mp_limb_t n;
 
     FLINT_TEST_INIT(state);
 
@@ -41,13 +39,18 @@ main(void)
 
     /* Check that it is valid in degree 3 with integer roots, ie */
     /* for polynomials of the form (x-i)(x-j)(x-k)               */
-    n = 101;                    /* TODO: a random number not divisible by small primes! */
-    nmod_init(&mod, n);
     for (i = 0; i < 4; i++)
         for (j = 0; j < 4; j++)
             for (k = 0; k < 4; k++)
             {
+                mp_limb_t n;
+                nmod_t mod;
                 nmod_poly_t a, b, c, d;
+
+                n = 20 + n_randbits(state, 8);
+                n = n_nextprime(n, 1);
+                nmod_init(&mod, n);
+
                 nmod_poly_init(a, n);
                 nmod_poly_init(b, n);
                 nmod_poly_init(c, n);
@@ -112,7 +115,10 @@ main(void)
     for (i = 0; i < 50 * flint_test_multiplier(); i++)
     {
         nmod_poly_t a, b, c, d;
-        n = 5003;               /* TODO: a random number not divisible by small primes! */
+        mp_limb_t n;
+
+        n = 35 + n_randbits(state, 8);
+        n = n_nextprime(n, 1);
 
         nmod_poly_init(a, n);
         nmod_poly_init(b, n);
@@ -151,7 +157,10 @@ main(void)
     for (i = 0; i < 20 * flint_test_multiplier(); i++)
     {
         nmod_poly_t a, b, c, d;
-        n = 5003;               /* TODO: a random number not divisible by small primes! */
+        mp_limb_t n;
+        n = n_randprime(state, 10, 1);
+        n = 25 + n_randbits(state, 8);
+        n = n_nextprime(n, 1);
 
         nmod_poly_init(a, n);
         nmod_poly_init(b, n);

--- a/nmod_poly/test/t-power_sums_schoenhage.c
+++ b/nmod_poly/test/t-power_sums_schoenhage.c
@@ -1,0 +1,181 @@
+/*=============================================================================
+
+    This file is part of FLINT.
+
+    FLINT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    FLINT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Vincent Delecroix
+
+******************************************************************************/
+
+#include <gmp.h>
+#include "flint.h"
+#include "nmod_poly.h"
+
+int
+main(void)
+{
+    int l, result;
+    mp_limb_t i, j, k, tot;
+    nmod_t mod;
+    mp_limb_t n;
+
+    FLINT_TEST_INIT(state);
+
+    flint_printf("power_sums_schoenhage....");
+
+    /* Check that it is valid in degree 3 with integer roots, ie */
+    /* for polynomials of the form (x-i)(x-j)(x-k)               */
+    n = 101;                    /* TODO: a random number not divisible by small primes! */
+    nmod_init(&mod, n);
+    for (i = 0; i < 4; i++)
+        for (j = 0; j < 4; j++)
+            for (k = 0; k < 4; k++)
+            {
+                nmod_poly_t a, b, c;
+                nmod_poly_init(a, n);
+                nmod_poly_init(b, n);
+                nmod_poly_init(c, n);
+
+                nmod_poly_set_coeff_ui(a, 0, n - i * j * k);
+                nmod_poly_set_coeff_ui(a, 1, i * j + i * k + j * k);
+                nmod_poly_set_coeff_ui(a, 2, n - i - j - k);
+                nmod_poly_set_coeff_ui(a, 3, 1);
+
+                nmod_poly_power_sums_schoenhage(b, a, 20);
+
+                for (l = 0; l < FLINT_MIN(20, nmod_poly_length(b)); l++)
+                {
+                    tot = nmod_add(nmod_pow_ui(i, l, mod),
+                                   nmod_pow_ui(j, l, mod), mod);
+                    tot = nmod_add(tot, nmod_pow_ui(k, l, mod), mod);
+
+                    result = nmod_poly_get_coeff_ui(b, l) == tot;
+                    if (!result)
+                    {
+                        flint_printf("FAIL: power sums integral root\n");
+                        flint_printf("%d %d %d %d\n", i, j, k, l);
+                        abort();
+                    }
+                }
+
+                nmod_poly_power_sums_to_poly_schoenhage(c, b);
+                result = nmod_poly_equal(a, c);
+                if (!result)
+                {
+                    flint_printf("FAIL: power sums to poly schoenhage\n");
+                    flint_printf("a = ");
+                    nmod_poly_print(a), flint_printf("\n\n");
+                    flint_printf("b = ");
+                    nmod_poly_print(b), flint_printf("\n\n");
+                    flint_printf("c = ");
+                    nmod_poly_print(c), flint_printf("\n\n");
+                    abort();
+                }
+
+                nmod_poly_clear(a);
+                nmod_poly_clear(b);
+                nmod_poly_clear(c);
+            }
+
+    /* Check that going back and forth between the power sums representation gives the identity */
+    for (i = 0; i < 50 * flint_test_multiplier(); i++)
+    {
+        nmod_poly_t a, b, c;
+        n = 5003;               /* TODO: a random number not divisible by small primes! */
+
+        nmod_poly_init(a, n);
+        nmod_poly_init(b, n);
+        nmod_poly_init(c, n);
+
+        nmod_poly_randtest_not_zero(a, state, 1 + n_randint(state, 20));
+        nmod_poly_make_monic(a, a);
+
+        nmod_poly_power_sums_schoenhage(b, a, 30);
+        nmod_poly_power_sums_to_poly_schoenhage(c, b);
+
+        result = nmod_poly_equal(a, c);
+        if (!result)
+        {
+            flint_printf("FAIL: power sums - power sums to poly\n");
+            flint_printf("a = ");
+            nmod_poly_print(a), flint_printf("\n\n");
+            flint_printf("b = ");
+            nmod_poly_print(b), flint_printf("\n\n");
+            flint_printf("c = ");
+            nmod_poly_print(c), flint_printf("\n\n");
+            abort();
+        }
+
+        nmod_poly_clear(a);
+        nmod_poly_clear(b);
+        nmod_poly_clear(c);
+    }
+
+
+    /* Check that the product of polynomials correspond to the sum of Power sums series */
+    /* (and aliasing of nmod_poly_power_sums)                                           */
+    for (i = 0; i < 20 * flint_test_multiplier(); i++)
+    {
+        nmod_poly_t a, b, c, d;
+        n = 5003;               /* TODO: a random number not divisible by small primes! */
+
+        nmod_poly_init(a, n);
+        nmod_poly_init(b, n);
+        nmod_poly_init(c, n);
+        nmod_poly_init(d, n);
+
+        nmod_poly_randtest_not_zero(a, state, 1 + n_randint(state, 10));
+        nmod_poly_randtest_not_zero(b, state, 1 + n_randint(state, 10));
+
+        nmod_poly_mul(c, a, b);
+        nmod_poly_power_sums_schoenhage(c, c, 20);
+
+        /* NOTE: the code path is not the same if the polynomial is monic. We let only a be monic */
+        nmod_poly_make_monic(a, a);
+        nmod_poly_power_sums_schoenhage(a, a, 20);
+        nmod_poly_power_sums_schoenhage(b, b, 20);
+        nmod_poly_add(d, a, b);
+
+        result = nmod_poly_equal(c, d);
+        if (!result)
+        {
+            flint_printf
+                ("FAIL: PowerSums(p1 p2) = PowerSums(p1) + PowerSums(p2)\n");
+            flint_printf("a = ");
+            nmod_poly_print(a), flint_printf("\n");
+            flint_printf("b = ");
+            nmod_poly_print(b), flint_printf("\n");
+            flint_printf("c = ");
+            nmod_poly_print(c), flint_printf("\n");
+            flint_printf("d = ");
+            nmod_poly_print(d), flint_printf("\n");
+            abort();
+        }
+
+        nmod_poly_clear(a);
+        nmod_poly_clear(b);
+        nmod_poly_clear(c);
+        nmod_poly_clear(d);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+
+    flint_printf("PASS\n");
+    return 0;
+}


### PR DESCRIPTION
Here is the implementation of power sums for nmod_poly_t. Contrarily to the case of fmpz_poly_t the Schoenhage formula does not suffers from coefficient blowup

![graphic_deg10_mod17](https://cloud.githubusercontent.com/assets/5619446/14406701/127e5aee-fe86-11e5-9c39-0cc59bea89aa.png)

Hopefully, a segmentation fault in the code forced me to use valgrind... and I discovered an issue with the previous code for fmpz and fmpq (very same bug for both).

The threshold seems fine on my computer (linux x86_64) for both power_sums and power_sums_to_poly.

![graphic_deg4_mod7](https://cloud.githubusercontent.com/assets/5619446/14406718/7b6e6b48-fe86-11e5-9d2f-4adbc96e1dc4.png)
![to_poly_mod7](https://cloud.githubusercontent.com/assets/5619446/14406714/6f9ad39c-fe86-11e5-8db1-08917c93ee92.png)
![to_poly_mod17](https://cloud.githubusercontent.com/assets/5619446/14406715/6fa1056e-fe86-11e5-9777-792f949e83db.png)
