### PR TITLE
suppress #pragma omp in .h file when compiling without openmp

### DIFF
--- a/ulong_extras.h
+++ b/ulong_extras.h
@@ -119,7 +119,9 @@ extern const unsigned int flint_primes_small[];
 extern FLINT_TLS_PREFIX ulong * _flint_primes[FLINT_BITS];
 extern FLINT_TLS_PREFIX double * _flint_prime_inverses[FLINT_BITS];
 extern FLINT_TLS_PREFIX int _flint_primes_used;
+#if defined(_OPENMP)
 #pragma omp threadprivate(_flint_primes, _flint_prime_inverses, _flint_primes_used)
+#endif
 
 FLINT_DLL void n_compute_primes(ulong num_primes);
 


### PR DESCRIPTION
Fixes issue #285: This prevents a warning from showing up when compiling every single file that includes ulong_extras.h without openmp enabled. You still get warnings in the .c files that use omp pragmas internally, and we should think about some way to suppress those, but this small patch at least makes the build bearable.