### PR TITLE
OpenMP initial integration

### DIFF
--- a/configure
+++ b/configure
@@ -17,6 +17,8 @@ SHARED=1
 STATIC=1
 TLS=1
 PTHREAD=1
+WANT_OPENMP=0
+OPENMP=0
 REENTRANT=0
 WANT_GC=0
 WANT_TLS=0
@@ -79,6 +81,8 @@ usage()
    echo "     --with-gc=<path>     GC safe build with path to gc"
    echo "     --enable-pthread     Use pthread (default)"
    echo "     --disable-pthread    Do not use pthread"
+   echo "     --enable-openmp      Use OpenMP"
+   echo "     --disable-openmp     Do not use OpenMP (default)"
    echo "     --enable-tls         Use thread-local storage (default)"
    echo "     --disable-tls        Do not use thread-local storage"
    echo "     --enable-assert      Enable use of asserts (use for debug builds only)"
@@ -172,6 +176,13 @@ while [ "$1" != "" ]; do
             GC_DIR="$VALUE"
          fi
          ;;
+      --enable-openmp)
+         OPENMP=1
+         WANT_OPENMP=1
+         ;;
+      --disable-openmp)
+         OPENMP=0
+         ;;
       --enable-pthread)
          PTHREAD=1
          ;;
@@ -183,7 +194,7 @@ while [ "$1" != "" ]; do
          WANT_TLS=1;;
       --disable-tls)
          TLS=0
-         ;;
+         WANT_TLS=2;;
       --enable-assert)
          ASSERT=1
          ;;
@@ -326,11 +337,26 @@ if [ -z "$AR" ]; then
    AR=ar
 fi
 
+#openmp provides tls
+if [ "$OPENMP" = "1" -a "$TLS" = "0" ]; then
+   if [ "$WANT_TLS" = "2" -a "$WANT_OPENMP" = "1" ]; then
+      echo "****WARNING**** Cannot have OpenMP without TLS. Disabling OpenMP."
+      OPENMP=0
+   elif [ "$WANT_OPENMP" = "1" ]; then
+      TLS=1
+   else
+      OPENMP=0
+   fi
+fi
+
 #handle gc and reentrant flags
 
 if [ "$WANT_GC" = "1" ]; then
       TLS=0
-      if [ "$WANT_TLS" = "1" ]; then
+      OPENMP=0
+      if [ "$WANT_OPENMP" = "1" ]; then
+          echo "****WARNING**** GC does not support TLS, which is implied by OpenMP....disabling both"
+      elif [ "$WANT_TLS" = "1" ]; then
           echo "****WARNING**** GC does not support TLS....disabling TLS"
       fi
       cp fmpz/link/fmpz_gc.c fmpz/fmpz.c
@@ -569,17 +595,24 @@ else
    printf "%s\n" "no"
 fi
 
+#get flag for OpenMP
+if [ "$OPENMP" = "1" ]; then
+    OPENMP_FLAG="-fopenmp"
+else
+    OPENMP_FLAG="-Wno-unknown-pragmas"
+fi
+
 #defaults for CFLAGS
 
 if [ -z "$CFLAGS" ]; then
    if [ "$OS" = "MINGW64" ]; then
-      CFLAGS="-std=c99 -O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG"
+      CFLAGS="-std=c99 -O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG $OPENMP_FLAG"
    elif [ "$OS" = "CYGWIN64" ]; then
-      CFLAGS="-O2 -funroll-loops -g -D _WIN64 $POPCNT_FLAG $ABI_FLAG"
+      CFLAGS="-O2 -funroll-loops -g -D _WIN64 $POPCNT_FLAG $ABI_FLAG $OPENMP_FLAG"
    elif [ "$MACHINE" = "mips64" ]; then
-      CFLAGS="-O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG"
+      CFLAGS="-O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG $OPENMP_FLAG"
    else
-      CFLAGS="-ansi -pedantic -Wall -O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG"
+      CFLAGS="-ansi -pedantic -Wall -O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG $OPENMP_FLAG"
    fi
 fi
 

--- a/flint.h
+++ b/flint.h
@@ -149,8 +149,17 @@ void flint_set_abort(void (*func)(void));
 #define FLINT_TLS_PREFIX
 #endif
 
+#ifdef _OPENMP
+#define FLINT_PREFER_OMP 1
+#elif HAVE_PTHREAD
+#define FLINT_PREFER_OMP 0
+#else
+#define FLINT_PREFER_OMP 1
+#endif
+
 FLINT_DLL int flint_get_num_threads(void);
 FLINT_DLL void flint_set_num_threads(int num_threads);
+FLINT_DLL void flint_parallel_cleanup(void);
 
 FLINT_DLL int flint_test_multiplier(void);
 

--- a/fmpz/link/fmpz_single.c
+++ b/fmpz/link/fmpz_single.c
@@ -23,6 +23,7 @@
 FLINT_TLS_PREFIX __mpz_struct ** mpz_free_arr = NULL;
 FLINT_TLS_PREFIX ulong mpz_free_num = 0;
 FLINT_TLS_PREFIX ulong mpz_free_alloc = 0;
+#pragma omp threadprivate(mpz_free_arr, mpz_free_num, mpz_free_alloc)
 
 __mpz_struct * _fmpz_new_mpz(void)
 {

--- a/fmpz_poly.h
+++ b/fmpz_poly.h
@@ -917,9 +917,21 @@ FLINT_DLL void _fmpz_poly_taylor_shift_divconquer(fmpz * poly, const fmpz_t c, s
 FLINT_DLL void fmpz_poly_taylor_shift_divconquer(fmpz_poly_t g, const fmpz_poly_t f,
     const fmpz_t c);
 
-FLINT_DLL void _fmpz_poly_taylor_shift_multi_mod(fmpz * poly, const fmpz_t c, slong n);
+FLINT_DLL void _fmpz_poly_taylor_shift_multi_mod_threaded(fmpz * poly, const fmpz_t c, slong n);
 
-FLINT_DLL void fmpz_poly_taylor_shift_multi_mod(fmpz_poly_t g, const fmpz_poly_t f, const fmpz_t c);
+FLINT_DLL void _fmpz_poly_taylor_shift_multi_mod_omp(fmpz * poly, const fmpz_t c, slong n);
+
+FMPZ_POLY_INLINE
+void fmpz_poly_taylor_shift_multi_mod(fmpz_poly_t g, const fmpz_poly_t f, const fmpz_t c)
+{
+    if (f != g)
+        fmpz_poly_set(g, f);
+#if FLINT_PREFER_OMP
+    _fmpz_poly_taylor_shift_multi_mod_omp(g->coeffs, c, g->length);
+#else
+    _fmpz_poly_taylor_shift_multi_mod_threaded(g->coeffs, c, g->length);
+#endif
+}
 
 FLINT_DLL void _fmpz_poly_taylor_shift(fmpz * poly, const fmpz_t c, slong n);
 

--- a/fmpz_poly/taylor_shift_multi_mod_omp.c
+++ b/fmpz_poly/taylor_shift_multi_mod_omp.c
@@ -1,0 +1,113 @@
+/*
+    Copyright (C) 2014 Fredrik Johansson
+    Authored 2016 Daniel S. Roche
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include <gmp.h>
+#include "flint.h"
+#include "fmpz.h"
+#include "fmpz_poly.h"
+
+void
+_fmpz_poly_taylor_shift_multi_mod_omp(fmpz * poly, const fmpz_t c, slong len)
+{
+    slong xbits, ybits, num_primes, i;
+    mp_ptr primes;
+    mp_ptr * residues;
+
+    if (len <= 1 || fmpz_is_zero(c))
+        return;
+
+    xbits = _fmpz_vec_max_bits(poly, len);
+
+    if (xbits == 0)
+        return;
+
+    /* If poly has degree D and coefficients at most |C|, the
+       output has coefficient at most D * |C| * 2^D * c^D */
+    xbits = FLINT_ABS(xbits) + 1;
+    ybits = xbits + len + FLINT_BIT_COUNT(len);
+
+    if (!fmpz_is_pm1(c))
+    {
+        fmpz_t t;
+        fmpz_init(t);
+        fmpz_pow_ui(t, c, len);
+        ybits += fmpz_bits(t);
+        fmpz_clear(t);
+    }
+
+    /* Use primes greater than 2^(FLINT_BITS-1) */
+    num_primes = (ybits + (FLINT_BITS - 1) - 1) / (FLINT_BITS - 1);
+    primes = flint_malloc(sizeof(mp_limb_t) * num_primes);
+    primes[0] = n_nextprime(UWORD(1) << (FLINT_BITS - 1), 1);
+    for (i = 1; i < num_primes; i++)
+        primes[i] = n_nextprime(primes[i-1], 1);
+
+    /* Space for poly reduced modulo the primes */
+    residues = flint_malloc(sizeof(mp_ptr) * num_primes);
+    for (i = 0; i < num_primes; i++)
+        residues[i] = flint_malloc(sizeof(mp_limb_t) * len);
+
+#pragma omp parallel private(i)
+    {
+        mp_ptr tmp;
+        slong j;
+
+        fmpz_comb_t comb;
+        fmpz_comb_temp_t comb_temp;
+
+        tmp = flint_malloc(sizeof(mp_limb_t) * num_primes);
+        fmpz_comb_init(comb, primes, num_primes);
+        fmpz_comb_temp_init(comb_temp, comb);
+
+        /* _fmpz_vec_multi_mod_ui_threaded(residues, poly, len, primes, num_primes, 0); */
+#pragma omp for schedule(static)
+        for (i = 0; i < len; i++)
+        {
+            fmpz_multi_mod_ui(tmp, poly + i, comb, comb_temp);
+            for (j = 0; j < num_primes; j++)
+                residues[j][i] = tmp[j];
+        }
+
+        /* _fmpz_poly_multi_taylor_shift_threaded(residues, len, c, primes, num_primes); */
+#pragma omp for
+        for (i = 0; i < num_primes; i++)
+        {
+            nmod_t mod;
+            mp_limb_t p, cm;
+
+            p = primes[i];
+            nmod_init(&mod, p);
+            cm = fmpz_fdiv_ui(c, p);
+            _nmod_poly_taylor_shift(residues[i], cm, len, mod);
+        }
+
+        /* _fmpz_vec_multi_mod_ui_threaded(residues, poly, len, primes, num_primes, 1); */
+#pragma omp for schedule(static) nowait
+        for (i = 0; i < len; i++)
+        {
+            for (j = 0; j < num_primes; j++)
+                tmp[j] = residues[j][i];
+            fmpz_multi_CRT_ui(poly + i, tmp, comb, comb_temp, 1);
+        }
+
+        flint_free(tmp);
+        fmpz_comb_clear(comb);
+        fmpz_comb_temp_clear(comb_temp);
+
+        flint_parallel_cleanup();
+    }
+
+    for (i = 0; i < num_primes; i++)
+        flint_free(residues[i]);
+    flint_free(residues);
+    flint_free(primes);
+}

--- a/fmpz_poly/taylor_shift_multi_mod_threaded.c
+++ b/fmpz_poly/taylor_shift_multi_mod_threaded.c
@@ -165,7 +165,7 @@ _fmpz_poly_multi_taylor_shift_threaded(mp_ptr * residues, slong len,
 }
 
 void
-_fmpz_poly_taylor_shift_multi_mod(fmpz * poly, const fmpz_t c, slong len)
+_fmpz_poly_taylor_shift_multi_mod_threaded(fmpz * poly, const fmpz_t c, slong len)
 {
     slong xbits, ybits, num_primes, i;
     mp_ptr primes;
@@ -214,13 +214,3 @@ _fmpz_poly_taylor_shift_multi_mod(fmpz * poly, const fmpz_t c, slong len)
     flint_free(residues);
     flint_free(primes);
 }
-
-void
-fmpz_poly_taylor_shift_multi_mod(fmpz_poly_t g, const fmpz_poly_t f, const fmpz_t c)
-{
-    if (f != g)
-        fmpz_poly_set(g, f);
-
-    _fmpz_poly_taylor_shift_multi_mod(g->coeffs, c, g->length);
-}
-

--- a/fmpz_poly/test/t-taylor_shift_multi_mod_threaded.c
+++ b/fmpz_poly/test/t-taylor_shift_multi_mod_threaded.c
@@ -26,7 +26,7 @@ main(void)
     flint_printf("taylor_shift_multi_mod....");
     fflush(stdout);
 
-#if HAVE_PTHREAD && (HAVE_TLS || FLINT_REENTRANT)
+#if FLINT_PREFER_OPENMP || (HAVE_PTHREAD && (HAVE_TLS || FLINT_REENTRANT))
 
     /* Check aliasing */
     for (i = 0; i < 100 * flint_test_multiplier(); i++)

--- a/memory_manager.c
+++ b/memory_manager.c
@@ -164,6 +164,8 @@ FLINT_TLS_PREFIX size_t flint_num_cleanup_functions = 0;
 
 FLINT_TLS_PREFIX flint_cleanup_function_t * flint_cleanup_functions = NULL;
 
+#pragma omp threadprivate(flint_num_cleanup_functions, flint_cleanup_functions)
+
 #if FLINT_REENTRANT && !HAVE_TLS
 void register_init()
 {

--- a/test/t-omp_cleanup.c
+++ b/test/t-omp_cleanup.c
@@ -1,0 +1,110 @@
+/*
+    Authored 2016 by Daniel S. Roche
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "flint.h"
+#include "ulong_extras.h"
+
+int thread_active = 0;
+#pragma omp threadprivate(thread_active)
+
+int thread_count = 0;
+int free_count = 0;
+
+void cleanup()
+{
+    if (thread_active)
+    {
+#pragma omp atomic
+        --thread_count;
+#pragma omp atomic
+        ++free_count;
+        thread_active = 0;
+    }
+}
+
+void foo()
+{
+    if (!thread_active)
+    {
+#pragma omp atomic
+        ++thread_count;
+        flint_register_cleanup_function(cleanup);
+        thread_active = 1;
+    }
+}
+
+int main(void)
+{
+    int i, result;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("omp_cleanup....");
+    fflush(stdout);
+
+#ifdef _OPENMP
+
+    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    {
+        int threads, tmin;
+        slong iters;
+
+        threads = (int)n_randint(state, 8) + 1;
+        flint_set_num_threads(threads);
+
+        iters = (slong)n_randint(state, 1000) + threads;
+
+        free_count = 0;
+
+#pragma omp parallel
+        {
+            slong j;
+
+#pragma omp for
+            for (j = 0; j < iters; ++j)
+                foo();
+
+            flint_parallel_cleanup();
+        }
+
+#ifdef _OPENMP
+        tmin = FLINT_MIN(1, threads - 1);
+#else
+        tmin = 0;
+#endif
+
+        result = (thread_count == 1) && (free_count >= tmin);
+
+        if (!result)
+        {
+            flint_printf("FAIL:\n");
+            flint_printf("tcount = %d, fcount = %d\n",
+                thread_count, free_count);
+            abort();
+        }
+    }
+
+    FLINT_TEST_CLEANUP(state);
+
+    if (thread_count != 0)
+    {
+        flint_printf("FAIL: final cleanup\n");
+        abort();
+    }
+    
+    flint_printf("PASS\n");
+
+#else
+    FLINT_TEST_CLEANUP(state);
+    flint_printf("SKIPPED\n");
+#endif
+
+    return 0;
+}

--- a/thread_support.c
+++ b/thread_support.c
@@ -10,8 +10,12 @@
 */
 
 #include "flint.h"
+#ifdef _OPENMP
+#include <omp.h>
+#endif
 
 FLINT_TLS_PREFIX int _flint_num_threads = 1;
+#pragma omp threadprivate(_flint_num_threads)
 
 int flint_get_num_threads()
 {
@@ -21,5 +25,17 @@ int flint_get_num_threads()
 void flint_set_num_threads(int num_threads)
 {
     _flint_num_threads = num_threads;
+#ifdef _OPENMP
+    omp_set_num_threads(num_threads);
+#endif
 }
 
+void flint_parallel_cleanup()
+{
+    int needs_cleanup = 1;
+#pragma omp master
+    needs_cleanup = 0;
+
+    if (needs_cleanup)
+        flint_cleanup();
+}

--- a/ulong_extras.h
+++ b/ulong_extras.h
@@ -119,6 +119,7 @@ extern const unsigned int flint_primes_small[];
 extern FLINT_TLS_PREFIX ulong * _flint_primes[FLINT_BITS];
 extern FLINT_TLS_PREFIX double * _flint_prime_inverses[FLINT_BITS];
 extern FLINT_TLS_PREFIX int _flint_primes_used;
+#pragma omp threadprivate(_flint_primes, _flint_prime_inverses, _flint_primes_used)
 
 FLINT_DLL void n_compute_primes(ulong num_primes);
 

--- a/ulong_extras/compute_primes.c
+++ b/ulong_extras/compute_primes.c
@@ -48,6 +48,7 @@ const unsigned int flint_primes_small[] =
 FLINT_TLS_PREFIX mp_limb_t * _flint_primes[FLINT_BITS];
 FLINT_TLS_PREFIX double * _flint_prime_inverses[FLINT_BITS];
 FLINT_TLS_PREFIX int _flint_primes_used = 0;
+#pragma omp threadprivate(_flint_primes, _flint_prime_inverses, _flint_primes_used)
 
 #if FLINT_REENTRANT && !HAVE_TLS
 void n_compute_primes_init()


### PR DESCRIPTION
This is my initial stab at OpenMP for FLINT. Here's what I've done specifically:

+ Added configure options to enable/disable openmp support. It's currently disabled by default.
+ Integrate with existing code, mostly adding `#pragma omp threadprivate()` declarations wherever something was declared using TLS.
+ Added a new function `flint_parallel_cleanup()` which calls the cleanup functions to clear caches etc. *unless* you're in the master thread.
+ A new test in `test/t-omp-cleanup.c` checks OpenMP support and that the cleanup function is working as promised.
+ There's a new flag in `flint.h`, `FLINT_PREFER_OMP, which is 1 if OpenMP is enabled, or if pthreads is *disabled*. (The logic being, OpenMP code will still run fine if the pragmas are ignored, but if you don't have pthreads that code will simply not work.)
+ The `fmpz_poly_taylor_shift_multi_mod` function now checks `FLINT_PREFER_OMP` to decide whether to use the pthreads implementation (already in Flint) or the OpenMP version that I made up.

This is all still undocumented, mostly because I wasn't sure where to add things in the documentation! Perhaps there should be a new section in `flint-manual.tex` on multithreading?

As for actually using OpenMP in the Flint library, there are certainly many opportunities! I have a few recommendations for all of us:
+ Separate the parallel construct  `omp parallel` from the work-sharing constructs like `omp for`, `omp sections`, etc. This way, the cleanup can be called once per thread, no matter how the work is split up.
+ Don't just throw omp pragmas on every loop you see. There is a penalty (maybe a few dozen milliseconds or more) to spinning up threads and cleaning them up, so things should only be run in parallel when there is a reasonable expectation that with at least two cores, the execution will actually be faster.
+ Regarding the previous point, I think in many cases it would be advisable to have a separate `_omp` version of a function that is only called when the problem size is large enough, or if the user explicitly wants it.
+ Nesting OpenMP parallel sections within each other, or with pthreads, is not a good idea and we should avoid it. This also means not calling external libraries that might be threaded (such as Atlas BLAS) from within a parallel section of Flint.
+ Stick to the OpenMP 2.0 standard if we can, as this should be most widely supported. Also prefer if at all possible to use the `#pragma omp` syntax rather than the library calls from `omp.h`. This will ensure the code runs correctly even when OpenMP support is not enabled.