### PR TITLE
Optimize heap for multiplication

### DIFF
--- a/fmpz_mpoly/mul_heap_threaded.c
+++ b/fmpz_mpoly/mul_heap_threaded.c
@@ -152,12 +152,14 @@ slong _fmpz_mpoly_mul_heap_part1(fmpz ** poly1, ulong ** exp1, slong * alloc,
                
                     e1[k] = exp;
                     first = 0; 
-                } else /* addmul product of input poly coeffs */
+                } else
+                {   /* addmul product of input poly coeffs */
                     fmpz_addmul(p1 + k, poly2 + x->i, poly3 + x->j);
+                }
 
-               /* for each node in this chain */
-               while ((x = x->next) != NULL)
-               {
+                /* for each node in this chain */
+                while ((x = x->next) != NULL)
+                {
                     /* addmul product of input poly coeffs */
                     fmpz_addmul(p1 + k, poly2 + x->i, poly3 + x->j);
 
@@ -301,7 +303,7 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
     {
         if (  (start[i] < end[i])
            && (  (i == 0)
-              || (start[i] < start[i-1])
+              || (start[i] < start[i - 1])
               )
            )
         {
@@ -309,7 +311,7 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
             x->i = i;
             x->j = start[i];
             x->next = NULL;
-            hind[x->i] = 2*(x->j+1) + 0;
+            hind[x->i] = 2*(x->j + 1) + 0;
             mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N,
                                                              exp3 + x->j*N, N);
             if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x, &heap_len,
@@ -430,9 +432,11 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
                 x->j = j;
                 x->next = NULL;
 
-                hind[x->i] = 2*(x->j+1) + 0;
-                mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
-                if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x, &heap_len, N, maskhi, masklo))
+                hind[x->i] = 2*(x->j + 1) + 0;
+                mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N,
+                                                       exp3 + x->j*N, N);
+                if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
+                                                 &heap_len, N, maskhi, masklo))
                     exp_next--;
             }
 
@@ -450,9 +454,11 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
                 x->j = j + 1;
                 x->next = NULL;
 
-                hind[x->i] = 2*(x->j+1) + 0;
-                mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
-                if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x, &heap_len, N, maskhi, masklo))
+                hind[x->i] = 2*(x->j + 1) + 0;
+                mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N,
+                                                       exp3 + x->j*N, N);
+                if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
+                                                 &heap_len, N, maskhi, masklo))
                     exp_next--;
             }
         }     

--- a/fmpz_mpoly/mul_heap_threaded.c
+++ b/fmpz_mpoly/mul_heap_threaded.c
@@ -32,14 +32,15 @@ slong _fmpz_mpoly_mul_heap_part1(fmpz ** poly1, ulong ** exp1, slong * alloc,
               const fmpz * poly3, const ulong * exp3, slong len3,
                                       slong * start, slong * end, ulong maskhi)
 {
-    slong i, k;
-    slong next_free, Q_len = 0, heap_len = 1; /* heap zero index unused */
+    slong i, j, k;
+    slong Q_len = 0, heap_len = 1; /* heap zero index unused */
     mpoly_heap1_s * heap;
     mpoly_heap_t * chain;
-    mpoly_heap_t ** Q;
+    slong * Q;
     mpoly_heap_t * x;
     fmpz * p1 = *poly1;
     ulong * e1 = *exp1;
+    slong * hind;
     ulong exp, cy;
     ulong c[3], p[2]; /* for accumulating coefficients */
     int first, small;
@@ -55,22 +56,31 @@ slong _fmpz_mpoly_mul_heap_part1(fmpz ** poly1, ulong ** exp1, slong * alloc,
     /* alloc array of heap nodes which can be chained together */
     chain = (mpoly_heap_t *) TMP_ALLOC(len2*sizeof(mpoly_heap_t));
     /* space for temporary storage of pointers to heap nodes */
-    Q = (mpoly_heap_t **) TMP_ALLOC(len2*sizeof(mpoly_heap_t *));
+    Q = (slong *) TMP_ALLOC(2*len2*sizeof(slong));
    
-    /* start with no heap nodes in use */
-    next_free = 0;
+    /* space for heap indices */
+    hind = (slong *) TMP_ALLOC(len2*sizeof(slong));
+    for (i = 0; i < len2; i++)
+        hind[i] = 2*start[i] + 0;
 
     /* put all the starting nodes on the heap */
     for (i = 0; i < len2; i++)
-        if (start[i] < end[i])
+    {
+        if (  (start[i] < end[i])
+           && (  (i == 0)
+              || (start[i] < start[i-1])
+              )
+           )
         {
-            x = chain + next_free++;
+            x = chain + i;
             x->i = i;
             x->j = start[i];
             x->next = NULL;
+            hind[x->i] = 2*(x->j+1) + 1;
             _mpoly_heap_insert1(heap, exp2[x->i] + exp3[x->j], x, &heap_len,
                                                                        maskhi);
         }
+    }
 
     /* output poly index starts at -1, will be immediately updated to 0 */
     k = -WORD(1);
@@ -97,6 +107,11 @@ slong _fmpz_mpoly_mul_heap_part1(fmpz ** poly1, ulong ** exp1, slong * alloc,
             /* pop chain from heap */
             x = _mpoly_heap_pop1(heap, &heap_len, maskhi);
 
+            /* temporarily store indicies of this node */
+            hind[x->i] &= -WORD(2);
+            Q[Q_len++] = x->i;
+            Q[Q_len++] = x->j;
+
             /* if output coeffs will fit in three words */
             if (small)
             {
@@ -115,10 +130,6 @@ slong _fmpz_mpoly_mul_heap_part1(fmpz ** poly1, ulong ** exp1, slong * alloc,
                     add_sssaaaaaa(cy, c[1], c[0], 0, c[1], c[0], 0, p[1], p[0]);
                     c[2] += (0 <= (slong) p[1]) ? cy : cy - 1;
                 }
-      
-                /* temporarily store pointer to this node */
-                if (x->j < len3 - 1)
-                    Q[Q_len++] = x;
 
                 /* for every node in this chain */
                 while ((x = x->next) != NULL)
@@ -128,9 +139,10 @@ slong _fmpz_mpoly_mul_heap_part1(fmpz ** poly1, ulong ** exp1, slong * alloc,
                     add_sssaaaaaa(cy, c[1], c[0], 0, c[1], c[0], 0, p[1], p[0]);
                     c[2] += (0 <= (slong) p[1]) ? cy : cy - 1;
 
-                    /* temporarily store pointer to this node */
-                    if (x->j < len3 - 1)
-                        Q[Q_len++] = x;
+                    /* take node out of heap and put into store */
+                    hind[x->i] &= -WORD(2);
+                    Q[Q_len++] = x->i;
+                    Q[Q_len++] = x->j;
                 }
            } else /* output coeffs require multiprecision */
            {
@@ -143,19 +155,16 @@ slong _fmpz_mpoly_mul_heap_part1(fmpz ** poly1, ulong ** exp1, slong * alloc,
                 } else /* addmul product of input poly coeffs */
                     fmpz_addmul(p1 + k, poly2 + x->i, poly3 + x->j);
 
-                /* temporarily store pointer to this node */
-                if (x->j < len3 - 1 || x->j == 0)
-                    Q[Q_len++] = x;
-
                /* for each node in this chain */
                while ((x = x->next) != NULL)
                {
                     /* addmul product of input poly coeffs */
                     fmpz_addmul(p1 + k, poly2 + x->i, poly3 + x->j);
 
-                    /* temporarily store pointer to this node */
-                    if (x->j < len3 - 1 || x->j == 0)
-                        Q[Q_len++] = x;
+                    /* take node out of heap and put into store */
+                    hind[x->i] &= -WORD(2);
+                    Q[Q_len++] = x->i;
+                    Q[Q_len++] = x->j;
                 }
             }
         }
@@ -164,14 +173,42 @@ slong _fmpz_mpoly_mul_heap_part1(fmpz ** poly1, ulong ** exp1, slong * alloc,
         while (Q_len > 0)
         {
             /* take node from store */
-            x = Q[--Q_len];
+            j = Q[--Q_len];
+            i = Q[--Q_len];
 
-            if (x->j + 1 < end[x->i])
+            /* should we go right? */
+            if (  (i + 1 < len2)
+               && (j + 0 < end[i + 1])
+               && (hind[i + 1] == 2*j + 0)
+               )
             {
-                x->j++;
+                x = chain + i + 1;
+                x->i = i + 1;
+                x->j = j;
                 x->next = NULL;
-                _mpoly_heap_insert1(heap, exp2[x->i] + exp3[x->j], x, &heap_len,
-                                                                       maskhi);
+
+                hind[x->i] = 2*(x->j+1) + 1;
+                _mpoly_heap_insert1(heap, exp2[x->i] + exp3[x->j], x,
+                                                            &heap_len, maskhi);
+            }
+
+            /* should we go up? */
+            if (  (j + 1 < end[i + 0])
+               && ((hind[i]&WORD(1)) == 0)
+               && (  (i == 0)
+                  || (hind[i - 1] >  2*(j + 2) + 1)
+                  || (hind[i - 1] == 2*(j + 2) + 0)
+                  )
+               )
+            {
+                x = chain + i;
+                x->i = i;
+                x->j = j + 1;
+                x->next = NULL;
+
+                hind[x->i] = 2*(x->j+1) + 1;
+                _mpoly_heap_insert1(heap, exp2[x->i] + exp3[x->j], x,
+                                                            &heap_len, maskhi);
             }
         }
 
@@ -206,11 +243,11 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
                  const fmpz * poly3, const ulong * exp3, slong len3,
             slong * start, slong * end, slong N, ulong maskhi, ulong masklo)
 {
-    slong i, k;
-    slong next_free, Q_len = 0, heap_len = 1; /* heap zero index unused */
+    slong i, j, k;
+    slong Q_len = 0, heap_len = 1; /* heap zero index unused */
     mpoly_heap_s * heap;
     mpoly_heap_t * chain;
-    mpoly_heap_t ** Q;
+    slong * Q;
     mpoly_heap_t * x;
     fmpz * p1 = *poly1;
     ulong * e1 = *exp1;
@@ -219,8 +256,8 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
     ulong * exp, * exps;
     ulong ** exp_list;
     slong exp_next;
+    slong * hind;
     int first, small;
-
     TMP_INIT;
 
     /* if exponent vectors fit in single word, call special version */
@@ -241,36 +278,45 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
     /* alloc array of heap nodes which can be chained together */
     chain = (mpoly_heap_t *) TMP_ALLOC(len2*sizeof(mpoly_heap_t));
     /* space for temporary storage of pointers to heap nodes */
-    Q = (mpoly_heap_t **) TMP_ALLOC(len2*sizeof(mpoly_heap_t *));
+    Q = (slong *) TMP_ALLOC(2*len2*sizeof(slong));
     /* allocate space for exponent vectors of N words */
     exps = (ulong *) TMP_ALLOC(len2*N*sizeof(ulong));
     /* list of pointers to allocated exponent vectors */
     exp_list = (ulong **) TMP_ALLOC(len2*sizeof(ulong *));
-
     for (i = 0; i < len2; i++)
-    {
-      exp_list[i] = exps + i*N;
-    }
+        exp_list[i] = exps + i*N;
+
+    /* space for heap indices */
+    hind = (slong *) TMP_ALLOC(len2*sizeof(slong));
+    for (i = 0; i < len2; i++)
+        hind[i] = 2*start[i] + 0;
+
 
     /* start with no heap nodes and no exponent vectors in use */
-    next_free = 0;
     exp_next = 0;
 
 
     /* put all the starting nodes on the heap */
     for (i = 0; i < len2; i++)
-        if (start[i] < end[i])
+    {
+        if (  (start[i] < end[i])
+           && (  (i == 0)
+              || (start[i] < start[i-1])
+              )
+           )
         {
-            x = chain + next_free++;
+            x = chain + i;
             x->i = i;
             x->j = start[i];
             x->next = NULL;
+            hind[x->i] = 2*(x->j+1) + 1;
             mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N,
                                                              exp3 + x->j*N, N);
             if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x, &heap_len,
                                                             N, maskhi, masklo))
                exp_next--;
         }
+    }
 
     /* output poly index starts at -1, will be immediately updated to 0 */
     k = -WORD(1);
@@ -299,6 +345,11 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
 
             x = _mpoly_heap_pop(heap, &heap_len, N, maskhi, masklo);
 
+            /* take node out of heap and put into store */
+            hind[x->i] &= -WORD(2);
+            Q[Q_len++] = x->i;
+            Q[Q_len++] = x->j;
+
             /* if output coeffs will fit in three words */
             if (small)
             {
@@ -319,10 +370,6 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
                     c[2] += (0 <= (slong) p[1]) ? cy : cy - 1;
                 }
 
-                /* temporarily store pointer to this node */
-                if (x->j < len3 - 1 || x->j == 0)
-                    Q[Q_len++] = x;
-
                 /* for every node in this chain */
                 while ((x = x->next) != NULL)
                 {
@@ -331,9 +378,10 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
                     add_sssaaaaaa(cy, c[1], c[0], 0, c[1], c[0], 0, p[1], p[0]);
                     c[2] += (0 <= (slong) p[1]) ? cy : cy - 1;
 
-                    /* temporarily store pointer to this node */
-                    if (x->j < len3 - 1 || x->j == 0)
-                        Q[Q_len++] = x;
+                    /* take node out of heap and put into store */
+                    hind[x->i] &= -WORD(2);
+                    Q[Q_len++] = x->i;
+                    Q[Q_len++] = x->j;
                 }
             } else /* output coeffs require multiprecision */
             {
@@ -345,12 +393,10 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
                     mpoly_monomial_set(e1 + k*N, exp, N);
 
                     first = 0; 
-                } else /* addmul product of input poly coeffs */
+                } else
+                {   /* addmul product of input poly coeffs */
                     fmpz_addmul(p1 + k, poly2 + x->i, poly3 + x->j);
-
-                /* temporarily store pointer to this node */
-                if (x->j < len3 - 1 || x->j == 0)
-                    Q[Q_len++] = x;
+                }
 
                 /* for each node in this chain */
                 while ((x = x->next) != NULL)
@@ -358,9 +404,10 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
                     /* addmul product of input poly coeffs */
                     fmpz_addmul(p1 + k, poly2 + x->i, poly3 + x->j);
 
-                    /* temporarily store pointer to this node */
-                    if (x->j < len3 - 1 || x->j == 0)
-                        Q[Q_len++] = x;
+                    /* take node out of heap and put into store */
+                    hind[x->i] &= -WORD(2);
+                    Q[Q_len++] = x->i;
+                    Q[Q_len++] = x->j;
                 }
             }
         }
@@ -369,22 +416,47 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
         while (Q_len > 0)
         {
             /* take node from store */
-            x = Q[--Q_len];
+            j = Q[--Q_len];
+            i = Q[--Q_len];
 
-            /* do not put next on heap if it is past the end */
-            if (x->j + 1 < end[x->i])
+            /* should we go right? */
+            if (  (i + 1 < len2)
+               && (j + 0 < end[i + 1])
+               && (hind[i + 1] == 2*j + 0)
+               )
             {
-                x->j++;
+                x = chain + i + 1;
+                x->i = i + 1;
+                x->j = j;
                 x->next = NULL;
 
-                mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N,
-                                                       exp3 + x->j*N, N);
-                if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
-                                                 &heap_len, N, maskhi, masklo))
-                   exp_next--;
+                hind[x->i] = 2*(x->j+1) + 1;
+                mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
+                if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x, &heap_len, N, maskhi, masklo))
+                    exp_next--;
+            }
+
+            /* should we go up? */
+            if (  (j + 1 < end[i + 0])
+               && ((hind[i]&WORD(1)) == 0)
+               && (  (i == 0)
+                  || (hind[i - 1] >  2*(j + 2) + 1)
+                  || (hind[i - 1] == 2*(j + 2) + 0)
+                  )
+               )
+            {
+                x = chain + i;
+                x->i = i;
+                x->j = j + 1;
+                x->next = NULL;
+
+                hind[x->i] = 2*(x->j+1) + 1;
+                mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
+                if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x, &heap_len, N, maskhi, masklo))
+                    exp_next--;
             }
         }     
-   
+
         /* set output poly coeff from temporary accumulation, if not multiprec */
         if (small)
             fmpz_set_signed_uiuiui(p1 + k, c[2], c[1], c[0]);

--- a/fmpz_mpoly/mul_heap_threaded.c
+++ b/fmpz_mpoly/mul_heap_threaded.c
@@ -779,7 +779,6 @@ void fmpz_mpoly_mul_heap_threaded(fmpz_mpoly_t poly1, const fmpz_mpoly_t poly2,
     exp_bits = mpoly_optimize_bits(exp_bits, ctx->n);
 
     masks_from_bits_ord(maskhi, masklo, exp_bits, ctx->ord);
-    /* number of words exponent vectors packed into */
     N = words_per_exp(ctx->n, exp_bits);
 
     /* ensure input exponents are packed into same sized fields as output */

--- a/fmpz_mpoly/mul_heap_threaded.c
+++ b/fmpz_mpoly/mul_heap_threaded.c
@@ -61,7 +61,7 @@ slong _fmpz_mpoly_mul_heap_part1(fmpz ** poly1, ulong ** exp1, slong * alloc,
     /* space for heap indices */
     hind = (slong *) TMP_ALLOC(len2*sizeof(slong));
     for (i = 0; i < len2; i++)
-        hind[i] = 2*start[i] + 0;
+        hind[i] = 2*start[i] + 1;
 
     /* put all the starting nodes on the heap */
     for (i = 0; i < len2; i++)
@@ -76,7 +76,7 @@ slong _fmpz_mpoly_mul_heap_part1(fmpz ** poly1, ulong ** exp1, slong * alloc,
             x->i = i;
             x->j = start[i];
             x->next = NULL;
-            hind[x->i] = 2*(x->j+1) + 1;
+            hind[x->i] = 2*(x->j+1) + 0;
             _mpoly_heap_insert1(heap, exp2[x->i] + exp3[x->j], x, &heap_len,
                                                                        maskhi);
         }
@@ -108,7 +108,7 @@ slong _fmpz_mpoly_mul_heap_part1(fmpz ** poly1, ulong ** exp1, slong * alloc,
             x = _mpoly_heap_pop1(heap, &heap_len, maskhi);
 
             /* temporarily store indicies of this node */
-            hind[x->i] &= -WORD(2);
+            hind[x->i] |= WORD(1);
             Q[Q_len++] = x->i;
             Q[Q_len++] = x->j;
 
@@ -140,7 +140,7 @@ slong _fmpz_mpoly_mul_heap_part1(fmpz ** poly1, ulong ** exp1, slong * alloc,
                     c[2] += (0 <= (slong) p[1]) ? cy : cy - 1;
 
                     /* take node out of heap and put into store */
-                    hind[x->i] &= -WORD(2);
+                    hind[x->i] |= WORD(1);
                     Q[Q_len++] = x->i;
                     Q[Q_len++] = x->j;
                 }
@@ -162,7 +162,7 @@ slong _fmpz_mpoly_mul_heap_part1(fmpz ** poly1, ulong ** exp1, slong * alloc,
                     fmpz_addmul(p1 + k, poly2 + x->i, poly3 + x->j);
 
                     /* take node out of heap and put into store */
-                    hind[x->i] &= -WORD(2);
+                    hind[x->i] |= WORD(1);
                     Q[Q_len++] = x->i;
                     Q[Q_len++] = x->j;
                 }
@@ -179,7 +179,7 @@ slong _fmpz_mpoly_mul_heap_part1(fmpz ** poly1, ulong ** exp1, slong * alloc,
             /* should we go right? */
             if (  (i + 1 < len2)
                && (j + 0 < end[i + 1])
-               && (hind[i + 1] == 2*j + 0)
+               && (hind[i + 1] == 2*j + 1)
                )
             {
                 x = chain + i + 1;
@@ -187,17 +187,17 @@ slong _fmpz_mpoly_mul_heap_part1(fmpz ** poly1, ulong ** exp1, slong * alloc,
                 x->j = j;
                 x->next = NULL;
 
-                hind[x->i] = 2*(x->j+1) + 1;
+                hind[x->i] = 2*(x->j+1) + 0;
                 _mpoly_heap_insert1(heap, exp2[x->i] + exp3[x->j], x,
                                                             &heap_len, maskhi);
             }
 
             /* should we go up? */
             if (  (j + 1 < end[i + 0])
-               && ((hind[i]&WORD(1)) == 0)
+               && ((hind[i] & 1) == 1)
                && (  (i == 0)
                   || (hind[i - 1] >  2*(j + 2) + 1)
-                  || (hind[i - 1] == 2*(j + 2) + 0)
+                  || (hind[i - 1] == 2*(j + 2) + 1) /* gcc should fuse */
                   )
                )
             {
@@ -206,7 +206,7 @@ slong _fmpz_mpoly_mul_heap_part1(fmpz ** poly1, ulong ** exp1, slong * alloc,
                 x->j = j + 1;
                 x->next = NULL;
 
-                hind[x->i] = 2*(x->j+1) + 1;
+                hind[x->i] = 2*(x->j+1) + 0;
                 _mpoly_heap_insert1(heap, exp2[x->i] + exp3[x->j], x,
                                                             &heap_len, maskhi);
             }
@@ -289,7 +289,7 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
     /* space for heap indices */
     hind = (slong *) TMP_ALLOC(len2*sizeof(slong));
     for (i = 0; i < len2; i++)
-        hind[i] = 2*start[i] + 0;
+        hind[i] = 2*start[i] + 1;
 
 
     /* start with no heap nodes and no exponent vectors in use */
@@ -309,7 +309,7 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
             x->i = i;
             x->j = start[i];
             x->next = NULL;
-            hind[x->i] = 2*(x->j+1) + 1;
+            hind[x->i] = 2*(x->j+1) + 0;
             mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N,
                                                              exp3 + x->j*N, N);
             if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x, &heap_len,
@@ -346,7 +346,7 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
             x = _mpoly_heap_pop(heap, &heap_len, N, maskhi, masklo);
 
             /* take node out of heap and put into store */
-            hind[x->i] &= -WORD(2);
+            hind[x->i] |= WORD(1);
             Q[Q_len++] = x->i;
             Q[Q_len++] = x->j;
 
@@ -379,7 +379,7 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
                     c[2] += (0 <= (slong) p[1]) ? cy : cy - 1;
 
                     /* take node out of heap and put into store */
-                    hind[x->i] &= -WORD(2);
+                    hind[x->i] |= WORD(1);
                     Q[Q_len++] = x->i;
                     Q[Q_len++] = x->j;
                 }
@@ -405,7 +405,7 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
                     fmpz_addmul(p1 + k, poly2 + x->i, poly3 + x->j);
 
                     /* take node out of heap and put into store */
-                    hind[x->i] &= -WORD(2);
+                    hind[x->i] |= WORD(1);
                     Q[Q_len++] = x->i;
                     Q[Q_len++] = x->j;
                 }
@@ -422,7 +422,7 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
             /* should we go right? */
             if (  (i + 1 < len2)
                && (j + 0 < end[i + 1])
-               && (hind[i + 1] == 2*j + 0)
+               && (hind[i + 1] == 2*j + 1)
                )
             {
                 x = chain + i + 1;
@@ -430,7 +430,7 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
                 x->j = j;
                 x->next = NULL;
 
-                hind[x->i] = 2*(x->j+1) + 1;
+                hind[x->i] = 2*(x->j+1) + 0;
                 mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
                 if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x, &heap_len, N, maskhi, masklo))
                     exp_next--;
@@ -438,10 +438,10 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
 
             /* should we go up? */
             if (  (j + 1 < end[i + 0])
-               && ((hind[i]&WORD(1)) == 0)
+               && ((hind[i] & 1) == 1)
                && (  (i == 0)
                   || (hind[i - 1] >  2*(j + 2) + 1)
-                  || (hind[i - 1] == 2*(j + 2) + 0)
+                  || (hind[i - 1] == 2*(j + 2) + 1) /* gcc should fuse */
                   )
                )
             {
@@ -450,7 +450,7 @@ slong _fmpz_mpoly_mul_heap_part(fmpz ** poly1, ulong ** exp1, slong * alloc,
                 x->j = j + 1;
                 x->next = NULL;
 
-                hind[x->i] = 2*(x->j+1) + 1;
+                hind[x->i] = 2*(x->j+1) + 0;
                 mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
                 if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x, &heap_len, N, maskhi, masklo))
                     exp_next--;

--- a/fmpz_mpoly/mul_johnson.c
+++ b/fmpz_mpoly/mul_johnson.c
@@ -54,7 +54,7 @@ slong _fmpz_mpoly_mul_johnson1(fmpz ** poly1, ulong ** exp1, slong * alloc,
     /* space for heap indices */
     hind = (slong *) TMP_ALLOC(len2*sizeof(slong));
     for (i = 0; i < len2; i++)
-    hind[i] = 0;
+        hind[i] = 1;
 
    
    /* put (0, 0, exp2[0] + exp3[0]) on heap */
@@ -64,7 +64,7 @@ slong _fmpz_mpoly_mul_johnson1(fmpz ** poly1, ulong ** exp1, slong * alloc,
    x->next = NULL;
 
    HEAP_ASSIGN(heap[1], exp2[0] + exp3[0], x);
-   hind[0] = 2*1 + 1;
+   hind[0] = 2*1 + 0;
 
    /* output poly index starts at -1, will be immediately updated to 0 */
    k = -WORD(1);
@@ -92,7 +92,7 @@ slong _fmpz_mpoly_mul_johnson1(fmpz ** poly1, ulong ** exp1, slong * alloc,
          x = _mpoly_heap_pop1(heap, &heap_len, maskhi);
          
          /* take node out of heap and put into store */
-         hind[x->i] &= -WORD(2);
+         hind[x->i] |= WORD(1);
          Q[Q_len++] = x->i;
          Q[Q_len++] = x->j;
 
@@ -124,7 +124,7 @@ slong _fmpz_mpoly_mul_johnson1(fmpz ** poly1, ulong ** exp1, slong * alloc,
                c[2] += (0 <= (slong) p[1]) ? cy : cy - 1;
 
                /* take node out of heap and put into store */
-               hind[x->i] &= -WORD(2);
+               hind[x->i] |= WORD(1);
                Q[Q_len++] = x->i;
                Q[Q_len++] = x->j;
             }
@@ -146,7 +146,7 @@ slong _fmpz_mpoly_mul_johnson1(fmpz ** poly1, ulong ** exp1, slong * alloc,
                fmpz_addmul(p1 + k, poly2 + x->i, poly3 + x->j);
 
                /* take node out of heap and put into store */
-               hind[x->i] &= -WORD(2);
+               hind[x->i] |= WORD(1);
                Q[Q_len++] = x->i;
                Q[Q_len++] = x->j;
             }
@@ -162,7 +162,7 @@ slong _fmpz_mpoly_mul_johnson1(fmpz ** poly1, ulong ** exp1, slong * alloc,
 
          /* should we go right? */
          if (  (i + 1 < len2)
-            && (hind[i + 1] == 2*j + 0)
+            && (hind[i + 1] == 2*j + 1)
             )
          {
             x = chain + i + 1;
@@ -170,17 +170,17 @@ slong _fmpz_mpoly_mul_johnson1(fmpz ** poly1, ulong ** exp1, slong * alloc,
             x->j = j;
             x->next = NULL;
 
-            hind[x->i] = 2*(x->j+1) + 1;
+            hind[x->i] = 2*(x->j+1) + 0;
             _mpoly_heap_insert1(heap, exp2[x->i] + exp3[x->j], x, &heap_len,
                                                                        maskhi);
          }
 
          /* should we go up? */
          if (  (j + 1 < len3)
-            && ((hind[i]&WORD(1)) == 0)
+            && ((hind[i] & 1) == 1)
             && (  (i == 0)
                || (hind[i - 1] >  2*(j + 2) + 1)
-               || (hind[i - 1] == 2*(j + 2) + 0)
+               || (hind[i - 1] == 2*(j + 2) + 1) /* gcc should fuse */
                )
             )
          {
@@ -189,7 +189,7 @@ slong _fmpz_mpoly_mul_johnson1(fmpz ** poly1, ulong ** exp1, slong * alloc,
             x->j = j + 1;
             x->next = NULL;
 
-            hind[x->i] = 2*(x->j+1) + 1;
+            hind[x->i] = 2*(x->j+1) + 0;
             _mpoly_heap_insert1(heap, exp2[x->i] + exp3[x->j], x, &heap_len,
                                                                        maskhi);
          }
@@ -266,7 +266,7 @@ slong _fmpz_mpoly_mul_johnson(fmpz ** poly1, ulong ** exp1, slong * alloc,
    /* space for heap indices */
    hind = (slong *) TMP_ALLOC(len2*sizeof(slong));
    for (i = 0; i < len2; i++)
-   hind[i] = 0;
+       hind[i] = 1;
 
    /* start with no heap nodes and no exponent vectors in use */
    exp_next = 0;
@@ -282,7 +282,7 @@ slong _fmpz_mpoly_mul_johnson(fmpz ** poly1, ulong ** exp1, slong * alloc,
 
    mpoly_monomial_add(heap[1].exp, exp2, exp3, N);
 
-    hind[0] = 2*1 + 1;
+    hind[0] = 2*1 + 0;
 
    /* output poly index starts at -1, will be immediately updated to 0 */
    k = -WORD(1);
@@ -312,7 +312,7 @@ slong _fmpz_mpoly_mul_johnson(fmpz ** poly1, ulong ** exp1, slong * alloc,
          x = _mpoly_heap_pop(heap, &heap_len, N, maskhi, masklo);
 
          /* take node out of heap and put into store */
-         hind[x->i] &= -WORD(2);
+         hind[x->i] |= WORD(1);
          Q[Q_len++] = x->i;
          Q[Q_len++] = x->j;
 
@@ -345,7 +345,7 @@ slong _fmpz_mpoly_mul_johnson(fmpz ** poly1, ulong ** exp1, slong * alloc,
                c[2] += (0 <= (slong) p[1]) ? cy : cy - 1;
 
                /* take node out of heap and put into store */
-               hind[x->i] &= -WORD(2);
+               hind[x->i] |= WORD(1);
                Q[Q_len++] = x->i;
                Q[Q_len++] = x->j;
             }
@@ -371,7 +371,7 @@ slong _fmpz_mpoly_mul_johnson(fmpz ** poly1, ulong ** exp1, slong * alloc,
                fmpz_addmul(p1 + k, poly2 + x->i, poly3 + x->j);
 
                /* take node out of heap and put into store */
-               hind[x->i] &= -WORD(2);
+               hind[x->i] |= WORD(1);
                Q[Q_len++] = x->i;
                Q[Q_len++] = x->j;
             }
@@ -387,7 +387,7 @@ slong _fmpz_mpoly_mul_johnson(fmpz ** poly1, ulong ** exp1, slong * alloc,
 
          /* should we go right? */
          if (  (i + 1 < len2)
-            && (hind[i + 1] == 2*j + 0)
+            && (hind[i + 1] == 2*j + 1)
             )
          {
             x = chain + i + 1;
@@ -395,7 +395,7 @@ slong _fmpz_mpoly_mul_johnson(fmpz ** poly1, ulong ** exp1, slong * alloc,
             x->j = j;
             x->next = NULL;
 
-            hind[x->i] = 2*(x->j+1) + 1;
+            hind[x->i] = 2*(x->j+1) + 0;
             mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
             if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x, &heap_len, N, maskhi, masklo))
                exp_next--;
@@ -403,10 +403,10 @@ slong _fmpz_mpoly_mul_johnson(fmpz ** poly1, ulong ** exp1, slong * alloc,
 
          /* should we go up? */
          if (  (j + 1 < len3)
-            && ((hind[i]&WORD(1)) == 0)
+            && ((hind[i] & 1) == 1)
             && (  (i == 0)
                || (hind[i - 1] >  2*(j + 2) + 1)
-               || (hind[i - 1] == 2*(j + 2) + 0)
+               || (hind[i - 1] == 2*(j + 2) + 1) /* gcc should fuse */
                )
             )
          {
@@ -415,7 +415,7 @@ slong _fmpz_mpoly_mul_johnson(fmpz ** poly1, ulong ** exp1, slong * alloc,
             x->j = j + 1;
             x->next = NULL;
 
-            hind[x->i] = 2*(x->j+1) + 1;
+            hind[x->i] = 2*(x->j+1) + 0;
             mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
             if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x, &heap_len, N, maskhi, masklo))
                exp_next--;

--- a/fmpz_mpoly/mul_johnson.c
+++ b/fmpz_mpoly/mul_johnson.c
@@ -56,7 +56,6 @@ slong _fmpz_mpoly_mul_johnson1(fmpz ** poly1, ulong ** exp1, slong * alloc,
     for (i = 0; i < len2; i++)
         hind[i] = 1;
 
-   
    /* put (0, 0, exp2[0] + exp3[0]) on heap */
    x = chain + 0;
    x->i = 0;
@@ -136,8 +135,10 @@ slong _fmpz_mpoly_mul_johnson1(fmpz ** poly1, ulong ** exp1, slong * alloc,
                
                e1[k] = exp;
                first = 0; 
-            } else /* addmul product of input poly coeffs */
+            } else
+            {  /* addmul product of input poly coeffs */
                fmpz_addmul(p1 + k, poly2 + x->i, poly3 + x->j);
+            }
 
             /* for each node in this chain */
             while ((x = x->next) != NULL)
@@ -359,7 +360,7 @@ slong _fmpz_mpoly_mul_johnson(fmpz ** poly1, ulong ** exp1, slong * alloc,
                mpoly_monomial_set(e1 + k*N, exp, N);
 
                first = 0; 
-            } else 
+            } else
             {  /* addmul product of input poly coeffs */
                fmpz_addmul(p1 + k, poly2 + x->i, poly3 + x->j);
             }
@@ -396,8 +397,10 @@ slong _fmpz_mpoly_mul_johnson(fmpz ** poly1, ulong ** exp1, slong * alloc,
             x->next = NULL;
 
             hind[x->i] = 2*(x->j+1) + 0;
-            mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
-            if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x, &heap_len, N, maskhi, masklo))
+            mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N,
+                                                   exp3 + x->j*N, N);
+            if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
+                                                 &heap_len, N, maskhi, masklo))
                exp_next--;
          }
 
@@ -416,8 +419,10 @@ slong _fmpz_mpoly_mul_johnson(fmpz ** poly1, ulong ** exp1, slong * alloc,
             x->next = NULL;
 
             hind[x->i] = 2*(x->j+1) + 0;
-            mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
-            if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x, &heap_len, N, maskhi, masklo))
+            mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N,
+                                                   exp3 + x->j*N, N);
+            if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
+                                                 &heap_len, N, maskhi, masklo))
                exp_next--;
          }
       }

--- a/fmpz_mpoly/mul_johnson.c
+++ b/fmpz_mpoly/mul_johnson.c
@@ -490,14 +490,14 @@ void fmpz_mpoly_mul_johnson(fmpz_mpoly_t poly1, const fmpz_mpoly_t poly2,
 
    exp_bits = 8;
    while (bits >= exp_bits) /* extra bit required for signs */
-      exp_bits *= 2;
+       exp_bits += 1;
 
    exp_bits = FLINT_MAX(exp_bits, poly2->bits);
    exp_bits = FLINT_MAX(exp_bits, poly3->bits);
+   exp_bits = mpoly_optimize_bits(exp_bits, ctx->n);
 
    masks_from_bits_ord(maskhi, masklo, exp_bits, ctx->ord);
-   /* number of words exponent vectors packed into */
-   N = (exp_bits*ctx->n - 1)/FLINT_BITS + 1;
+   N = words_per_exp(ctx->n, exp_bits);
 
    /* ensure input exponents are packed into same sized fields as output */
    if (exp_bits > poly2->bits)


### PR DESCRIPTION
This patch replaced mul_johnson with the DAN version below. 
I think this patch is good from a theoretical POV because it roughly equalizes
the timings across
 - the monomials orderings, and
 - the order the polynomials were fed into mul_johnson


mul_johnsonOLD: the current state of the fmpz_mpoly, which has general_bits but
no heap delay tactics.

mul_johnsonBIL: an adaptation of the delay tactics in pow_fps. I do not
understand these conditions, but they are faithfully transfered to mul_johnson.
These conditions are having absolutely no effect on the heap size.

mul_johnsonDAN: delay tactics that were found by monkeying with the conditions
until the code passed all tests and delayed roughly how I wanted it to.
These conditions do not look at the exponents, but rather only at the 'topology'
as in mul_johnsonBIL. I do not fully understand why this code is correct.

mul_johnsonEXP: delay tactics with intelligently designed conditions to keep
the heap as small as possible. These conditions look at the exponents, and the
implementation is fairly efficient, with only one more level of indirection. I
fully understand why this code is correct. This keeps the heap VERY small, but
the heap is already small enough in the DAN version that the extra work is
apparently unjustified.


First h1 = (f*g)^n was calculated using pow_fps. The timing is in POW column.
Then, h = f^n * g^n was calculated twice for each multiplication function and
checked against h1. h was cleared then init'ed before each run and the
displayed numbers are

avg timing (avg heap size)

Finally, the operands were revered for h = g^n * f^n.

```
*** Multiplication f*g sparse Pearce ***
ord: lex
        POW       OLD           BIL          DAN        EXP
11      5212       910 (3718)    980 (3718)   800 (33)   770 (13)
12      10792     1870 (5296)   2010 (5296)  1680 (41)  1640 (15)
13      23896     3930 (7366)   4220 (7366)  3520 (49)  3520 (18)

ord: deglex
        POW       OLD           BIL          DAN        EXP
11      6587      1020 (3986)   1096 (3986)   809 (95)   861 (60)
12      13241     1990 (5662)   2149 (5662)  1660 (110) 1770 (70)
13      30766     4220 (7862)   4500 (7861)  3590 (126) 3830 (81)

ord: degrevlex
        POW       OLD           BIL          DAN        EXP
11      6531      1820 (4004)   1890 (4004)   840 (104)  776 (68)
12      13110     3740 (5687)   3850 (5687)  1720 (122) 1900 (80)
13      30805     7650 (7886)   7980 (7886)  3710 (141) 4080 (92)


*** Multiplication g*f sparse Pearce ***
ord: lex
        POW       OLD           BIL          DAN        EXP
11      5233      1130 (1549)   1200 (1549)   772 (33)   840 (19)
12      10754     2300 (2216)   2450 (2216)  1620 (41)  1780 (23)
13      23948     4680 (3049)   4990 (3049)  3400 (49)  3890 (28)

ord: deglex
        POW       OLD           BIL          DAN        EXP
11      6556      1830 (3967)   1900 (3967)   780 (94)   890 (53)
12      13140     3740 (5637)   3860 (5637)  1610 (109) 1840 (61)
13      30761     7680 (7825)   7990 (7824)  3490 (126) 3990 (70)

ord: degrevlex
        POW       OLD           BIL          DAN        EXP
11      6534       990 (3962)   1070 (3962)   850 (105)  860 (71)
12      13112     1960 (5638)   2120 (5638)  1750 (123) 1900 (84)
13      30813     4160 (7823)   4470 (7822)  3770 (143) 3900 (98)
`
