### PR TITLE
fix -r -pie ld incompatibilities

### DIFF
--- a/Makefile.subdirs
+++ b/Makefile.subdirs
@@ -59,7 +59,7 @@ $(BUILD_DIR)/$(MOD_DIR)_%.o: %.c
 	$(QUIET_CC) $(CC) $(CFLAGS) $(INCS) -c $< -o $@ -MMD -MP -MF "$(BUILD_DIR)/$(MOD_DIR)_$*.d" -MT "$(BUILD_DIR)/$(MOD_DIR)_$*.d" -MT "$@"
 
 $(MOD_LOBJ): $(LOBJS)
-	$(QUIET_CC) $(CC) $(ABI_FLAG) -Wl,-r $^ -o $@ -nostdlib
+	$(QUIET_CC) $(CC) $(ABI_FLAG) -r $^ -o $@ -nostdlib
 
 -include $(LOBJS:.lo=.d)
 

--- a/Makefile.subdirs
+++ b/Makefile.subdirs
@@ -59,7 +59,7 @@ $(BUILD_DIR)/$(MOD_DIR)_%.o: %.c
 	$(QUIET_CC) $(CC) $(CFLAGS) $(INCS) -c $< -o $@ -MMD -MP -MF "$(BUILD_DIR)/$(MOD_DIR)_$*.d" -MT "$(BUILD_DIR)/$(MOD_DIR)_$*.d" -MT "$@"
 
 $(MOD_LOBJ): $(LOBJS)
-	$(QUIET_CC) $(CC) $(ABI_FLAG) -r $^ -o $@ -nostdlib
+	$(QUIET_CC) $(CC) $(ABI_FLAG) -Wl,-r $^ -o $@ -nostdlib -no-pie
 
 -include $(LOBJS:.lo=.d)
 

--- a/fq/Makefile
+++ b/fq/Makefile
@@ -35,7 +35,7 @@ $(BUILD_DIR)/$(MOD_DIR)_%.o: %.c
 	$(CC) $(CFLAGS) -c $(INCS) $< -o $@
 
 $(MOD_LOBJ): $(LOBJS)
-	$(CC) $(ABI_FLAG) -r $^ -o $@ -nostdlib
+	$(CC) $(ABI_FLAG) -Wl,-r $^ -o $@ -nostdlib -no-pie
 
 $(BUILD_DIR)/%.lo: %.c
 	$(CC) $(PICFLAG) $(CFLAGS) $(INCS) -c $< -o $@

--- a/fq/Makefile
+++ b/fq/Makefile
@@ -35,7 +35,7 @@ $(BUILD_DIR)/$(MOD_DIR)_%.o: %.c
 	$(CC) $(CFLAGS) -c $(INCS) $< -o $@
 
 $(MOD_LOBJ): $(LOBJS)
-	$(CC) $(ABI_FLAG) -Wl,-r $^ -o $@ -nostdlib
+	$(CC) $(ABI_FLAG) -r $^ -o $@ -nostdlib
 
 $(BUILD_DIR)/%.lo: %.c
 	$(CC) $(PICFLAG) $(CFLAGS) $(INCS) -c $< -o $@

--- a/fq_poly/Makefile
+++ b/fq_poly/Makefile
@@ -35,7 +35,7 @@ $(BUILD_DIR)/$(MOD_DIR)_%.o: %.c
 	$(CC) $(CFLAGS) -c $(INCS) $< -o $@
 
 $(MOD_LOBJ): $(LOBJS)
-	$(CC) $(ABI_FLAG) -r $^ -o $@ -nostdlib
+	$(CC) $(ABI_FLAG) -Wl,-r $^ -o $@ -nostdlib -no-pie
 
 $(BUILD_DIR)/%.lo: %.c
 	$(CC) $(PICFLAG) $(CFLAGS) $(INCS) -c $< -o $@

--- a/fq_poly/Makefile
+++ b/fq_poly/Makefile
@@ -35,7 +35,7 @@ $(BUILD_DIR)/$(MOD_DIR)_%.o: %.c
 	$(CC) $(CFLAGS) -c $(INCS) $< -o $@
 
 $(MOD_LOBJ): $(LOBJS)
-	$(CC) $(ABI_FLAG) -Wl,-r $^ -o $@ -nostdlib
+	$(CC) $(ABI_FLAG) -r $^ -o $@ -nostdlib
 
 $(BUILD_DIR)/%.lo: %.c
 	$(CC) $(PICFLAG) $(CFLAGS) $(INCS) -c $< -o $@

--- a/padic_mat/Makefile
+++ b/padic_mat/Makefile
@@ -35,7 +35,7 @@ $(BUILD_DIR)/$(MOD_DIR)_%.o: %.c
 	$(CC) $(CFLAGS) -c $(INCS) $< -o $@
 
 $(MOD_LOBJ): $(LOBJS)
-	$(CC) $(ABI_FLAG) -r $^ -o $@ -nostdlib
+	$(CC) $(ABI_FLAG) -fno-pie -Wl,-r $^ -o $@ -nostdlib
 
 $(BUILD_DIR)/%.lo: %.c
 	$(CC) $(PICFLAG) $(CFLAGS) $(INCS) -c $< -o $@

--- a/padic_mat/Makefile
+++ b/padic_mat/Makefile
@@ -35,7 +35,7 @@ $(BUILD_DIR)/$(MOD_DIR)_%.o: %.c
 	$(CC) $(CFLAGS) -c $(INCS) $< -o $@
 
 $(MOD_LOBJ): $(LOBJS)
-	$(CC) $(ABI_FLAG) -Wl,-r $^ -o $@ -nostdlib
+	$(CC) $(ABI_FLAG) -r $^ -o $@ -nostdlib
 
 $(BUILD_DIR)/%.lo: %.c
 	$(CC) $(PICFLAG) $(CFLAGS) $(INCS) -c $< -o $@

--- a/padic_poly/Makefile
+++ b/padic_poly/Makefile
@@ -35,7 +35,7 @@ $(BUILD_DIR)/$(MOD_DIR)_%.o: %.c
 	$(CC) $(CFLAGS) -c $(INCS) $< -o $@
 
 $(MOD_LOBJ): $(LOBJS)
-	$(CC) $(ABI_FLAG) -r $^ -o $@ -nostdlib
+	$(CC) $(ABI_FLAG) -fno-pie -Wl,-r $^ -o $@ -nostdlib
 
 $(BUILD_DIR)/%.lo: %.c
 	$(CC) $(PICFLAG) $(CFLAGS) $(INCS) -c $< -o $@

--- a/padic_poly/Makefile
+++ b/padic_poly/Makefile
@@ -35,7 +35,7 @@ $(BUILD_DIR)/$(MOD_DIR)_%.o: %.c
 	$(CC) $(CFLAGS) -c $(INCS) $< -o $@
 
 $(MOD_LOBJ): $(LOBJS)
-	$(CC) $(ABI_FLAG) -Wl,-r $^ -o $@ -nostdlib
+	$(CC) $(ABI_FLAG) -r $^ -o $@ -nostdlib
 
 $(BUILD_DIR)/%.lo: %.c
 	$(CC) $(PICFLAG) $(CFLAGS) $(INCS) -c $< -o $@

--- a/qadic/Makefile
+++ b/qadic/Makefile
@@ -35,7 +35,7 @@ $(BUILD_DIR)/$(MOD_DIR)_%.o: %.c
 	$(CC) $(CFLAGS) -c $(INCS) $< -o $@
 
 $(MOD_LOBJ): $(LOBJS)
-	$(CC) $(ABI_FLAG) -r $^ -o $@ -nostdlib
+	$(CC) $(ABI_FLAG) -fno-pie -Wl,-r $^ -o $@ -nostdlib
 
 $(BUILD_DIR)/%.lo: %.c
 	$(CC) $(PICFLAG) $(CFLAGS) $(INCS) -c $< -o $@

--- a/qadic/Makefile
+++ b/qadic/Makefile
@@ -35,7 +35,7 @@ $(BUILD_DIR)/$(MOD_DIR)_%.o: %.c
 	$(CC) $(CFLAGS) -c $(INCS) $< -o $@
 
 $(MOD_LOBJ): $(LOBJS)
-	$(CC) $(ABI_FLAG) -Wl,-r $^ -o $@ -nostdlib
+	$(CC) $(ABI_FLAG) -r $^ -o $@ -nostdlib
 
 $(BUILD_DIR)/%.lo: %.c
 	$(CC) $(PICFLAG) $(CFLAGS) $(INCS) -c $< -o $@


### PR DESCRIPTION
May solve the issue #298.

It remove the buiding error

    /usr/bin/ld: -r and -pie may not be used together

It modify every makefile gcc options from:

    -Wl,-r

to:

    -r

So that the options `-r` is not sent to ld anymore but used somewhere else ... I don't know what consume the `-r` option which is still needed.

This PR is just a place to discuss as long noone fully understand the bug. But it worked for me.
