### PR TITLE
Fix factorization over finite fields

### DIFF
--- a/fq_poly_factor_templates/factor.c
+++ b/fq_poly_factor_templates/factor.c
@@ -128,7 +128,9 @@ __TEMPLATE(T, poly_factor_deflation) (TEMPLATE(T, poly_factor_t) result,
     {
         TEMPLATE(T, poly_factor_t) def_res;
         TEMPLATE(T, poly_t) def;
+        TEMPLATE(T, t) lc_dummy;
 
+        TEMPLATE(T, init) (lc_dummy, ctx);
         TEMPLATE(T, poly_init) (def, ctx);
         TEMPLATE(T, poly_deflate) (def, input, deflation, ctx);
         TEMPLATE(T, poly_factor_init) (def_res, ctx);
@@ -145,13 +147,13 @@ __TEMPLATE(T, poly_factor_deflation) (TEMPLATE(T, poly_factor_t) result,
 
             /* Factor inflation */
             if (def_res->exp[i] == 1)
-                __TEMPLATE(T, poly_factor) (result, leading_coeff, pol,
+                __TEMPLATE(T, poly_factor) (result, lc_dummy, pol,
                                             algorithm, ctx);
             else
             {
                 TEMPLATE(T, poly_factor_t) t;
                 TEMPLATE(T, poly_factor_init) (t, ctx);
-                __TEMPLATE(T, poly_factor) (t, leading_coeff, pol, algorithm,
+                __TEMPLATE(T, poly_factor) (t, lc_dummy, pol, algorithm,
                                             ctx);
                 TEMPLATE(T, poly_factor_pow) (t, def_res->exp[i], ctx);
                 TEMPLATE(T, poly_factor_concat) (result, t, ctx);
@@ -160,6 +162,7 @@ __TEMPLATE(T, poly_factor_deflation) (TEMPLATE(T, poly_factor_t) result,
             TEMPLATE(T, poly_clear) (pol, ctx);
         }
 
+        TEMPLATE(T, clear) (lc_dummy, ctx);
         TEMPLATE(T, poly_factor_clear) (def_res, ctx);
     }
 }

--- a/fq_poly_factor_templates/test/t-factor.c
+++ b/fq_poly_factor_templates/test/t-factor.c
@@ -33,11 +33,16 @@ main(void)
         TEMPLATE(T, poly_t) pol1, poly, quot, rem, product;
         TEMPLATE(T, poly_factor_t) res;
         TEMPLATE(T, ctx_t) ctx;
+        TEMPLATE(T, t) randlead;
         TEMPLATE(T, t) lead;
         slong length, num, i, j;
         ulong exp[5], prod1;
 
         TEMPLATE(T, ctx_randtest) (ctx, state);
+
+        TEMPLATE(T, init) (randlead, ctx);
+
+        TEMPLATE(T, randtest_not_zero) (randlead, state, ctx);
 
         TEMPLATE(T, poly_init) (pol1, ctx);
         TEMPLATE(T, poly_init) (poly, ctx);
@@ -45,7 +50,7 @@ main(void)
         TEMPLATE(T, poly_init) (rem, ctx);
 
         TEMPLATE(T, poly_zero) (pol1, ctx);
-        TEMPLATE(T, poly_one) (pol1, ctx);
+        TEMPLATE3(T, poly_set, T) (pol1, randlead, ctx);
 
         length = n_randint(state, 4) + 2;
         TEMPLATE(T, poly_randtest_irreducible) (poly, state, length, ctx);
@@ -136,6 +141,7 @@ main(void)
         TEMPLATE(T, poly_clear) (poly, ctx);
         TEMPLATE(T, poly_factor_clear) (res, ctx);
         TEMPLATE(T, clear) (lead, ctx);
+        TEMPLATE(T, clear) (randlead, ctx);
         TEMPLATE(T, ctx_clear) (ctx);
     }
 


### PR DESCRIPTION
Sometimes the factorization of `fq_poly` and `fq_nmod_poly` returns
the wrong leading coefficient.

```julia
function __factor(x::fq_poly)
   R = parent(x)
   F = base_ring(R)
   a = F()
   fac = Nemo.fq_poly_factor(F)
   ccall((:fq_poly_factor, :libflint), Void, (Ptr{Nemo.fq_poly_factor},
         Ptr{fq}, Ptr{fq_poly}, Ptr{FqFiniteField}),
         &fac, &a, &x, &F)
   res = Dict{fq_poly,Int}()
   for i in 1:fac.num
      f = R()
      ccall((:fq_poly_factor_get_poly, :libflint), Void,
            (Ptr{fq_poly}, Ptr{Nemo.fq_poly_factor}, Int,
            Ptr{FqFiniteField}), &f, &fac, i-1, &F)
      e = unsafe_load(fac.exp,i)
      res[f] = e
   end
   return res, a
end
```
Then
```julia
julia> using Nemo; F, a = FiniteField(fmpz(2), 3, "a");  Fx, x = PolynomialRing(F,"x");
julia> __factor(a*x^2)
(Dict(x=>2),1)
```

See also the corresponding lines in https://github.com/wbhart/flint2/blob/trunk/nmod_poly_factor/factor.c#L118-L138.

I have also changed the test to use non-monic polynomials.