### PR TITLE
Undefine count_leading_zeros and count_trailing_zeros in longlong.h

### DIFF
--- a/longlong.h
+++ b/longlong.h
@@ -32,6 +32,11 @@
  extern "C" {
 #endif
 
+/* Undefine to make the ifndef logic below for the fallback 
+   work even if the symbols are already defined (e.g. by givaro).  */
+#undef count_leading_zeros
+#undef count_trailing_zeros
+
 /* x86 : 64 bit */
 #if (GMP_LIMB_BITS == 64 && defined (__amd64__)) 
 


### PR DESCRIPTION
fixes #306

The fallbacks at the end of the file are only defined when there is no
definition yet. When building SageMath it can happen that the symbols
are already defined in a givaro header. That lead to build failures on
architectures that are supposed to use the fallback here, like arm64
and ppc64el.