### PR TITLE
rename tmp variable that makes g++ -Wshadow complain

### DIFF
--- a/fmpz.h
+++ b/fmpz.h
@@ -416,8 +416,8 @@ fmpz_neg(fmpz_t f1, const fmpz_t f2)
     else                        /* coeff is large */
     {
         /* No need to retain value in promotion, as if aliased, both already large */
-        __mpz_struct *mpz_ptr = _fmpz_promote(f1);
-        mpz_neg(mpz_ptr, COEFF_TO_PTR(*f2));
+        __mpz_struct *mpz_res = _fmpz_promote(f1);
+        mpz_neg(mpz_res, COEFF_TO_PTR(*f2));
     }
 }
 


### PR DESCRIPTION
This fixes this compiler warning:
```
In file included from /home/ralf/sage/local/include/flint/fmpq_poly.h:38:0,
                 from basic.h:41,
                 from pseries.h:26,
                 from useries.h:26,
                 from useries.cpp:26:
/home/ralf/sage/local/include/flint/fmpz.h: In function 'void fmpz_neg(fmpz*, const fmpz*)':
/home/ralf/sage/local/include/flint/fmpz.h:428:23: warning: declaration of 'mpz_ptr' shadows a global declaration [-Wshadow]
         __mpz_struct *mpz_ptr = _fmpz_promote(f1);
                       ^~~~~~~
In file included from /home/ralf/sage/local/include/flint/fmpq_poly.h:37:0,
                 from basic.h:41,
                 from pseries.h:26,
                 from useries.h:26,
                 from useries.cpp:26:
/home/ralf/sage/local/include/gmp.h:306:23: note: shadowed declaration is here
 typedef __mpz_struct *mpz_ptr;
                       ^~~~~~~
```