### PR TITLE
move _fmpq_vec_init and _fmpq_vec_clear back to fmpq.h for compatibility

### DIFF
--- a/fmpq.h
+++ b/fmpq.h
@@ -339,6 +339,14 @@ FLINT_DLL void _fmpq_harmonic_ui(fmpz_t num, fmpz_t den, ulong n);
 
 FLINT_DLL void fmpq_harmonic_ui(fmpq_t x, ulong n);
 
+FLINT_DLL fmpq * _fmpq_vec_init(slong len);
+
+FMPQ_INLINE
+void _fmpq_vec_clear(fmpq * vec, slong len)
+{
+    _fmpz_vec_clear((fmpz *) vec, 2 * len);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/fmpq_vec.h
+++ b/fmpq_vec.h
@@ -28,13 +28,8 @@
 
 /*  Memory management  *******************************************************/
 
-FLINT_DLL fmpq * _fmpq_vec_init(slong len);
-
-FMPQ_VEC_INLINE
-void _fmpq_vec_clear(fmpq * vec, slong len)
-{
-    _fmpz_vec_clear((fmpz *) vec, 2 * len);
-}
+/* _fmpq_vec_init and _fmpq_vec_clear are declared in fmpq.h for backward
+   compatibility */
 
 /*  Randomisation  ***********************************************************/
 


### PR DESCRIPTION
A recent commit moved _fmpq_vec_init and _fmpq_vec_clear out of fmpq.h into the new fmpq_vec.h. This broke Arb. This commit moves them back for compatibility. We must be more careful to avoid breaking the documented interface.