### PR TITLE
Optimize heap division

### DIFF
--- a/fmpz_mpoly.h
+++ b/fmpz_mpoly.h
@@ -633,16 +633,45 @@ void _fmpz_mpoly_sub_uiuiui_fmpz(ulong * c, const fmpz_t d)
 }
 
 FMPZ_MPOLY_INLINE
+void _fmpz_mpoly_add_uiuiui_fmpz(ulong * c, const fmpz_t d)
+{
+    fmpz fc = *d;
+
+    if (!COEFF_IS_MPZ(fc))
+    {
+        ulong f0, f1, f2;
+        f0 = fc;
+        f1 = f2 = -((slong) f0 < 0);
+        add_sssaaaaaa(c[2], c[1], c[0], c[2], c[1], c[0], f2, f1, f0);
+   } else
+   {
+      slong size = fmpz_size(d);
+      __mpz_struct * m = COEFF_TO_PTR(fc);
+      if (fmpz_sgn(d) < 0)
+         mpn_sub(c, c, 3, m->_mp_d, size);
+      else
+         mpn_add(c, c, 3, m->_mp_d, size);
+   }
+}
+
+FMPZ_MPOLY_INLINE
 void _fmpz_mpoly_submul_uiuiui_fmpz(ulong * c, slong d1, slong d2)
 {
-   ulong p[2];
-
-   smul_ppmm(p[1], p[0], d1, d2);
-   if (0 > (slong) p[1])
-      add_sssaaaaaa(c[2], c[1], c[0], c[2], c[1], c[0], ~WORD(0), p[1], p[0]);
-   else
-      add_sssaaaaaa(c[2], c[1], c[0], c[2], c[1], c[0], 0, p[1], p[0]);
+    ulong p[2], p2;
+    smul_ppmm(p[1], p[0], d1, d2);
+    p2 = -((slong) p[1] < 0);
+    sub_dddmmmsss(c[2], c[1], c[0], c[2], c[1], c[0], p2, p[1], p[0]);
 }
+
+FMPZ_MPOLY_INLINE
+void _fmpz_mpoly_addmul_uiuiui_fmpz(ulong * c, slong d1, slong d2)
+{
+    ulong p[2], p2;
+    smul_ppmm(p[1], p[0], d1, d2);
+    p2 = -((slong) p[1] < 0);
+    add_sssaaaaaa(c[2], c[1], c[0], c[2], c[1], c[0], p2, p[1], p[0]);
+}
+
 
 
 /******************************************************************************

--- a/fmpz_mpoly/div_monagan_pearce.c
+++ b/fmpz_mpoly/div_monagan_pearce.c
@@ -149,7 +149,7 @@ slong _fmpz_mpoly_div_monagan_pearce1(fmpz ** polyq, ulong ** expq,
                } else
                {
                   /* subtract q[j]*poly3 coeff from accum. three word coeff */
-                  _fmpz_mpoly_submul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
+                  _fmpz_mpoly_addmul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
                }
             } else /* accumulated coeffs are multiprecision */
             {
@@ -186,7 +186,7 @@ slong _fmpz_mpoly_div_monagan_pearce1(fmpz ** polyq, ulong ** expq,
                   } else
                   {
                      /* subtract q[j]*poly3 coeff from accum. three word coeff */
-                     _fmpz_mpoly_submul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
+                     _fmpz_mpoly_addmul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
                   }
                } else /* accumulated coeffs are multiprecision */
                {
@@ -519,7 +519,7 @@ slong _fmpz_mpoly_div_monagan_pearce(fmpz ** polyq,
                } else
                {
                   /* subtract q[j]*poly3 coeff from accum. three word coeff */
-                  _fmpz_mpoly_submul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
+                  _fmpz_mpoly_addmul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
                }
             } else /* accumulated coeffs are multiprecision */
             {
@@ -555,7 +555,7 @@ slong _fmpz_mpoly_div_monagan_pearce(fmpz ** polyq,
                   } else
                   {
                      /* subtract q[j]*poly3 coeff from accum. three word coeff */
-                     _fmpz_mpoly_submul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
+                     _fmpz_mpoly_addmul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
                   }
                } else /* accumulated coeffs are multiprecision */
                {

--- a/fmpz_mpoly/divides_monagan_pearce.c
+++ b/fmpz_mpoly/divides_monagan_pearce.c
@@ -61,19 +61,12 @@ slong _fmpz_mpoly_divides_monagan_pearce1(fmpz ** poly1, ulong ** exp1,
     small = FLINT_ABS(bits2) <= (FLINT_ABS(bits3) + FLINT_BIT_COUNT(len3) + FLINT_BITS - 2)
          && FLINT_ABS(bits3) <= FLINT_BITS - 2;
 
-
-flint_printf("bits2: %wd\n",bits2);
-if (small)
-{
-    printf("starting small\n");
-}
-
+    /* alloc array of heap nodes which can be chained together */
     next_loc = len3 + 4;   /* something bigger than heap can ever be */
     heap = (mpoly_heap1_s *) TMP_ALLOC((len3 + 1)*sizeof(mpoly_heap1_s));
-    /* alloc array of heap nodes which can be chained together */
     chain = (mpoly_heap_t *) TMP_ALLOC(len3*sizeof(mpoly_heap_t));
-    /* space for temporary storage of indices of heap nodes */
     store = store_base = (slong *) TMP_ALLOC(2*len3*sizeof(mpoly_heap_t *));
+
     /* space for flagged heap indicies */
     hind = (slong *) TMP_ALLOC(len3*sizeof(slong));
     for (i = 0; i < len3; i++)
@@ -120,22 +113,10 @@ if (small)
         if (small)
         {
             acc_sm[0] = acc_sm[1] = acc_sm[2] = 0;
-
-            while (heap_len > 1 && heap[1].exp == exp)
+            do
             {
                 x = _mpoly_heap_pop1(heap, &heap_len, maskhi);
-                *store++ = x->i;
-                *store++ = x->j;
-
-                if (x->i != -WORD(1))
-                    hind[x->i] |= WORD(1);
-
-                if (x->i == -WORD(1))
-                    _fmpz_mpoly_add_uiuiui_fmpz(acc_sm, poly2 + x->j);
-                else
-                    _fmpz_mpoly_mysubmul_uiuiui_fmpz(acc_sm, poly3[x->i], p1[x->j]);
-
-                while ((x = x->next) != NULL)
+                do
                 {
                     *store++ = x->i;
                     *store++ = x->j;
@@ -145,28 +126,16 @@ if (small)
                     if (x->i == -WORD(1))
                         _fmpz_mpoly_add_uiuiui_fmpz(acc_sm, poly2 + x->j);
                     else
-                        _fmpz_mpoly_mysubmul_uiuiui_fmpz(acc_sm, poly3[x->i], p1[x->j]);
-                }
-            }
-
+                        _fmpz_mpoly_submul_uiuiui_fmpz(acc_sm, poly3[x->i], p1[x->j]);
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && heap[1].exp == exp);
         } else
         {
             fmpz_zero(acc_lg);  
-
-            while (heap_len > 1 && heap[1].exp == exp)
+            do
             {
                 x = _mpoly_heap_pop1(heap, &heap_len, maskhi);
-                *store++ = x->i;
-                *store++ = x->j;
-                if (x->i != -WORD(1))
-                    hind[x->i] |= WORD(1);
-
-                if (x->i == -WORD(1))
-                    fmpz_add(acc_lg, acc_lg, poly2 + x->j);
-                else
-                    fmpz_submul(acc_lg, poly3 + x->i, p1 + x->j);
-
-                while ((x = x->next) != NULL)
+                do
                 {
                     *store++ = x->i;
                     *store++ = x->j;
@@ -177,8 +146,8 @@ if (small)
                         fmpz_add(acc_lg, acc_lg, poly2 + x->j);
                     else
                         fmpz_submul(acc_lg, poly3 + x->i, p1 + x->j);
-                }
-            }
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && heap[1].exp == exp);
         }
 
         /* process nodes taken from the heap */
@@ -219,7 +188,6 @@ if (small)
                 if (j + 1 == k)
                 {
                     s++;
-                    continue;
                 } else if (  1 /* (j + 1 < k) must be true */
                           && ((hind[i] & 1) == 1)
                           && ((i == 1) || (hind[i - 1] >= 2*(j + 2) + 1))
@@ -241,7 +209,7 @@ if (small)
         {
             ulong d0, d1, ds = acc_sm[2];
 
-            /* d1:d0 = abs(acc_sm[1:0]) assuming ds is sign extension of acc_sm[1:0] */
+            /* d1:d0 = abs(acc_sm[1:0]) assuming ds is sign extension of acc_sm[1] */
             sub_ddmmss(d1, d0, acc_sm[1]^ds, acc_sm[0]^ds, ds, ds);
             
             if ((acc_sm[0] | acc_sm[1] | acc_sm[2]) == 0)
@@ -266,7 +234,6 @@ if (small)
                     p1[k] = (qq^ds) - ds;
                 } else
                 {
-printf("1 switching to large\n");
                     small = 0;
                     fmpz_set_ui(p1 + k, qq);
                     if (ds != WORD(0))
@@ -274,7 +241,6 @@ printf("1 switching to large\n");
                 }
             } else
             {
-printf("2 switching to large\n");
                 small = 0;
                 fmpz_set_signed_uiuiui(acc_lg, acc_sm[2], acc_sm[1], acc_sm[0]);
                 fmpz_fdiv_qr(p1 + k, r, acc_lg, poly3 + 0);
@@ -310,22 +276,21 @@ printf("2 switching to large\n");
                                                  &next_loc, &heap_len, maskhi);
         }
         s = 1;
-   }
+    }
 
-   k++;
+    k++;
 
 cleanup:
 
-   fmpz_clear(acc_lg);
-   fmpz_clear(r);
+    fmpz_clear(acc_lg);
+    fmpz_clear(r);
 
-   (*poly1) = p1;
-   (*exp1) = e1;
-   
-   TMP_END;
+    (*poly1) = p1;
+    (*exp1) = e1;
 
-   /* return length of quotient, or zero if division not exact */
-   return k;
+    TMP_END;
+
+    return k;
 
 not_exact_division:
     for (i = 0; i <= k; i++)
@@ -340,216 +305,154 @@ slong _fmpz_mpoly_divides_monagan_pearce(fmpz ** poly1, ulong ** exp1,
        const fmpz * poly3, const ulong * exp3, slong len3, slong bits, slong N,
                                                     ulong maskhi, ulong masklo)
 {
-   slong i, j, k, s;
-   slong next_loc;
-   slong Q_len = 0, heap_len = 2; /* heap zero index unused */
-   mpoly_heap_s * heap;
-   mpoly_heap_t * chain;
-   slong * Q;
-   mpoly_heap_t * x;
-   fmpz * p1 = *poly1;
-   ulong * e1 = *exp1;
-   ulong * exp, * exps;
-   ulong ** exp_list;
-   ulong c[3]; /* for accumulating coefficients */
-   slong exp_next;
-   int first, d1, d2;
-   ulong mask = 0;
-   fmpz_t mb, qc, r, temp;
-   slong * hind;
-   int small;
-   slong bits2, bits3;
-    int lc_neg;
-    ulong lc_norm, lc_abs, lc_n, lc_i;
-   TMP_INIT;
+    slong i, j, k, s;
+    slong next_loc;
+    slong heap_len = 2; /* heap zero index unused */
+    mpoly_heap_s * heap;
+    mpoly_heap_t * chain;
+    slong * store, * store_base;
+    mpoly_heap_t * x;
+    fmpz * p1 = *poly1;
+    ulong * e1 = *exp1;
+    ulong * exp, * exps;
+    ulong ** exp_list;
+    fmpz_t r, acc_lg;
+    ulong acc_sm[3];
+    slong exp_next;
+    ulong mask;
+    slong * hind;
+    int lt_divides, small;
+    slong bits2, bits3;
+    ulong lc_norm, lc_abs, lc_sign, lc_n, lc_i;
+    TMP_INIT;
 
-   /* if exponent vectors are all one word, call specialised version */
-   if (N == 1)
-      return _fmpz_mpoly_divides_monagan_pearce1(poly1, exp1, alloc,
+    /* if exponent vectors are all one word, call specialised version */
+    if (N == 1)
+        return _fmpz_mpoly_divides_monagan_pearce1(poly1, exp1, alloc,
                            poly2, exp2, len2, poly3, exp3, len3, bits, maskhi);
 
-   TMP_START;
+    TMP_START;
 
-   fmpz_init(mb);
-   fmpz_init(qc);
-   fmpz_init(r);
-    fmpz_init(temp);
+    fmpz_init(acc_lg);
+    fmpz_init(r);
 
-   /* whether intermediate computations q - a*b will fit in three words */
-   bits2 = _fmpz_vec_max_bits(poly2, len2);
-   bits3 = _fmpz_vec_max_bits(poly3, len3);
-   /* allow one bit for sign, one bit for subtraction */
-   small = FLINT_ABS(bits2) <= (FLINT_ABS(bits3) + FLINT_BIT_COUNT(len3) + FLINT_BITS - 2) &&
-           FLINT_ABS(bits3) <= FLINT_BITS - 2;
+    /* whether intermediate computations q - a*b will fit in three words */
+    bits2 = _fmpz_vec_max_bits(poly2, len2);
+    bits3 = _fmpz_vec_max_bits(poly3, len3);
+    /* allow one bit for sign, one bit for subtraction */
+    small = FLINT_ABS(bits2) <= (FLINT_ABS(bits3) + FLINT_BIT_COUNT(len3) + FLINT_BITS - 2)
+          && FLINT_ABS(bits3) <= FLINT_BITS - 2;
 
-   next_loc = len3 + 4;   /* something bigger than heap can ever be */
-   heap = (mpoly_heap_s *) TMP_ALLOC((len3 + 1)*sizeof(mpoly_heap_s));
-   /* alloc array of heap nodes which can be chained together */
-   chain = (mpoly_heap_t *) TMP_ALLOC(len3*sizeof(mpoly_heap_t));
-   /* space for temporary storage of pointers to heap nodes */
-   Q = (slong *) TMP_ALLOC(2*len3*sizeof(mpoly_heap_t *));
-   /* array of exponent vectors, each of "N" words */
-   exps = (ulong *) TMP_ALLOC(len3*N*sizeof(ulong));
-   /* list of pointers to available exponent vectors */
-   exp_list = (ulong **) TMP_ALLOC(len3*sizeof(ulong *));
-   /* set up list of available exponent vectors */
-   for (i = 0; i < len3; i++)
-      exp_list[i] = exps + i*N;
+    /* alloc array of heap nodes which can be chained together */
+    next_loc = len3 + 4;   /* something bigger than heap can ever be */
+    heap = (mpoly_heap_s *) TMP_ALLOC((len3 + 1)*sizeof(mpoly_heap_s));
+    chain = (mpoly_heap_t *) TMP_ALLOC(len3*sizeof(mpoly_heap_t));
+    store = store_base = (slong *) TMP_ALLOC(2*len3*sizeof(mpoly_heap_t *));
 
-    /* space for heap indices */
+    /* array of exponent vectors, each of "N" words */
+    exps = (ulong *) TMP_ALLOC(len3*N*sizeof(ulong));
+    /* list of pointers to available exponent vectors */
+    exp_list = (ulong **) TMP_ALLOC(len3*sizeof(ulong *));
+    /* set up list of available exponent vectors */
+    exp_next = 0;
+    for (i = 0; i < len3; i++)
+        exp_list[i] = exps + i*N;
+
+    /* space for flagged heap indicies */
     hind = (slong *) TMP_ALLOC(len3*sizeof(slong));
     for (i = 0; i < len3; i++)
         hind[i] = 1;
 
-   /* start with no heap nodes or exponents in use */
-   exp_next = 0;
+    /* mask with high bit set in each word of each field of exponent vector */
+    mask = 0;
+    for (i = 0; i < FLINT_BITS/bits; i++)
+        mask = (mask << bits) + (UWORD(1) << (bits - 1));
 
-   /* mask with high bit set in each word of each field of exponent vector */
-   for (i = 0; i < FLINT_BITS/bits; i++)
-      mask = (mask << bits) + (UWORD(1) << (bits - 1));
+    /* output poly index starts at -1, will be immediately updated to 0 */
+    k = -WORD(1);
 
-   /* output poly index starts at -1, will be immediately updated to 0 */
-   k = -WORD(1);
-   
-   /* s is the number of terms * (latest quotient) we should put into heap */
-   s = len3;
-   
-   /* insert (-1, 0, exp2[0]) into heap */
-   x = chain + 0;
-   x->i = -WORD(1);
-   x->j = 0;
-   x->next = NULL;
-   heap[1].next = x;
-   heap[1].exp = exp_list[exp_next++];
-   mpoly_monomial_set(heap[1].exp, exp2, N);
+    /* s is the number of terms * (latest quotient) we should put into heap */
+    s = len3;
 
-   /* precompute -c_0 where c_i is the i-th coeff of poly3 */
-   fmpz_neg(mb, poly3 + 0);
+    /* insert (-1, 0, exp2[0]) into heap */
+    x = chain + 0;
+    x->i = -WORD(1);
+    x->j = 0;
+    x->next = NULL;
+    heap[1].next = x;
+    heap[1].exp = exp_list[exp_next++];
+    mpoly_monomial_set(heap[1].exp, exp2, N);
 
-    lc_abs = FLINT_ABS(*mb);
-    lc_neg = (slong)(*mb) < 0;
+    /* precompute leading cofficient info assuming "small" case */
+    lc_abs = FLINT_ABS(poly3[0]);
+    lc_sign = -((slong)(poly3[0]) < 0);
     count_leading_zeros(lc_norm, lc_abs);
     lc_n = lc_abs << lc_norm;
     invert_limb(lc_i, lc_n);
 
+    while (heap_len > 1)
+    {
+        exp = heap[1].exp;
 
-
-   /* while heap is nonempty */
-   while (heap_len > 1)
-   {
-      /* get pointer to exponent field of heap top */
-      exp = heap[1].exp;
-
-      /* check for overflow in exponent: not an exact division */
-      if (mpoly_monomial_overflows(exp, N, mask))
-      {
-            for (i = 0; i < k; i++)
-               _fmpz_demote(p1 + i);
-
-            k = 0;
-
-            goto cleanup;
-      }
+        if (mpoly_monomial_overflows(exp, N, mask))
+            goto not_exact_division;
       
-      /* realloc output poly ready for next quotient term */
-      k++;
-      _fmpz_mpoly_fit_length(&p1, &e1, alloc, k + 1, N);
+        k++;
+        _fmpz_mpoly_fit_length(&p1, &e1, alloc, k + 1, N);
 
-      /* whether we are on first heap node for this exponent */
-      first = 1;
-      
-      /* whether current exponent is divisible by exp3[0] */
-      d1 = 0;
+        lt_divides = mpoly_monomial_divides(e1 + k*N, exp, exp3, N, mask);
 
-      /* set temporary coeff to zero */
-      c[0] = c[1] = c[2] = 0;
-
-      /* while heap nonempty and contains chain with current output exponent */
-      while (heap_len > 1 && mpoly_monomial_equal(heap[1].exp, exp, N))
-      {
-         /* put pointer to exponent on heap top into list of available exps */
-         exp_list[--exp_next] = heap[1].exp;
-
-         /* pop chain from heap */
-         x = _mpoly_heap_pop(heap, &heap_len, N, maskhi, masklo);
-         Q[Q_len++] = x->i;
-         Q[Q_len++] = x->j;
-         if (x->i != -WORD(1))
-            hind[x->i] |= WORD(1);
-
-
-         /* if first heap node for this exp, check it's divisible by exp3[0] */
-         if (first)
-         {
-            d1 = mpoly_monomial_divides(e1 + k*N, exp, exp3, N, mask);
-            first = 0; 
-         }
-
-         /* if accumulated coeffs will fit in three words */
-         if (small)
-         {
-            if (x->i == -WORD(1))
-               _fmpz_mpoly_sub_uiuiui_fmpz(c, poly2 + x->j);
-            else
-               _fmpz_mpoly_submul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
-
-
-
-         } else
-         {
-            if (x->i == -WORD(1))
-               fmpz_sub(qc, qc, poly2 + x->j);
-            else
-               fmpz_addmul(qc, poly3 + x->i, p1 + x->j);
-
-
-         }
-
-         /* for every node in this chain */
-         while ((x = x->next) != NULL)
-         {
-            /* take node out of heap and put into store */
-            Q[Q_len++] = x->i;
-            Q[Q_len++] = x->j;
-            if (x->i != -WORD(1))
-               hind[x->i] |= WORD(1);
-
-            /* if accumulated coeffs will fit in three words */
-            if (small)
-            {
-               if (x->i == -WORD(1))
-               {
-                  /* subtract poly2[j] from accumulated three word coeff */
-                  _fmpz_mpoly_sub_uiuiui_fmpz(c, poly2 + x->j);
-               } else
-               {
-                  /* subtract poly3[i]*q[j] from accum. three word coeff */
-                  _fmpz_mpoly_submul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
-               }
-            } else /* accumulated coeffs are multiprecision */
-            {
-               if (x->i == -WORD(1))
-               {
-                  /* subtract poly2[j] from accumulated coeff */
-                  fmpz_sub(qc, qc, poly2 + x->j);
-               } else
-               {
-                  /* subtract poly3[i]*q[j] from accum. coeff */
-                  fmpz_addmul(qc, poly3 + x->i, p1 + x->j);
-               }
-            }
-         }
-      }
-
-        /* for each node temporarily stored */
-        while (Q_len > 0)
+        if (small) 
         {
-            /* take node from store */
-            j = Q[--Q_len];
-            i = Q[--Q_len];
+            acc_sm[0] = acc_sm[1] = acc_sm[2] = 0;
+            do
+            {
+                exp_list[--exp_next] = heap[1].exp;
+                x = _mpoly_heap_pop(heap, &heap_len, N, maskhi, masklo);
+                do
+                {
+                    *store++ = x->i;
+                    *store++ = x->j;
+                    if (x->i != -WORD(1))
+                        hind[x->i] |= WORD(1);
+
+                    if (x->i == -WORD(1))
+                        _fmpz_mpoly_add_uiuiui_fmpz(acc_sm, poly2 + x->j);
+                    else
+                        _fmpz_mpoly_submul_uiuiui_fmpz(acc_sm, poly3[x->i], p1[x->j]);
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && mpoly_monomial_equal(heap[1].exp, exp, N));
+        } else
+        {
+            fmpz_zero(acc_lg);
+            do
+            {
+                exp_list[--exp_next] = heap[1].exp;
+                x = _mpoly_heap_pop(heap, &heap_len, N, maskhi, masklo);
+                do
+                {
+                    *store++ = x->i;
+                    *store++ = x->j;
+                    if (x->i != -WORD(1))
+                        hind[x->i] |= WORD(1);
+
+                    if (x->i == -WORD(1))
+                        fmpz_add(acc_lg, acc_lg, poly2 + x->j);
+                    else
+                        fmpz_submul(acc_lg, poly3 + x->i, p1 + x->j);
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && mpoly_monomial_equal(heap[1].exp, exp, N));
+        }
+
+        /* process nodes taken from the heap */
+        while (store > store_base)
+        {
+            j = *--store;
+            i = *--store;
 
             if (i == -WORD(1))
             {
+                /* take next dividend term */
                 if (j + 1 < len2)
                 {
                     x = chain + 0;
@@ -559,7 +462,7 @@ slong _fmpz_mpoly_divides_monagan_pearce(fmpz ** poly1, ulong ** exp1,
                     mpoly_monomial_set(exp_list[exp_next], exp2 + x->j*N, N);
                     if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
                                       &next_loc, &heap_len, N, maskhi, masklo))
-                       exp_next--;
+                        exp_next--;
                 }
             } else
             {
@@ -577,14 +480,13 @@ slong _fmpz_mpoly_divides_monagan_pearce(fmpz ** poly1, ulong ** exp1,
                                                            e1   + x->j*N, N);
                     if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
                                       &next_loc, &heap_len, N, maskhi, masklo))
-                       exp_next--;
+                        exp_next--;
                 }
                 /* should we go up? */
                 if (j + 1 == k)
                 {
                     s++;
-                    continue;
-                } else if (  1 /*(j + 1 < k)*/
+                } else if (  1 /* (j + 1 < k) is always true */
                           && ((hind[i] & 1) == 1)
                           && ((i == 1) || (hind[i - 1] >= 2*(j + 2) + 1))
                           )
@@ -603,127 +505,102 @@ slong _fmpz_mpoly_divides_monagan_pearce(fmpz ** poly1, ulong ** exp1,
             }
         }
 
-      /* if accumulated coeff is zero, no output coeff to be written */
-      if ((small && (c[2] == 0 && c[1] == 0 && c[0] == 0))
-            || (!small && fmpz_is_zero(qc)))
-      {
-         k--;
-      } else
-      {
-         /* if accumulated coeff fit in three words */
-         if (small)
-         {
-            ulong d[3];
-            int neg = lc_neg;
+        /* try to divide accumulated term by leading term */
+        if (small)
+        {
+            ulong d0, d1, ds = acc_sm[2];
 
-            /* set d = abs(c) */
-            if (0 > (slong) c[2])
+            /* d1:d0 = abs(acc_sm[1:0]) assuming ds is sign extension of acc_sm[1] */
+            sub_ddmmss(d1, d0, acc_sm[1]^ds, acc_sm[0]^ds, ds, ds);
+            
+            if ((acc_sm[0] | acc_sm[1] | acc_sm[2]) == 0)
             {
-               neg = !lc_neg;
-               mpn_neg(d, c, 3);
-            } else
-            {
-               flint_mpn_copyi(d, c, 3);
+                k--;
+                continue;
             }
 
-            /* check quotient of accumulated coeff by -poly3[0] is small */
-            if (d[2] != 0 || d[1] >= lc_abs) /* quotient not a small */
-            {
-               /* convert three words to multiprecision value */
-               fmpz_set_signed_uiuiui(qc, c[2], c[1], c[0]);
-
-               /* continue in non-small case from now on */
-               fmpz_fdiv_qr(p1 + k, r, qc, mb); /* quotient and remainder */
-
-               /* coeff division exact if remainder zero */
-               d2 = fmpz_is_zero(r);
-
-               small = 0;
-            } else /* quotient may fit a small */
+            if (ds == -((slong)acc_sm[1] < 0) && d1 < lc_abs)
             {
                 ulong qq, rr, nhi, nlo;
-                nhi = (d[1] << lc_norm) | (d[0] >> (FLINT_BITS - lc_norm));
-                nlo = d[0] << lc_norm;
+                nhi = (d1 << lc_norm) | (d0 >> (FLINT_BITS - lc_norm));
+                nlo = d0 << lc_norm;
                 udiv_qrnnd_preinv(qq, rr, nhi, nlo, lc_n, lc_i);
-                fmpz_set_signed_uiuiui(qc, c[2], c[1], c[0]);
-                fmpz_fdiv_qr(temp, r, qc, mb);
-                assert((rr==0) == (fmpz_is_zero(r)!=0));
-                /* check quotient really fit a small */
+                if (rr != WORD(0))
+                    goto not_exact_division;
+
+                ds ^= lc_sign;
                 if ((qq & (WORD(3) << (FLINT_BITS - 2))) == WORD(0))
                 {
                     _fmpz_demote(p1 + k);
-                    p1[k] = neg ? -qq : qq;
-                    assert((rr!=0)||(*temp == p1[k]));
+                    p1[k] = (qq^ds) - ds;
                 } else
                 {
-                    fmpz_set_ui(p1 + k, qq);
-                    if (neg)
-                        fmpz_neg(p1 + k, p1 + k);
-                    assert((rr!=0)||fmpz_equal(temp, p1 + k));
                     small = 0;
+                    fmpz_set_ui(p1 + k, qq);
+                    if (ds != WORD(0))
+                        fmpz_neg(p1 + k, p1 + k);
                 }
-                /* coeff division exact if remainder zero */
-                d2 = rr==0;/*r1 == 0;*/
-            }
-         } else /* multiprecision case */
-         {
-            /* write out quotient and compute remainder */
-            fmpz_fdiv_qr(p1 + k, r, qc, mb);
-
-            /* coeff division exact if remainder zero */
-            d2 = fmpz_is_zero(r);
-         }
-
-         /* if coeffs or monomials don't divide, or exponent too large */
-         if (!d1 || !d2 ||
-          mpoly_monomial_gt(exp, exp2 + (len2 - 1)*N, N, maskhi, masklo)) /* inexact division */
-         {
-            for (i = 0; i <= k; i++)
-               _fmpz_demote(p1 + i);
-
-            k = 0;
-
-            goto cleanup;
-         }
-
-            if (s > 1)
+            } else
             {
-                i = 1;
-                x = chain + i;
-                x->i = i;
-                x->j = k;
-                x->next = NULL;
-                hind[x->i] = 2*(x->j + 1) + 0;
-                mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                       e1   + x->j*N, N);
-                if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
-                                      &next_loc, &heap_len, N, maskhi, masklo))
-                    exp_next--;
+                small = 0;
+                fmpz_set_signed_uiuiui(acc_lg, acc_sm[2], acc_sm[1], acc_sm[0]);
+                fmpz_fdiv_qr(p1 + k, r, acc_lg, poly3 + 0);
+                if (!fmpz_is_zero(r))
+                    goto not_exact_division;
             }
-            s = 1;
 
-      } 
-      
-      /* zero temporary accumulator */
-      fmpz_zero(qc);  
-   }
+        } else
+        {
+            if (fmpz_is_zero(acc_lg))
+            {
+                k--;
+                continue;
+            }
+            fmpz_fdiv_qr(p1 + k, r, acc_lg, poly3 + 0);
+            if (!fmpz_is_zero(r))
+                goto not_exact_division;
+        }
 
-   k++;
+        if (!lt_divides ||
+                mpoly_monomial_gt(exp, exp2 + (len2 - 1)*N, N, maskhi, masklo))
+            goto not_exact_division;
+
+        if (s > 1)
+        {
+            i = 1;
+            x = chain + i;
+            x->i = i;
+            x->j = k;
+            x->next = NULL;
+            hind[x->i] = 2*(x->j + 1) + 0;
+            mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
+                                                   e1   + x->j*N, N);
+            if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
+                                  &next_loc, &heap_len, N, maskhi, masklo))
+                exp_next--;
+        }
+        s = 1;      
+    }
+
+    k++;
 
 cleanup:
 
-   fmpz_clear(mb);
-   fmpz_clear(qc);
-   fmpz_clear(r);
-    fmpz_clear(temp);
+    fmpz_clear(acc_lg);
+    fmpz_clear(r);
 
-   (*poly1) = p1;
-   (*exp1) = e1;
-   
-   TMP_END;
+    (*poly1) = p1;
+    (*exp1) = e1;
 
-   /* return length of quotient, or zero if division not exact */
-   return k;
+    TMP_END;
+
+    return k;
+
+not_exact_division:
+    for (i = 0; i <= k; i++)
+        _fmpz_demote(p1 + i);
+    k = 0;
+    goto cleanup;
 }
 
 /* return 1 if quotient is exact */

--- a/fmpz_mpoly/divrem_ideal_monagan_pearce.c
+++ b/fmpz_mpoly/divrem_ideal_monagan_pearce.c
@@ -142,7 +142,7 @@ slong _fmpz_mpoly_divrem_ideal_monagan_pearce1(fmpz_mpoly_struct ** polyq,
             if (x->i == -WORD(1))
                _fmpz_mpoly_sub_uiuiui_fmpz(c, poly2 + x->j);
             else
-            {   _fmpz_mpoly_submul_uiuiui_fmpz(c,
+            {   _fmpz_mpoly_addmul_uiuiui_fmpz(c,
                          poly3[x->p]->coeffs[x->i], polyq[x->p]->coeffs[x->j]);
             }
          } else
@@ -166,7 +166,7 @@ slong _fmpz_mpoly_divrem_ideal_monagan_pearce1(fmpz_mpoly_struct ** polyq,
                if (x->i == -WORD(1))
                   _fmpz_mpoly_sub_uiuiui_fmpz(c, poly2 + x->j);
                else
-                  _fmpz_mpoly_submul_uiuiui_fmpz(c,
+                  _fmpz_mpoly_addmul_uiuiui_fmpz(c,
                          poly3[x->p]->coeffs[x->i], polyq[x->p]->coeffs[x->j]);
             } else
             {
@@ -501,7 +501,7 @@ slong _fmpz_mpoly_divrem_ideal_monagan_pearce(fmpz_mpoly_struct ** polyq,
             if (x->i == -WORD(1))
                _fmpz_mpoly_sub_uiuiui_fmpz(c, poly2 + x->j);
             else
-               _fmpz_mpoly_submul_uiuiui_fmpz(c,
+               _fmpz_mpoly_addmul_uiuiui_fmpz(c,
                          poly3[x->p]->coeffs[x->i], polyq[x->p]->coeffs[x->j]);
          } else
          {
@@ -524,7 +524,7 @@ slong _fmpz_mpoly_divrem_ideal_monagan_pearce(fmpz_mpoly_struct ** polyq,
                if (x->i == -WORD(1))
                   _fmpz_mpoly_sub_uiuiui_fmpz(c, poly2 + x->j);
                else
-                  _fmpz_mpoly_submul_uiuiui_fmpz(c,
+                  _fmpz_mpoly_addmul_uiuiui_fmpz(c,
                          poly3[x->p]->coeffs[x->i], polyq[x->p]->coeffs[x->j]);
             } else
             {

--- a/fmpz_mpoly/divrem_monagan_pearce.c
+++ b/fmpz_mpoly/divrem_monagan_pearce.c
@@ -150,7 +150,7 @@ slong _fmpz_mpoly_divrem_monagan_pearce1(slong * lenr,
             } else
             {
                /* subtract q[j]*poly3 coeff from accum. three word coeff */
-               _fmpz_mpoly_submul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
+               _fmpz_mpoly_addmul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
             }
          } else /* accumulated coeffs are multiprecision */
          {
@@ -184,7 +184,7 @@ slong _fmpz_mpoly_divrem_monagan_pearce1(slong * lenr,
                } else
                {
                   /* subtract q[j]*poly3 coeff from accum. three word coeff */
-                  _fmpz_mpoly_submul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
+                  _fmpz_mpoly_addmul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
                }
             } else /* accumulated coeffs are multiprecision */
             {
@@ -558,7 +558,7 @@ slong _fmpz_mpoly_divrem_monagan_pearce(slong * lenr,
             } else /* accumulated coeffs are multiprecision */
             {
                /* subtract q[j]*poly3 coeff from accum. three word coeff */
-               _fmpz_mpoly_submul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
+               _fmpz_mpoly_addmul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
             }
          } else
          {
@@ -592,7 +592,7 @@ slong _fmpz_mpoly_divrem_monagan_pearce(slong * lenr,
                } else
                {
                   /* subtract q[j]*poly3 coeff from accum. three word coeff */
-                  _fmpz_mpoly_submul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
+                  _fmpz_mpoly_addmul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
                }
             } else /* accumulated coeffs are multiprecision */
             {

--- a/fmpz_mpoly/test/t-divides_monagan_pearce.c
+++ b/fmpz_mpoly/test/t-divides_monagan_pearce.c
@@ -26,6 +26,35 @@ main(void)
     flint_printf("divides_monagan_pearce....");
     fflush(stdout);
 
+
+    /*
+        A bad case is hit when testing with multiplier 50. The following
+        example illustrates this behaviour if the ordering is changed to
+        ORD_DEGLEX
+    */
+
+{
+    fmpz_mpoly_ctx_t ctx;
+    fmpz_mpoly_t f, g, q, r;
+
+    fmpz_mpoly_ctx_init(ctx, 2, ORD_LEX);
+    fmpz_mpoly_init(f, ctx);
+    fmpz_mpoly_init(g, ctx);
+    fmpz_mpoly_init(q, ctx);
+    fmpz_mpoly_init(r, ctx);
+
+    fmpz_mpoly_set_str_pretty(f, "-x1^1918*x2^1075-x1^1891*x2^2001",NULL, ctx);
+    fmpz_mpoly_set_str_pretty(g, "x1^22*x2^3-x1^19*x2^21-x1^16*x2^10-2*x1^14*x2^17-x1^14*x2^11-x1*x2^15-2*x2^17", NULL, ctx);
+
+    ok1 = fmpz_mpoly_divides_monagan_pearce(q, f, g, ctx);
+
+    fmpz_mpoly_clear(f, ctx);
+    fmpz_mpoly_clear(g, ctx);
+    fmpz_mpoly_clear(q, ctx);
+    fmpz_mpoly_clear(r, ctx);
+}
+
+
     /* Check f*g/g = f */
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
@@ -213,9 +242,9 @@ main(void)
 
        exp_bits = n_randint(state, FLINT_BITS - 1 - 
                   mpoly_ordering_isdeg(ord)*FLINT_BIT_COUNT(nvars)) + 1;
-       exp_bits1 = n_randint(state, FLINT_BITS - 1 - 
+       exp_bits1 = n_randint(state, FLINT_BITS - 2 -
                   mpoly_ordering_isdeg(ord)*FLINT_BIT_COUNT(nvars)) + 1;
-       exp_bits2 = n_randint(state, FLINT_BITS - 1 - 
+       exp_bits2 = n_randint(state, FLINT_BITS - 2 -
                   mpoly_ordering_isdeg(ord)*FLINT_BIT_COUNT(nvars)) + 1;
 
        exp_bound = n_randbits(state, exp_bits);
@@ -371,9 +400,9 @@ main(void)
 
        exp_bits = n_randint(state, FLINT_BITS - 1 - 
                   mpoly_ordering_isdeg(ord)*FLINT_BIT_COUNT(nvars)) + 1;
-       exp_bits1 = n_randint(state, FLINT_BITS - 1 - 
+       exp_bits1 = n_randint(state, FLINT_BITS - 2 -
                   mpoly_ordering_isdeg(ord)*FLINT_BIT_COUNT(nvars)) + 1;
-       exp_bits2 = n_randint(state, FLINT_BITS - 1 - 
+       exp_bits2 = n_randint(state, FLINT_BITS - 2 -
                   mpoly_ordering_isdeg(ord)*FLINT_BIT_COUNT(nvars)) + 1;
 
        exp_bound = n_randbits(state, exp_bits);


### PR DESCRIPTION
I though it would be good to submit a PR because the basically the whole of divides_monagan_pearce.c had to be rewritten. The other ..._monagan_pearce functions do not have this optimization yet. If it would be better to apply these changes to those files before merging, please let me know. There is also an interesting issue at the beginning of the test code for divides_monagan_pearce. I think if you set the multiplier to 20 with the new test code, it blows up because of a large potential quotient. IT completely crashed my computer.

The new divides function is slightly faster than mul_johnson on sparse inputs, and slightly slower than mul_johnson on dense inputs.