### PR TITLE
Optimize heap division part2

### DIFF
--- a/fmpz_mpoly.h
+++ b/fmpz_mpoly.h
@@ -689,14 +689,21 @@ void _fmpz_mpoly_addmul_uiuiui_fmpz(ulong * c, slong d1, slong d2)
 FMPZ_MPOLY_INLINE
 void fmpz_mpoly_test(const fmpz_mpoly_t poly, const fmpz_mpoly_ctx_t ctx)
 {
-   slong N;
+   slong i, N;
    ulong maskhi, masklo;
 
    masks_from_bits_ord(maskhi, masklo, poly->bits, ctx->ord);
    N = words_per_exp(ctx->n, poly->bits);
 
    if (!mpoly_monomials_test(poly->exps, poly->length, N, maskhi, masklo))
-      flint_throw(FLINT_ERROR, "Polynomial invalid");
+      flint_throw(FLINT_ERROR, "Polynomial exponents invalid");
+
+    for (i = 0; i < poly->length; i++)
+    {
+        if (fmpz_equal_si(poly->coeffs + i, 0))
+            flint_throw(FLINT_ERROR, "Polynomial has a zero coefficient");
+    }
+
 }
 
 

--- a/fmpz_mpoly.h
+++ b/fmpz_mpoly.h
@@ -610,6 +610,9 @@ FLINT_DLL void _fmpz_mpoly_to_fmpz_array(fmpz * p, const fmpz * coeffs,
 FLINT_DLL void _fmpz_mpoly_chunk_max_bits(slong * b1, slong * maxb1,
                           const fmpz * poly1, slong * i1, slong * n1, slong i);
 
+#define FLINT_SIGN(x) (-(ulong)((slong)(x) < 0))
+
+
 FMPZ_MPOLY_INLINE
 void _fmpz_mpoly_sub_uiuiui_fmpz(ulong * c, const fmpz_t d)
 {
@@ -617,10 +620,10 @@ void _fmpz_mpoly_sub_uiuiui_fmpz(ulong * c, const fmpz_t d)
 
    if (!COEFF_IS_MPZ(fc))
    {
-      if (fc >= 0)
-         sub_dddmmmsss(c[2], c[1], c[0], c[2], c[1], c[0], 0, 0, fc);
-      else
-         add_sssaaaaaa(c[2], c[1], c[0], c[2], c[1], c[0], 0, 0, -fc);
+        ulong f0, f1, f2;
+        f0 = fc;
+        f1 = f2 = FLINT_SIGN(f0);
+        sub_dddmmmsss(c[2], c[1], c[0], c[2], c[1], c[0], f2, f1, f0);
    } else
    {
       slong size = fmpz_size(d);
@@ -641,7 +644,7 @@ void _fmpz_mpoly_add_uiuiui_fmpz(ulong * c, const fmpz_t d)
     {
         ulong f0, f1, f2;
         f0 = fc;
-        f1 = f2 = -((slong) f0 < 0);
+        f1 = f2 = FLINT_SIGN(f0);
         add_sssaaaaaa(c[2], c[1], c[0], c[2], c[1], c[0], f2, f1, f0);
    } else
    {
@@ -659,7 +662,7 @@ void _fmpz_mpoly_submul_uiuiui_fmpz(ulong * c, slong d1, slong d2)
 {
     ulong p[2], p2;
     smul_ppmm(p[1], p[0], d1, d2);
-    p2 = -((slong) p[1] < 0);
+    p2 = FLINT_SIGN(p[1]);
     sub_dddmmmsss(c[2], c[1], c[0], c[2], c[1], c[0], p2, p[1], p[0]);
 }
 
@@ -668,7 +671,7 @@ void _fmpz_mpoly_addmul_uiuiui_fmpz(ulong * c, slong d1, slong d2)
 {
     ulong p[2], p2;
     smul_ppmm(p[1], p[0], d1, d2);
-    p2 = -((slong) p[1] < 0);
+    p2 = FLINT_SIGN(p[1]);
     add_sssaaaaaa(c[2], c[1], c[0], c[2], c[1], c[0], p2, p[1], p[0]);
 }
 

--- a/fmpz_mpoly/div_monagan_pearce.c
+++ b/fmpz_mpoly/div_monagan_pearce.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2017 William Hart
+    Copyright (C) 2017 Daniel Schultz
 
     This file is part of FLINT.
 
@@ -198,8 +198,7 @@ slong _fmpz_mpoly_div_monagan_pearce1(fmpz ** polyq, ulong ** expq,
                 if (j + 1 == k)
                 {
                     s++;
-                } else if (  1 /* (j + 1 < k) must be true */
-                          && ((hind[i] & 1) == 1)
+                } else if (  ((hind[i] & 1) == 1)
                           && ((i == 1) || (hind[i - 1] >= 2*(j + 2) + 1))
                           )
                 {
@@ -506,8 +505,7 @@ slong _fmpz_mpoly_div_monagan_pearce(fmpz ** polyq,
                 if (j + 1 == k)
                 {
                     s++;
-                } else if (  1 /* (j + 1 < k) is always true */
-                          && ((hind[i] & 1) == 1)
+                } else if (  ((hind[i] & 1) == 1)
                           && ((i == 1) || (hind[i - 1] >= 2*(j + 2) + 1))
                           )
                 {

--- a/fmpz_mpoly/div_monagan_pearce.c
+++ b/fmpz_mpoly/div_monagan_pearce.c
@@ -36,29 +36,27 @@ slong _fmpz_mpoly_div_monagan_pearce1(fmpz ** polyq, ulong ** expq,
             slong len2, const fmpz * poly3, const ulong * exp3, slong len3,
                                                       slong bits, ulong maskhi)
 {
-   slong i, k, s;
-   slong next_loc = len3 + 4;   /* something bigger than heap can ever be */
-   slong next_free, Q_len = 0;
-   slong reuse_len = 0, heap_len = 2; /* heap zero index unused */
-   mpoly_heap1_s * heap;
-   mpoly_heap_t * chain;
-   mpoly_heap_t ** Q, ** reuse;
-   mpoly_heap_t * x, * x2;
-   fmpz * p1 = *polyq;
-   ulong * e1 = *expq;
-   ulong exp, exp_temp, exp3_lead, tmp = 0;
-   ulong c[3]; /* for accumulating coefficients */
-   ulong mask = 0, ub;
-   fmpz_t mb, qc;
-   int small;
-   slong bits2, bits3;
-   int d1, divides;
-   TMP_INIT;
+    slong i, j, k, s;
+    slong next_loc, heap_len = 2;
+    mpoly_heap1_s * heap;
+    mpoly_heap_t * chain;
+    slong * store, * store_base;
+    mpoly_heap_t * x;
+    fmpz * p1 = *polyq;
+    ulong * e1 = *expq;
+    slong * hind;
+    ulong mask, exp;
+    fmpz_t r, acc_lg;
+    ulong acc_sm[3];
+    int lt_divides, small;
+    slong bits2, bits3;
+    ulong lc_norm, lc_abs, lc_sign, lc_n, lc_i;
+    TMP_INIT;
 
-   TMP_START;
+    TMP_START;
 
-   fmpz_init(mb);
-   fmpz_init(qc);
+    fmpz_init(acc_lg);
+    fmpz_init(r);
 
    /* whether intermediate computations q - a*b will fit in three words */
    bits2 = _fmpz_vec_max_bits(poly2, len2);
@@ -67,674 +65,569 @@ slong _fmpz_mpoly_div_monagan_pearce1(fmpz ** polyq, ulong ** expq,
    small = FLINT_ABS(bits2) <= (FLINT_ABS(bits3) + FLINT_BIT_COUNT(len3) +
            FLINT_BITS - 2) && FLINT_ABS(bits3) <= FLINT_BITS - 2;
 
-   heap = (mpoly_heap1_s *) TMP_ALLOC((len3 + 1)*sizeof(mpoly_heap1_s));
-   /* alloc array of heap nodes which can be chained together */
-   chain = (mpoly_heap_t *) TMP_ALLOC(len3*sizeof(mpoly_heap_t));
-   /* space for temporary storage of pointers to heap nodes */
-   Q = (mpoly_heap_t **) TMP_ALLOC(len3*sizeof(mpoly_heap_t *));
-   /* space for pointers to heap nodes which can be reused */
-   reuse = (mpoly_heap_t **) TMP_ALLOC(len3*sizeof(mpoly_heap_t *));
+    /* whether intermediate computations q - a*b will fit in three words */
+    bits2 = _fmpz_vec_max_bits(poly2, len2);
+    bits3 = _fmpz_vec_max_bits(poly3, len3);
+    /* allow one bit for sign, one bit for subtraction */
+    small = FLINT_ABS(bits2) <= (FLINT_ABS(bits3) + FLINT_BIT_COUNT(len3) + FLINT_BITS - 2)
+         && FLINT_ABS(bits3) <= FLINT_BITS - 2;
 
-   /* start with no heap nodes in use */
-   next_free = 0;
+    /* alloc array of heap nodes which can be chained together */
+    next_loc = len3 + 4;   /* something bigger than heap can ever be */
+    heap = (mpoly_heap1_s *) TMP_ALLOC((len3 + 1)*sizeof(mpoly_heap1_s));
+    chain = (mpoly_heap_t *) TMP_ALLOC(len3*sizeof(mpoly_heap_t));
+    store = store_base = (slong *) TMP_ALLOC(2*len3*sizeof(mpoly_heap_t *));
 
-   /* mask with high bit set in each field of exponent vector */
-   for (i = 0; i < FLINT_BITS/bits; i++)
-      mask = (mask << bits) + (UWORD(1) << (bits - 1));
+    /* space for flagged heap indicies */
+    hind = (slong *) TMP_ALLOC(len3*sizeof(slong));
+    for (i = 0; i < len3; i++)
+        hind[i] = 1;
 
-   /* quotient poly indices start at -1 */
-   k = -WORD(1);
+    /* mask with high bit set in each field of exponent vector */
+    mask = 0;
+    for (i = 0; i < FLINT_BITS/bits; i++)
+        mask = (mask << bits) + (UWORD(1) << (bits - 1));
+
+    /* quotient poly indices start at -1 */
+    k = -WORD(1);
+
+    /* see description of divisor heap division in paper */
+    s = len3;
    
-   /* see description of divisor heap division in paper */
-   s = len3;
-   
-   x = chain + next_free++;
-   x->i = -WORD(1);
-   x->j = 0;
-   x->next = NULL;
+    /* insert (-1, 0, exp2[0]) into heap */
+    x = chain + 0;
+    x->i = -WORD(1);
+    x->j = 0;
+    x->next = NULL;
+    HEAP_ASSIGN(heap[1], exp2[0], x);
 
-   /* insert (-1, 0, exp2[0]) into heap */
-   HEAP_ASSIGN(heap[1], exp2[0], x);
+    /* precompute leading cofficient info assuming "small" case */
+    lc_abs = FLINT_ABS(poly3[0]);
+    lc_sign = FLINT_SIGN(poly3[0]);
+    count_leading_zeros(lc_norm, lc_abs);
+    lc_n = lc_abs << lc_norm;
+    invert_limb(lc_i, lc_n);
 
-   /* precompute -c_n where c_n is the leading coeff of poly3 */
-   fmpz_neg(mb, poly3);
+    while (heap_len > 1)
+    {
+        exp = heap[1].exp;
 
-   ub = ((ulong) FLINT_ABS(*mb)) >> 1; /* abs(lc(poly3))/2 */
-   
-   /* precompute leading exponent of poly3 */
-   exp3_lead = exp3[0];
+        if (mpoly_monomial_overflows1(exp, mask))
+            goto exp_overflow;
 
-   /* while heap is nonempty */
-   while (heap_len > 1)
-   {
-      /* get exponent field of heap top */
-      exp = heap[1].exp;
-      
-      /* check there has been no overflow */
-      if ((exp & mask) != 0)
-      {
-         for (i = 0; i < k; i++)
-            _fmpz_demote(p1 + i);
+        k++;
+        _fmpz_mpoly_fit_length(&p1, &e1, allocq, k + 1, 1);
 
-         k = -WORD(1);
+        lt_divides = mpoly_monomial_divides1(e1 + k, exp, exp3[0], mask);
 
-         goto cleanup;
-      }
-
-      /* only do arithmetic for monomials that divide */
-      divides = mpoly_monomial_divides1(&tmp, exp, exp3_lead, mask);
-
-      /* realloc quotient poly ready for next quotient term */
-      k++;
-      _fmpz_mpoly_fit_length(&p1, &e1, allocq, k + 1, 1);
-
-      /* set temporary coeff to zero */
-      c[0] = c[1] = c[2] = 0;
-
-      /* while heap nonempty and contains chain with current output exponent */
-      while (heap_len > 1 && heap[1].exp == exp)
-      {
-         /* pop chain from heap */
-         x = _mpoly_heap_pop1(heap, &heap_len, maskhi);
-         
-         if (divides)
-         {
-            /* if accumulated coeffs will fit in three words */
-            if (small)
+        /* take nodes from heap with exponent matching exp */
+        if (small)
+        {
+            acc_sm[0] = acc_sm[1] = acc_sm[2] = 0;
+            do
             {
-               if (x->i == -WORD(1))
-               {
-                  /* subtract poly2 coeff from accumulated three word coeff */
-                  _fmpz_mpoly_sub_uiuiui_fmpz(c, poly2 + x->j);
-               } else
-               {
-                  /* subtract q[j]*poly3 coeff from accum. three word coeff */
-                  _fmpz_mpoly_addmul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
-               }
-            } else /* accumulated coeffs are multiprecision */
+                x = _mpoly_heap_pop1(heap, &heap_len, maskhi);
+                do
+                {
+                    *store++ = x->i;
+                    *store++ = x->j;
+                    if (x->i != -WORD(1))
+                        hind[x->i] |= WORD(1);
+
+                    if (x->i == -WORD(1))
+                        _fmpz_mpoly_add_uiuiui_fmpz(acc_sm, poly2 + x->j);
+                    else
+                        _fmpz_mpoly_submul_uiuiui_fmpz(acc_sm, poly3[x->i], p1[x->j]);
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && heap[1].exp == exp);
+        } else
+        {
+            fmpz_zero(acc_lg);  
+            do
             {
-               if (x->i == -WORD(1))
-               {
-                  /* subtract poly2 coeff from accum. coeff */
-                  fmpz_sub(qc, qc, poly2 + x->j);
-               } else
-               {
-                  /* subtract q[j]*poly3 coeff from accum. coeff */
-                  fmpz_addmul(qc, poly3 + x->i, p1 + x->j);
-               }
-            }
-         }
+                x = _mpoly_heap_pop1(heap, &heap_len, maskhi);
+                do
+                {
+                    *store++ = x->i;
+                    *store++ = x->j;
+                    if (x->i != -WORD(1))
+                        hind[x->i] |= WORD(1);
 
-         /* temporarily store pointer to this node, or designate for reuse */
-         if (x->i != -WORD(1) || x->j < len2 - 1)
-            Q[Q_len++] = x;
-         else
-            reuse[reuse_len++] = x;
+                    if (x->i == -WORD(1))
+                        fmpz_add(acc_lg, acc_lg, poly2 + x->j);
+                    else
+                        fmpz_submul(acc_lg, poly3 + x->i, p1 + x->j);
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && heap[1].exp == exp);
+        }
 
-         /* for every node in this chain */
-         while ((x = x->next) != NULL)
-         {
-            if (divides)
+        /* process nodes taken from the heap */
+        while (store > store_base)
+        {
+            j = *--store;
+            i = *--store;
+
+            if (i == -WORD(1))
             {
-               /* if accumulated coeffs will fit in three words */
-               if (small)
-               {
-                  if (x->i == -WORD(1))
-                  {
-                     /* subtract poly2 coeff from accum. three word coeff */
-                     _fmpz_mpoly_sub_uiuiui_fmpz(c, poly2 + x->j);
-                  } else
-                  {
-                     /* subtract q[j]*poly3 coeff from accum. three word coeff */
-                     _fmpz_mpoly_addmul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
-                  }
-               } else /* accumulated coeffs are multiprecision */
-               {
-                  if (x->i == -WORD(1))
-                  {
-                     /* subtract poly2 coeff from accum. coeff */
-                     fmpz_sub(qc, qc, poly2 + x->j);
-                  } else
-                  {
-                     /* subtract q[j]*poly3 coeff from accum. coeff */
-                     fmpz_addmul(qc, poly3 + x->i, p1 + x->j);
-                  }
-               }
-            }
-
-            /* temporarily store pointer to node, or designate for reuse */
-            if (x->i != -WORD(1) || x->j < len2 - 1)
-               Q[Q_len++] = x;
-            else
-               reuse[reuse_len++] = x;
-         }
-      }
-
-      /* for each node temporarily stored */
-      while (Q_len > 0)
-      {
-         /* take node from store */
-         x = Q[--Q_len];
-     
-         if (x->i == -WORD(1))
-         {
-            x->j++;
-            x->next = NULL;
-
-            /* insert (x->i, x->j + 1, exp2[x->j]) in heap */
-            exp_temp = exp2[x->j];
-
-            /* but only if monomial is big enough */
-            if ((exp_temp^maskhi) >= (exp3_lead^maskhi))
-               _mpoly_heap_insert1(heap, exp_temp, x,
+                /* take next dividend term */
+                if (j + 1 < len2)
+                {
+                    x = chain + 0;
+                    x->i = i;
+                    x->j = j + 1;
+                    x->next = NULL;
+                    _mpoly_heap_insert1(heap, exp2[x->j], x,
                                                  &next_loc, &heap_len, maskhi);
-         } else if (x->j < k - 1)
-         {
-            x->j++;
-            x->next = NULL;
-
-            /* insert (x->i, x->j + 1, exp3[x->i] + e1[x->j]) in heap */
-            exp_temp = exp3[x->i] + e1[x->j];
-
-            /* but only if monomial is big enough */
-            if ((exp_temp^maskhi) >= (exp3_lead^maskhi))
-               _mpoly_heap_insert1(heap, exp_temp, x,
+                }
+            } else
+            {
+                /* should we go right? */
+                if (  (i + 1 < len3)
+                   && (hind[i + 1] == 2*j + 1)
+                   )
+                {
+                    x = chain + i + 1;
+                    x->i = i + 1;
+                    x->j = j;
+                    x->next = NULL;
+                    hind[x->i] = 2*(x->j + 1) + 0;
+                    _mpoly_heap_insert1(heap, exp3[x->i] + e1[x->j], x,
                                                  &next_loc, &heap_len, maskhi);
-         } else if (x->j == k - 1)
-         {
-            s++;
-            
-            /* node x no longer needed, designate for reuse */
-            reuse[reuse_len++] = x;
-         }
-      }
+                }
+                /* should we go up? */
+                if (j + 1 == k)
+                {
+                    s++;
+                } else if (  1 /* (j + 1 < k) must be true */
+                          && ((hind[i] & 1) == 1)
+                          && ((i == 1) || (hind[i - 1] >= 2*(j + 2) + 1))
+                          )
+                {
+                    x = chain + i;
+                    x->i = i;
+                    x->j = j + 1;
+                    x->next = NULL;
+                    hind[x->i] = 2*(x->j + 1) + 0;
+                    _mpoly_heap_insert1(heap, exp3[x->i] + e1[x->j], x,
+                                                 &next_loc, &heap_len, maskhi);
+                }
+            }
+        }
 
-      /* if accumulated coeff is zero, no output coeff to be written */
-      if ((small && (c[2] == 0 && c[1] == 0 && c[0] == 0)) ||
-          (!small && fmpz_is_zero(qc)))
-         k--;
-      else /* accumulated coeff is nonzero */
-      {
-         /* check current exp divisible by leading exp of poly3... */
-         d1 = mpoly_monomial_divides1(e1 + k, exp, exp3_lead, mask);
-
-         /* ... if not, no quotient term */
-         if (!d1)
+        /* try to divide accumulated term by leading term */
+        if (!lt_divides)
+        {
             k--;
-         else /* monomial exact division, so quotient term */
-         {
-            /* if accumulated coeff in three words */
-            if (small)
+            continue;
+        }
+        if (small)
+        {
+            ulong d0, d1, ds = acc_sm[2];
+
+            /* d1:d0 = abs(acc_sm[1:0]) assuming ds is sign extension of acc_sm[1] */
+            sub_ddmmss(d1, d0, acc_sm[1]^ds, acc_sm[0]^ds, ds, ds);
+            
+            if ((acc_sm[0] | acc_sm[1] | acc_sm[2]) == 0)
             {
-               ulong d[3];
-
-               /* compute d = abs(c) */
-               if (0 > (slong) c[2])
-                  mpn_neg(d, c, 3);
-               else
-                  flint_mpn_copyi(d, c, 3);
-
-               /* check quotient of accumulated coeff by lc(poly3) is small */
-               if (d[2] != 0 || ub <= d[1] ||
-                  (ub == 0 && 0 > (slong) d[0])) /* quotient not a small */
-               {
-                  /* upgrade to multiprecision accumulated coeffs */
-                  fmpz_set_signed_uiuiui(qc, c[2], c[1], c[0]);
-
-                  small = 0;
-               } else /* quotient fits a small */
-               {
-                  ulong q, r1;
-
-                  /* compute quotient and discard remainder coeff */
-                  sdiv_qrnnd(q, r1, c[1], c[0], *mb);
-
-                  fmpz_set_si(p1 + k, q);
-
-                  if (COEFF_IS_MPZ(FLINT_ABS(q))) /* quotient too large */
-                  {
-                     /* upgrade to multiprecision accumulated coeffs */
-                     fmpz_set_signed_uiuiui(qc, c[2], c[1], c[0]);
-
-                     small = 0;
-                  }
-               }
-            } 
-
-            /* if accumulated coeff is multiprecision, incl. from upgrade */
-            if (!small)
-            {
-               /* write out quotient coeff */
-               fmpz_fdiv_q(p1 + k, qc, mb);
+                k--;
+                continue;
             }
 
-            /* if the quotient coeff was nonzero */
-            if (!fmpz_is_zero(p1 + k))
+            if (ds == FLINT_SIGN(acc_sm[1]) && d1 < lc_abs)
             {
-               /* see paper */
-               for (i = 1; i < s; i++)
-               {
-                  /* get an empty node, from reuse array if possible */
-                  if (reuse_len != 0)
-                     x2 = reuse[--reuse_len];
-                  else
-                     x2 = chain + next_free++;
-            
-                  x2->i = i;
-                  x2->j = k;
-                  x2->next = NULL;
+                ulong qq, rr, nhi, nlo;
+                nhi = (d1 << lc_norm) | (d0 >> (FLINT_BITS - lc_norm));
+                nlo = d0 << lc_norm;
+                udiv_qrnnd_preinv(qq, rr, nhi, nlo, lc_n, lc_i);
+                (void) rr;
+                if (qq == 0)
+                {
+                    k--;
+                    continue;
+                }
+                if ((qq & (WORD(3) << (FLINT_BITS - 2))) == 0)
+                {
+                    _fmpz_demote(p1 + k);
+                    p1[k] = (qq^ds^lc_sign) - (ds^lc_sign);
+                } else
+                {
+                    small = 0;
+                    fmpz_set_ui(p1 + k, qq);
+                    if (ds != lc_sign)
+                        fmpz_neg(p1 + k, p1 + k);
+                }
+            } else
+            {
+                small = 0;
+                fmpz_set_signed_uiuiui(acc_lg, acc_sm[2], acc_sm[1], acc_sm[0]);
+                goto large_lt_divides;
+            }
+        } else
+        {
+            if (fmpz_is_zero(acc_lg))
+            {
+                k--;
+                continue;
+            }
+large_lt_divides:
+            fmpz_fdiv_qr(p1 + k, r, acc_lg, poly3 + 0);
+            if (fmpz_is_zero(p1 + k))
+            {
+                k--;
+                continue;
+            }
+        }
 
-                  /* insert (i, k, exp3[i] + e1[k]) */
-                  exp_temp = exp3[i] + e1[k];
-
-                  /* but only if monomial is big enough */
-                  if ((exp_temp^maskhi) >= (exp3_lead^maskhi))
-                     _mpoly_heap_insert1(heap, exp_temp, x2,
+        /* put newly generated quotient term back into the heap if neccesary */
+        if (s > 1)
+        {
+            i = 1;
+            x = chain + i;
+            x->i = i;
+            x->j = k;
+            x->next = NULL;
+            hind[x->i] = 2*(x->j + 1) + 0;
+            _mpoly_heap_insert1(heap, exp3[x->i] + e1[x->j], x,
                                                  &next_loc, &heap_len, maskhi);
-               }
-               s = 1;
-            } else /* quotient coeff was zero, nothing to write out */
-               k--;
-         }
-      } 
-      
-      /* zero temporary accumulator */
-      fmpz_zero(qc);  
-   }
+        }
+        s = 1;
+    }
 
-   k++;
+    k++;
 
 cleanup:
 
-   fmpz_clear(mb);
-   fmpz_clear(qc);
+    fmpz_clear(acc_lg);
+    fmpz_clear(r);
 
-   (*polyq) = p1;
-   (*expq) = e1;
+    (*polyq) = p1;
+    (*expq) = e1;
 
-   TMP_END;
+    TMP_END;
 
-   /* return quotient poly length */
-   return k;
+    /* return quotient poly length */
+    return k;
+
+exp_overflow:
+    for (i = 0; i < k; i++)
+        _fmpz_demote(p1 + i);
+    k = -WORD(1);
+    goto cleanup;
 }
 
-/*
-   Set polyq to the quotient poly2 by poly3 discarding remainder (with notional
-   remainder coeffs reduced modulo the leading coeff of poly3), and return
-   the length of the quotient. This version of the function assumes the
-   exponent vectors all fit in "N" words. The exponent vectors are assumed to
-   have fields with the given number of bits. Assumes input polys are nonzero.
-   Implements "Polynomial division using dynamic arrays, heaps and packed
-   exponents" by Michael Monagan and Roman Pearce [1], except that we use a
-   heap with smallest exponent at head. Note that if a < b then
-   (n - b) < (n - b) where n is the maximum value a and b can take. The word
-   "maxn" is set to an exponent vector whose fields are all set to such a
-   value n. This allows division from left to right with a heap with smallest
-   exponent at the head. Quotient poly is written in reverse order.
-   [1] http://www.cecm.sfu.ca/~rpearcea/sdmp/sdmp_paper.pdf 
-*/
+
 slong _fmpz_mpoly_div_monagan_pearce(fmpz ** polyq,
            ulong ** expq, slong * allocq, const fmpz * poly2,
    const ulong * exp2, slong len2, const fmpz * poly3, const ulong * exp3, 
                    slong len3, slong bits, slong N, ulong maskhi, ulong masklo)
 {
-   slong i, k, s;
-   slong next_loc = len3 + 4;   /* something bigger than heap can ever be */
-   slong next_free, Q_len = 0;
-   slong reuse_len = 0, heap_len = 2; /* heap zero index unused */
-   mpoly_heap_s * heap;
-   mpoly_heap_t * chain;
-   mpoly_heap_t ** Q, ** reuse;
-   mpoly_heap_t * x, * x2;
-   fmpz * p1 = *polyq;
-   ulong * e1 = *expq;
-   ulong * exp, * exps, * texp, * tmp;
-   ulong ** exp_list;
-   ulong c[3]; /* for accumulating coefficients */
-   slong exp_next;
-   ulong mask = 0, ub;
-   fmpz_t mb, qc;
-   int small;
-   slong bits2, bits3;
-   int d1, divides;
-   TMP_INIT;
+    slong i, j, k, s;
+    slong next_loc;
+    slong heap_len = 2; /* heap zero index unused */
+    mpoly_heap_s * heap;
+    mpoly_heap_t * chain;
+    slong * store, * store_base;
+    mpoly_heap_t * x;
+    fmpz * p1 = *polyq;
+    ulong * e1 = *expq;
+    ulong * exp, * exps;
+    ulong ** exp_list;
+    slong exp_next;
+    ulong mask;
+    fmpz_t r, acc_lg;
+    ulong acc_sm[3];
+    slong * hind;
+    int lt_divides, small;
+    slong bits2, bits3;
+    ulong lc_norm, lc_abs, lc_sign, lc_n, lc_i;
+    TMP_INIT;
 
-   /* if exponent vectors fit in one word, call specialised version */
-   if (N == 1)
-      return _fmpz_mpoly_div_monagan_pearce1(polyq, expq, allocq,
+    /* if exponent vectors fit in one word, call specialised version */
+    if (N == 1)
+        return _fmpz_mpoly_div_monagan_pearce1(polyq, expq, allocq,
                            poly2, exp2, len2, poly3, exp3, len3, bits, maskhi);
 
-   TMP_START;
+    TMP_START;
 
-   fmpz_init(mb);
-   fmpz_init(qc);
+    fmpz_init(acc_lg);
+    fmpz_init(r);
 
-   /* whether intermediate computations q - a*b will fit in three words */
-   bits2 = _fmpz_vec_max_bits(poly2, len2);
-   bits3 = _fmpz_vec_max_bits(poly3, len3);
-   /* allow one bit for sign, one bit for subtraction */
-   small = FLINT_ABS(bits2) <= (FLINT_ABS(bits3) + 
-           FLINT_BIT_COUNT(len3) + FLINT_BITS - 2) &&
-           FLINT_ABS(bits3) <= FLINT_BITS - 2;
+    /* whether intermediate computations q - a*b will fit in three words */
+    bits2 = _fmpz_vec_max_bits(poly2, len2);
+    bits3 = _fmpz_vec_max_bits(poly3, len3);
+    /* allow one bit for sign, one bit for subtraction */
+    small = FLINT_ABS(bits2) <= (FLINT_ABS(bits3) + FLINT_BIT_COUNT(len3) + FLINT_BITS - 2)
+         && FLINT_ABS(bits3) <= FLINT_BITS - 2;
 
-   heap = (mpoly_heap_s *) TMP_ALLOC((len3 + 1)*sizeof(mpoly_heap_s));
-   /* alloc array of heap nodes which can be chained together */
-   chain = (mpoly_heap_t *) TMP_ALLOC(len3*sizeof(mpoly_heap_t));
-   /* space for temporary storage of pointers to heap nodes */
-   Q = (mpoly_heap_t **) TMP_ALLOC(len3*sizeof(mpoly_heap_t *));
-   /* space for pointers to heap nodes which can be reused */
-   reuse = (mpoly_heap_t **) TMP_ALLOC(len3*sizeof(mpoly_heap_t *));
-   /* array of exponents of N words each */
-   exps = (ulong *) TMP_ALLOC(len3*N*sizeof(ulong));
-   /* array of pointers to unused exponent vectors */
-   exp_list = (ulong **) TMP_ALLOC(len3*sizeof(ulong *));
-   /* space for temporary exponent vectors, for exponent computations */
-   texp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-   texp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-   tmp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-   /* space to save copy of current exponent vector */
-   exp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
 
-   /* set up list of available exponent vectors */
-   for (i = 0; i < len3; i++)
-      exp_list[i] = exps + i*N;
+    /* alloc array of heap nodes which can be chained together */
+    next_loc = len3 + 4;   /* something bigger than heap can ever be */
+    heap = (mpoly_heap_s *) TMP_ALLOC((len3 + 1)*sizeof(mpoly_heap_s));
+    chain = (mpoly_heap_t *) TMP_ALLOC(len3*sizeof(mpoly_heap_t));
+    store = store_base = (slong *) TMP_ALLOC(2*len3*sizeof(mpoly_heap_t *));
 
-   /* start with no heap nodes and no exponent vectors in use */
-   next_free = 0;
-   exp_next = 0;
+    /* array of exponent vectors, each of "N" words */
+    exps = (ulong *) TMP_ALLOC(len3*N*sizeof(ulong));
+    /* list of pointers to available exponent vectors */
+    exp_list = (ulong **) TMP_ALLOC(len3*sizeof(ulong *));
+    /* space to save copy of current exponent vector */
+    exp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
+    /* set up list of available exponent vectors */
+    exp_next = 0;
+    for (i = 0; i < len3; i++)
+        exp_list[i] = exps + i*N;
 
-   /* mask with high bit set in each field of exponent vector */
-   for (i = 0; i < FLINT_BITS/bits; i++)
-      mask = (mask << bits) + (UWORD(1) << (bits - 1));
+    /* space for flagged heap indicies */
+    hind = (slong *) TMP_ALLOC(len3*sizeof(slong));
+    for (i = 0; i < len3; i++)
+        hind[i] = 1;
 
-   /* quotient and poly index starts at -1 */
-   k = -WORD(1);
+    /* mask with high bit set in each word of each field of exponent vector */
+    mask = 0;
+    for (i = 0; i < FLINT_BITS/bits; i++)
+        mask = (mask << bits) + (UWORD(1) << (bits - 1));
+
+    /* quotient and poly index starts at -1 */
+    k = -WORD(1);
    
-   /* see description of divisor heap division in paper */
-   s = len3;
+    /* s is the number of terms * (latest quotient) we should put into heap */
+    s = len3;
    
-   /* insert (-1, 0, exp2[0]) into heap */
-   x = chain + next_free++;
-   x->i = -WORD(1);
-   x->j = 0;
-   x->next = NULL;
+    /* insert (-1, 0, exp2[0]) into heap */
+    x = chain + 0;
+    x->i = -WORD(1);
+    x->j = 0;
+    x->next = NULL;
+    heap[1].next = x;
+    heap[1].exp = exp_list[exp_next++];
+    mpoly_monomial_set(heap[1].exp, exp2, N);
 
-   heap[1].next = x;
-   heap[1].exp = exp_list[exp_next++];
+    /* precompute leading cofficient info assuming "small" case */
+    lc_abs = FLINT_ABS(poly3[0]);
+    lc_sign = FLINT_SIGN(poly3[0]);
+    count_leading_zeros(lc_norm, lc_abs);
+    lc_n = lc_abs << lc_norm;
+    invert_limb(lc_i, lc_n);
 
-   mpoly_monomial_set(heap[1].exp, exp2, N);
+    while (heap_len > 1)
+    {
+        mpoly_monomial_set(exp, heap[1].exp, N);
 
-   /* precompute -c_n where c_n is the leading coeff of poly3 */
-   fmpz_neg(mb, poly3);
-
-   ub = ((ulong) FLINT_ABS(*mb)) >> 1; /* abs(lc(poly3))/2 */
-   
-   /* precompute leading exponent of poly3 */
-   mpoly_monomial_set(texp, exp3, N);
-
-   /* while heap is nonempty */
-   while (heap_len > 1)
-   {
-      /* make temporary copy of exponent at top of heap */
-      mpoly_monomial_set(exp, heap[1].exp, N);
+        if (mpoly_monomial_overflows(exp, N, mask))
+            goto exp_overflow;
       
-      /* check there has been no overflow */
-      if (mpoly_monomial_overflows(exp, N, mask))
-      {
-         for (i = 0; i < k; i++)
-            _fmpz_demote(p1 + i);
+        k++;
+        _fmpz_mpoly_fit_length(&p1, &e1, allocq, k + 1, N);
 
-         k = -WORD(1);
+        lt_divides = mpoly_monomial_divides(e1 + k*N, exp, exp3, N, mask);
 
-         goto cleanup2;
-      }
-
-      divides = mpoly_monomial_divides(tmp, exp, texp, N, mask);
-
-      /* realloc quotient poly, for next quotient term */
-      k++;
-      _fmpz_mpoly_fit_length(&p1, &e1, allocq, k + 1, N);
-
-      /* set temporary coeff to zero */
-      c[0] = c[1] = c[2] = 0;
-
-      /* while heap nonempty and contains chain with current output exponent */
-      while (heap_len > 1 && mpoly_monomial_equal(heap[1].exp, exp, N))
-      {
-         /* put pointer to exponent at heap top into list of available exps */
-         exp_list[--exp_next] = heap[1].exp;
-
-         /* pop chain from heap */
-         x = _mpoly_heap_pop(heap, &heap_len, N, maskhi, masklo);
-
-         if (divides)
-         {
-            /* if accumulated coeffs will fit in three words */
-            if (small)
+        /* take nodes from heap with exponent matching exp */
+        if (small) 
+        {
+            acc_sm[0] = acc_sm[1] = acc_sm[2] = 0;
+            do
             {
-               if (x->i == -WORD(1))
-               {
-                  /* subtract poly2 coeff from accumulated three word coeff */
-                  _fmpz_mpoly_sub_uiuiui_fmpz(c, poly2 + x->j);
-               } else
-               {
-                  /* subtract q[j]*poly3 coeff from accum. three word coeff */
-                  _fmpz_mpoly_addmul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
-               }
-            } else /* accumulated coeffs are multiprecision */
+                exp_list[--exp_next] = heap[1].exp;
+                x = _mpoly_heap_pop(heap, &heap_len, N, maskhi, masklo);
+                do
+                {
+                    *store++ = x->i;
+                    *store++ = x->j;
+                    if (x->i != -WORD(1))
+                        hind[x->i] |= WORD(1);
+
+                    if (x->i == -WORD(1))
+                        _fmpz_mpoly_add_uiuiui_fmpz(acc_sm, poly2 + x->j);
+                    else
+                        _fmpz_mpoly_submul_uiuiui_fmpz(acc_sm, poly3[x->i], p1[x->j]);
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && mpoly_monomial_equal(heap[1].exp, exp, N));
+        } else
+        {
+            fmpz_zero(acc_lg);
+            do
             {
-              if (x->i == -WORD(1))
-               {
-                  /* subtract poly2 coeff from accum. coeff */
-                  fmpz_sub(qc, qc, poly2 + x->j);
-               } else
-               {
-                  /* subtract q[j]*poly3 coeff from accum. coeff */
-                  fmpz_addmul(qc, poly3 + x->i, p1 + x->j);
-               }
-            }
-         }
+                exp_list[--exp_next] = heap[1].exp;
+                x = _mpoly_heap_pop(heap, &heap_len, N, maskhi, masklo);
+                do
+                {
+                    *store++ = x->i;
+                    *store++ = x->j;
+                    if (x->i != -WORD(1))
+                        hind[x->i] |= WORD(1);
 
-         /* temporarily store pointer to this node, or designate for reuse */
-         if (x->i != -WORD(1) || x->j < len2 - 1)
-            Q[Q_len++] = x;
-         else
-            reuse[reuse_len++] = x;
+                    if (x->i == -WORD(1))
+                        fmpz_add(acc_lg, acc_lg, poly2 + x->j);
+                    else
+                        fmpz_submul(acc_lg, poly3 + x->i, p1 + x->j);
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && mpoly_monomial_equal(heap[1].exp, exp, N));
+        }
 
-         while ((x = x->next) != NULL)
-         {
-            if (divides)
+        /* process nodes taken from the heap */
+        while (store > store_base)
+        {
+            j = *--store;
+            i = *--store;
+
+            if (i == -WORD(1))
             {
-               /* if accumulated coeffs will fit in three words */
-               if (small)
-               {
-                  if (x->i == -WORD(1))
-                  {
-                     /* subtract poly2 coeff from accumulated three word coeff */
-                     _fmpz_mpoly_sub_uiuiui_fmpz(c, poly2 + x->j);
-                  } else
-                  {
-                     /* subtract q[j]*poly3 coeff from accum. three word coeff */
-                     _fmpz_mpoly_addmul_uiuiui_fmpz(c, poly3[x->i], p1[x->j]);
-                  }
-               } else /* accumulated coeffs are multiprecision */
-               {
-                  if (x->i == -WORD(1))
-                  {
-                     /* subtract poly2 coeff from accum. coeff */
-                     fmpz_sub(qc, qc, poly2 + x->j);
-                  } else
-                  {
-                     /* subtract q[j]*poly3 coeff from accum. coeff */
-                     fmpz_addmul(qc, poly3 + x->i, p1 + x->j);
-                  }
-               }
-            }
-
-            /* temporarily store pointer to node, or designate for reuse */
-            if (x->i != -WORD(1) || x->j < len2 - 1)
-               Q[Q_len++] = x;
-            else
-               reuse[reuse_len++] = x;
-         }
-      }
-
-      /* for each node temporarily stored */
-      while (Q_len > 0)
-      {
-         /* take node from store */
-         x = Q[--Q_len];
-     
-         if (x->i == -WORD(1))
-         {
-            x->j++;
-            x->next = NULL;
-
-            /* insert (x->i, x->j + 1, exp2[x->j]) in heap */
-            mpoly_monomial_set(exp_list[exp_next], exp2 + x->j*N, N);
-
-            /* but only if the exponent is big enough */
-            if (!mpoly_monomial_lt(texp, exp_list[exp_next], N, maskhi, masklo))
-            {
-               if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
-                                      &next_loc, &heap_len, N, maskhi, masklo))
-                  exp_next--;
-            }
-         } else if (x->j < k - 1)
-         {
-            x->j++;
-            x->next = NULL;
-
-            /* insert (x->i, x->j + 1, exp3[x->i] + e1[x->j]) in heap */
-            mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N, e1 + x->j*N, N);
-
-            /* but only if exponent is big enough */
-            if (!mpoly_monomial_lt(texp, exp_list[exp_next], N, maskhi, masklo))
-            {
-               if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
-                                      &next_loc, &heap_len, N, maskhi, masklo))
-               exp_next--;
-            }
-         } else if (x->j == k - 1)
-         {
-            s++;
-            
-            /* node x no longer needed, designate for reuse */
-            reuse[reuse_len++] = x;
-         }
-      }
-
-      /* if accumulated coeff is zero, no quotient coeff to be written */
-      if ((small && (c[2] == 0 && c[1] == 0 && c[0] == 0)) ||
-         (!small && fmpz_is_zero(qc)))
-         k--;
-      else /* accumulated coeff is nonzero */
-      {
-         /* check current exp divisible by leading exp of poly3... */
-         d1 = mpoly_monomial_divides(e1 + k*N, exp, texp, N, mask);
-
-         /* ... if not, no quotient term to be written */
-         if (!d1)
-            k--;
-         else
-         {
-            /* if accumulated coeff in three words */
-            if (small)
-            {
-               ulong d[3];
-
-               /* compute d = abs(c) */
-               if (0 > (slong) c[2])
-                  mpn_neg(d, c, 3);
-               else
-                  flint_mpn_copyi(d, c, 3);
-
-               /* check quotient of accumulated coeff by lc(poly3) is small */
-               if (d[2] != 0 || ub <= d[1] ||
-                  (ub == 0 && 0 > (slong) d[0])) /* quotient not a small */
-               {
-                  /* upgrade to multiprecision accumulated coeffs */
-                  fmpz_set_signed_uiuiui(qc, c[2], c[1], c[0]);
-
-                  small = 0;
-               } else /* quotient fits a small */
-               {
-                  ulong q, r1;
-
-                  /* write out quotient coefficient and discard remainder */
-                  sdiv_qrnnd(q, r1, c[1], c[0], *mb);
-
-                  fmpz_set_si(p1 + k, q);
-
-                  if (COEFF_IS_MPZ(FLINT_ABS(q))) /* quotient too large */
-                  {
-                     /* upgrade to multiprecision accumulated coeffs */
-                     fmpz_set_signed_uiuiui(qc, c[2], c[1], c[0]);
-
-                     small = 0;
-                  }
-               }
-            } 
-
-            /* if accumulated coeff is multiprecision, incl. from upgrade */
-            if (!small)
-            {
-               /* write out quotient coefficient */
-               fmpz_fdiv_q(p1 + k, qc, mb);
-            }
-
-            /* if quotient coefficient nonzero */
-            if (!fmpz_is_zero(p1 + k))
-            {
-               /* see paper */
-               for (i = 1; i < s; i++)
-               {
-                  /* get an empty node, from reuse array if possible */
-                  if (reuse_len != 0)
-                     x2 = reuse[--reuse_len];
-                  else
-                     x2 = chain + next_free++;
-            
-                  x2->i = i;
-                  x2->j = k;
-                  x2->next = NULL;
-
-                  /* insert (i, k, exp3[i] + e1[k]) */
-                  mpoly_monomial_add(exp_list[exp_next], exp3 + i*N, e1 + k*N, N);
-
-                  /* but only if exponent is big enough */
-                  if (!mpoly_monomial_lt(texp, exp_list[exp_next], N,
-                                                               maskhi, masklo))
-                  {
-                     if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x2,
+                /* take next dividend term */
+                if (j + 1 < len2)
+                {
+                    x = chain + 0;
+                    x->i = i;
+                    x->j = j + 1;
+                    x->next = NULL;
+                    mpoly_monomial_set(exp_list[exp_next], exp2 + x->j*N, N);
+                    if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
                                       &next_loc, &heap_len, N, maskhi, masklo))
                         exp_next--;
-                  }
-               }
-               s = 1;
-            } else /* quotient coeff was zero, nothing to write out */
-               k--;
-         }
-      } 
-      
-      /* zero temporary accumulator */
-      fmpz_zero(qc);  
-   }
+                }
+            } else
+            {
+                /* should we go up */
+                if (  (i + 1 < len3)
+                   && (hind[i + 1] == 2*j + 1)
+                   )
+                {
+                    x = chain + i + 1;
+                    x->i = i + 1;
+                    x->j = j;
+                    x->next = NULL;
+                    hind[x->i] = 2*(x->j + 1) + 0;
+                    mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
+                                                           e1   + x->j*N, N);
+                    if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
+                                      &next_loc, &heap_len, N, maskhi, masklo))
+                        exp_next--;
+                }
+                /* should we go up? */
+                if (j + 1 == k)
+                {
+                    s++;
+                } else if (  1 /* (j + 1 < k) is always true */
+                          && ((hind[i] & 1) == 1)
+                          && ((i == 1) || (hind[i - 1] >= 2*(j + 2) + 1))
+                          )
+                {
+                    x = chain + i;
+                    x->i = i;
+                    x->j = j + 1;
+                    x->next = NULL;
+                    hind[x->i] = 2*(x->j + 1) + 0;
+                    mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
+                                                           e1   + x->j*N, N);
+                    if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
+                                      &next_loc, &heap_len, N, maskhi, masklo))
+                        exp_next--;
+                }
+            }
+        }
 
-   k++;
+        /* try to divide accumulated term by leading term */
+        if (!lt_divides)
+        {
+            k--;
+            continue;
+        }
+        if (small)
+        {
+            ulong d0, d1, ds = acc_sm[2];
 
-cleanup2:
+            /* d1:d0 = abs(acc_sm[1:0]) assuming ds is sign extension of acc_sm[1] */
+            sub_ddmmss(d1, d0, acc_sm[1]^ds, acc_sm[0]^ds, ds, ds);
+            
+            if ((acc_sm[0] | acc_sm[1] | acc_sm[2]) == 0)
+            {
+                k--;
+                continue;
+            }
 
-   fmpz_clear(mb);
-   fmpz_clear(qc);
+            if (ds == FLINT_SIGN(acc_sm[1]) && d1 < lc_abs)
+            {
+                ulong qq, rr, nhi, nlo;
+                nhi = (d1 << lc_norm) | (d0 >> (FLINT_BITS - lc_norm));
+                nlo = d0 << lc_norm;
+                udiv_qrnnd_preinv(qq, rr, nhi, nlo, lc_n, lc_i);
+                (void) rr;
+                if (qq == 0)
+                {
+                    k--;
+                    continue;
+                }
+                if ((qq & (WORD(3) << (FLINT_BITS - 2))) == 0)
+                {
+                    _fmpz_demote(p1 + k);
+                    p1[k] = (qq^ds^lc_sign) - (ds^lc_sign);
+                } else
+                {
+                    small = 0;
+                    fmpz_set_ui(p1 + k, qq);
+                    if (ds != lc_sign)
+                        fmpz_neg(p1 + k, p1 + k);
+                }
+            } else
+            {
+                small = 0;
+                fmpz_set_signed_uiuiui(acc_lg, acc_sm[2], acc_sm[1], acc_sm[0]);
+                goto large_lt_divides;
+            }
+        } else
+        {
+            if (fmpz_is_zero(acc_lg))
+            {
+                k--;
+                continue;
+            }
+large_lt_divides:
+            fmpz_fdiv_qr(p1 + k, r, acc_lg, poly3 + 0);
+            if (fmpz_is_zero(p1 + k))
+            {
+                k--;
+                continue;
+            }
+        }
 
-   (*polyq) = p1;
-   (*expq) = e1;
-   
-   TMP_END;
+        /* put newly generated quotient term back into the heap if neccesary */
+        if (s > 1)
+        {
+            i = 1;
+            x = chain + i;
+            x->i = i;
+            x->j = k;
+            x->next = NULL;
+            hind[x->i] = 2*(x->j + 1) + 0;
+            mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
+                                                   e1   + x->j*N, N);
+            if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
+                                  &next_loc, &heap_len, N, maskhi, masklo))
+                exp_next--;
+        }
+        s = 1;
+    }
 
-   /* return quotient poly length */
-   return k;
+    k++;
+
+cleanup:
+
+    fmpz_clear(acc_lg);
+    fmpz_clear(r);
+
+    (*polyq) = p1;
+    (*expq) = e1;
+
+    TMP_END;
+
+    /* return quotient poly length */
+    return k;
+
+exp_overflow:
+    for (i = 0; i < k; i++)
+        _fmpz_demote(p1 + i);
+    k = -WORD(1);
+    goto cleanup;
+
 }
 
 void fmpz_mpoly_div_monagan_pearce(fmpz_mpoly_t q, const fmpz_mpoly_t poly2, 

--- a/fmpz_mpoly/divides_monagan_pearce.c
+++ b/fmpz_mpoly/divides_monagan_pearce.c
@@ -316,9 +316,9 @@ slong _fmpz_mpoly_divides_monagan_pearce(fmpz ** poly1, ulong ** exp1,
     ulong * e1 = *exp1;
     ulong * exp, * exps;
     ulong ** exp_list;
+    slong exp_next;
     fmpz_t r, acc_lg;
     ulong acc_sm[3];
-    slong exp_next;
     ulong mask;
     slong * hind;
     int lt_divides, small;

--- a/fmpz_mpoly/divides_monagan_pearce.c
+++ b/fmpz_mpoly/divides_monagan_pearce.c
@@ -88,7 +88,6 @@ slong _fmpz_mpoly_divides_monagan_pearce1(fmpz ** poly1, ulong ** exp1,
     x->i = -WORD(1);
     x->j = 0;
     x->next = NULL;
-
     HEAP_ASSIGN(heap[1], exp2[0], x);
 
     /* precompute leading cofficient info assuming "small" case */
@@ -227,16 +226,15 @@ slong _fmpz_mpoly_divides_monagan_pearce1(fmpz ** poly1, ulong ** exp1,
                 if (rr != WORD(0))
                     goto not_exact_division;
 
-                ds ^= lc_sign;
                 if ((qq & (WORD(3) << (FLINT_BITS - 2))) == WORD(0))
                 {
                     _fmpz_demote(p1 + k);
-                    p1[k] = (qq^ds) - ds;
+                    p1[k] = (qq^ds^lc_sign) - (ds^lc_sign);
                 } else
                 {
                     small = 0;
                     fmpz_set_ui(p1 + k, qq);
-                    if (ds != WORD(0))
+                    if (ds != lc_sign)
                         fmpz_neg(p1 + k, p1 + k);
                 }
             } else
@@ -528,16 +526,15 @@ slong _fmpz_mpoly_divides_monagan_pearce(fmpz ** poly1, ulong ** exp1,
                 if (rr != WORD(0))
                     goto not_exact_division;
 
-                ds ^= lc_sign;
                 if ((qq & (WORD(3) << (FLINT_BITS - 2))) == WORD(0))
                 {
                     _fmpz_demote(p1 + k);
-                    p1[k] = (qq^ds) - ds;
+                    p1[k] = (qq^ds^lc_sign) - (ds^lc_sign);
                 } else
                 {
                     small = 0;
                     fmpz_set_ui(p1 + k, qq);
-                    if (ds != WORD(0))
+                    if (ds != lc_sign)
                         fmpz_neg(p1 + k, p1 + k);
                 }
             } else

--- a/fmpz_mpoly/divides_monagan_pearce.c
+++ b/fmpz_mpoly/divides_monagan_pearce.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2017 William Hart
+    Copyright (C) 2017 Daniel Schultz
 
     This file is part of FLINT.
 
@@ -187,8 +187,7 @@ slong _fmpz_mpoly_divides_monagan_pearce1(fmpz ** poly1, ulong ** exp1,
                 if (j + 1 == k)
                 {
                     s++;
-                } else if (  1 /* (j + 1 < k) must be true */
-                          && ((hind[i] & 1) == 1)
+                } else if (  ((hind[i] & 1) == 1)
                           && ((i == 1) || (hind[i - 1] >= 2*(j + 2) + 1))
                           )
                 {
@@ -484,8 +483,7 @@ slong _fmpz_mpoly_divides_monagan_pearce(fmpz ** poly1, ulong ** exp1,
                 if (j + 1 == k)
                 {
                     s++;
-                } else if (  1 /* (j + 1 < k) is always true */
-                          && ((hind[i] & 1) == 1)
+                } else if (  ((hind[i] & 1) == 1)
                           && ((i == 1) || (hind[i - 1] >= 2*(j + 2) + 1))
                           )
                 {

--- a/fmpz_mpoly/divides_monagan_pearce.c
+++ b/fmpz_mpoly/divides_monagan_pearce.c
@@ -93,7 +93,7 @@ slong _fmpz_mpoly_divides_monagan_pearce1(fmpz ** poly1, ulong ** exp1,
 
     /* precompute leading cofficient info assuming "small" case */
     lc_abs = FLINT_ABS(poly3[0]);
-    lc_sign = -((slong)(poly3[0]) < 0);
+    lc_sign = FLINT_SIGN(poly3[0]);
     count_leading_zeros(lc_norm, lc_abs);
     lc_n = lc_abs << lc_norm;
     invert_limb(lc_i, lc_n);
@@ -218,7 +218,7 @@ slong _fmpz_mpoly_divides_monagan_pearce1(fmpz ** poly1, ulong ** exp1,
                 continue;
             }
 
-            if (ds == -((slong)acc_sm[1] < 0) && d1 < lc_abs)
+            if (ds == FLINT_SIGN(acc_sm[1]) && d1 < lc_abs)
             {
                 ulong qq, rr, nhi, nlo;
                 nhi = (d1 << lc_norm) | (d0 >> (FLINT_BITS - lc_norm));
@@ -385,7 +385,7 @@ slong _fmpz_mpoly_divides_monagan_pearce(fmpz ** poly1, ulong ** exp1,
 
     /* precompute leading cofficient info assuming "small" case */
     lc_abs = FLINT_ABS(poly3[0]);
-    lc_sign = -((slong)(poly3[0]) < 0);
+    lc_sign = FLINT_SIGN(poly3[0]);
     count_leading_zeros(lc_norm, lc_abs);
     lc_n = lc_abs << lc_norm;
     invert_limb(lc_i, lc_n);
@@ -519,7 +519,7 @@ slong _fmpz_mpoly_divides_monagan_pearce(fmpz ** poly1, ulong ** exp1,
                 continue;
             }
 
-            if (ds == -((slong)acc_sm[1] < 0) && d1 < lc_abs)
+            if (ds == FLINT_SIGN(acc_sm[1]) && d1 < lc_abs)
             {
                 ulong qq, rr, nhi, nlo;
                 nhi = (d1 << lc_norm) | (d0 >> (FLINT_BITS - lc_norm));

--- a/fmpz_mpoly/divrem_ideal_monagan_pearce.c
+++ b/fmpz_mpoly/divrem_ideal_monagan_pearce.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2017 William Hart
+    Copyright (C) 2017 Daniel Schultz
 
     This file is part of FLINT.
 
@@ -27,322 +27,280 @@ slong _fmpz_mpoly_divrem_ideal_monagan_pearce1(fmpz_mpoly_struct ** polyq,
        ulong * const * exp3, slong len, slong bits, const fmpz_mpoly_ctx_t ctx,
                                                                   ulong maskhi)
 {
-   slong i, l, w;
-   slong next_loc;
-   slong next_free, Q_len = 0, len3;
-   slong reuse_len = 0, heap_len = 2; /* heap zero index unused */
-   mpoly_heap1_s * heap;
-   mpoly_nheap_t * chain;
-   mpoly_nheap_t ** Q, ** reuse;
-   mpoly_nheap_t * x, * x2;
-   fmpz * p2 = *polyr;
-   ulong * e2 = *expr;
-   ulong exp, texp;
-   ulong c[3]; /* for accumulating coefficients */
-   ulong mask = 0;
-   ulong * ub;
-   slong * k, * s;
-   fmpz_t qc, q;
-   fmpz * mb;
-   int small;
-   slong bits2, bits3;
-   int d1, d2, div_flag;
-   TMP_INIT;
+    slong i, j, p, l, w;
+    slong next_loc;
+    slong * store, * store_base;
+    slong len3;
+    slong heap_len = 2; /* heap zero index unused */
+    mpoly_heap1_s * heap;
+    mpoly_nheap_t ** chains;
+    slong ** hinds;
+    mpoly_nheap_t * x;
+    fmpz * p2 = *polyr;
+    ulong * e2 = *expr;
+    ulong exp, texp;
+    ulong c[3]; /* for accumulating coefficients */
+    ulong mask;
+    ulong * ub;
+    slong * k, * s;
+    fmpz_t qc, q;
+    fmpz * mb;
+    int small;
+    slong bits2, bits3;
+    int d1, d2, div_flag;
+    TMP_INIT;
 
-   TMP_START;
+    TMP_START;
 
-   fmpz_init(q);
-   fmpz_init(qc);
 
-   bits2 = _fmpz_vec_max_bits(poly2, len2);
-   
-   bits3 = 0;
-   len3 = 0;
-   for (i = 0; i < len; i++)
-   {
-      slong b = FLINT_ABS(fmpz_mpoly_max_bits(poly3[i]));
-      bits3 = FLINT_MAX(bits3, b);
-      len3 += poly3[i]->length;
-   }
+    fmpz_init(q);
+    fmpz_init(qc);
+
+    bits2 = _fmpz_vec_max_bits(poly2, len2);
+
+    chains = (mpoly_nheap_t **) TMP_ALLOC(len*sizeof(mpoly_nheap_t *));
+    hinds = (slong **) TMP_ALLOC(len*sizeof(mpoly_heap_t *));
+
+    bits3 = 0;
+    len3 = 0;
+    for (w = 0; w < len; w++)
+    {
+        chains[w] = (mpoly_nheap_t *) TMP_ALLOC((poly3[w]->length)*sizeof(mpoly_nheap_t));
+        hinds[w] = (slong *) TMP_ALLOC((poly3[w]->length)*sizeof(slong));
+        bits3 = FLINT_MAX(bits3, FLINT_ABS(fmpz_mpoly_max_bits(poly3[w])));
+        len3 += poly3[w]->length;
+        for (i = 0; i < poly3[w]->length; i++)
+            hinds[w][i] = 1;
+    }
       
-   /* allow one bit for sign, one bit for subtraction */
-   small = FLINT_ABS(bits2) <= (FLINT_ABS(bits3) +
-           FLINT_BIT_COUNT(len3) + FLINT_BITS - 2) &&
-           FLINT_ABS(bits3) <= FLINT_BITS - 2;
+    /* allow one bit for sign, one bit for subtraction */
+    small = FLINT_ABS(bits2) <= (FLINT_ABS(bits3) + FLINT_BIT_COUNT(len3) + FLINT_BITS - 2)
+          && FLINT_ABS(bits3) <= FLINT_BITS - 2;
 
-   next_loc = len3 + 4;   /* something bigger than heap can ever be */
-   heap = (mpoly_heap1_s *) TMP_ALLOC((len3 + 1)*sizeof(mpoly_heap1_s));
-   chain = (mpoly_nheap_t *) TMP_ALLOC(len3*sizeof(mpoly_nheap_t));
-   Q = (mpoly_nheap_t **) TMP_ALLOC(len3*sizeof(mpoly_nheap_t *));
-   reuse = (mpoly_nheap_t **) TMP_ALLOC(len3*sizeof(mpoly_nheap_t *));
-   k = (slong *) TMP_ALLOC(len*sizeof(slong));
-   s = (slong *) TMP_ALLOC(len*sizeof(slong));
-   ub = (ulong *) TMP_ALLOC(len*sizeof(ulong));
-   mb = (fmpz * ) TMP_ALLOC(len*sizeof(fmpz));
+    next_loc = len3 + 4;   /* something bigger than heap can ever be */
+    heap = (mpoly_heap1_s *) TMP_ALLOC((len3 + 1)*sizeof(mpoly_heap1_s));
+    store = store_base = (slong *) TMP_ALLOC(3*len3*sizeof(mpoly_nheap_t *));
 
-   next_free = 0;
+    k = (slong *) TMP_ALLOC(len*sizeof(slong));
+    s = (slong *) TMP_ALLOC(len*sizeof(slong));
+    ub = (ulong *) TMP_ALLOC(len*sizeof(ulong));
+    mb = (fmpz * ) TMP_ALLOC(len*sizeof(fmpz));
 
-   for (i = 0; i < FLINT_BITS/bits; i++)
-      mask = (mask << bits) + (UWORD(1) << (bits - 1));
+    mask = 0;
+    for (i = 0; i < FLINT_BITS/bits; i++)
+        mask = (mask << bits) + (UWORD(1) << (bits - 1));
 
-   for (i = 0; i < len; i++)
-   {
-      k[i] = -WORD(1);
-      s[i] = poly3[i]->length;
-   }
-   l = -WORD(1);
+    for (w = 0; w < len; w++)
+    {
+        k[w] = -WORD(1);
+        s[w] = poly3[w]->length;
+    }
+    l = -WORD(1);
    
-   x = chain + next_free++;
-   x->i = -WORD(1);
-   x->j = 0;
-   x->p = -WORD(1);
-   x->next = NULL;
+    x = chains[0] + 0;
+    x->i = -WORD(1);
+    x->j = 0;
+    x->p = -WORD(1);
+    x->next = NULL;
+    HEAP_ASSIGN(heap[1], exp2[0], x);
 
-   HEAP_ASSIGN(heap[1], exp2[0], x);
+    for (i = 0; i < len; i++)
+    {
+        fmpz_init(mb + i);
+        fmpz_neg(mb + i, poly3[i]->coeffs);
+        ub[i] = ((ulong) FLINT_ABS(mb[i])) >> 1; /* abs(poly3[0])/2 */
+    }
 
-   for (i = 0; i < len; i++)
-   {
-      fmpz_init(mb + i);
+    while (heap_len > 1)
+    {
+        exp = heap[1].exp;
+        if (mpoly_monomial_overflows1(exp, mask))
+            goto exp_overflow;
 
-      fmpz_neg(mb + i, poly3[i]->coeffs);
-
-      ub[i] = ((ulong) FLINT_ABS(mb[i])) >> 1; /* abs(poly3[0])/2 */
-   }
-
-   while (heap_len > 1)
-   {
-      exp = heap[1].exp;
-
-      /* check there has been no overflow */
-      if ((exp & mask) != 0)
-      {
-         for (i = 0; i < l; i++)
-               _fmpz_demote(p2 + i);
-         for (w = 0; w < len; w++)
-         {
-            for (i = 0; i < k[w]; i++)
-               _fmpz_demote(polyq[w]->coeffs + i);
-
-            k[w] = -WORD(1); /* we add 1 to this before exit */
-         }
-
-         l = -WORD(2); /* we add 1 to this upon return */
-
-         goto cleanup;
-      }
-
-      c[0] = c[1] = c[2] = 0;
-
-      while (heap_len > 1 && heap[1].exp == exp)
-      {
-         x = _mpoly_heap_pop1(heap, &heap_len, maskhi);
-
-         if (small)
-         {
-            if (x->i == -WORD(1))
-               _fmpz_mpoly_sub_uiuiui_fmpz(c, poly2 + x->j);
-            else
-            {   _fmpz_mpoly_addmul_uiuiui_fmpz(c,
-                         poly3[x->p]->coeffs[x->i], polyq[x->p]->coeffs[x->j]);
-            }
-         } else
-         {
-            if (x->i == -WORD(1))
-               fmpz_sub(qc, qc, poly2 + x->j);
-            else
-               fmpz_addmul(qc, poly3[x->p]->coeffs + x->i,
-                                                   polyq[x->p]->coeffs + x->j);
-         }
-
-         if (x->i != -WORD(1) || x->j < len2 - 1)
-            Q[Q_len++] = x;
-         else
-            reuse[reuse_len++] = x;
-
-         while ((x = x->next) != NULL)
-         {
-            if (small)
+        c[0] = c[1] = c[2] = 0;
+        fmpz_zero(qc);
+        while (heap_len > 1 && heap[1].exp == exp)
+        {
+            x = _mpoly_heap_pop1(heap, &heap_len, maskhi);
+            do
             {
-               if (x->i == -WORD(1))
-                  _fmpz_mpoly_sub_uiuiui_fmpz(c, poly2 + x->j);
-               else
-                  _fmpz_mpoly_addmul_uiuiui_fmpz(c,
-                         poly3[x->p]->coeffs[x->i], polyq[x->p]->coeffs[x->j]);
+                *store++ = x->i;
+                *store++ = x->j;
+                *store++ = x->p;
+                if (x->i != -WORD(1))
+                    hinds[x->p][x->i] |= WORD(1);
+
+                if (small)
+                {
+                    if (x->i == -WORD(1))
+                      _fmpz_mpoly_sub_uiuiui_fmpz(c, poly2 + x->j);
+                    else
+                      _fmpz_mpoly_addmul_uiuiui_fmpz(c,
+                             poly3[x->p]->coeffs[x->i], polyq[x->p]->coeffs[x->j]);
+                } else
+                {
+                    if (x->i == -WORD(1))
+                        fmpz_sub(qc, qc, poly2 + x->j);
+                    else
+                        fmpz_addmul(qc, poly3[x->p]->coeffs + x->i,
+                                                   polyq[x->p]->coeffs + x->j);
+                }
+            } while ((x = x->next) != NULL);
+        }
+
+        while (store > store_base)
+        {
+            p = *--store;
+            j = *--store;
+            i = *--store;
+            if (i == -WORD(1))
+            {
+                if (j + 1 < len2)
+                {
+                    x = chains[0] + 0;
+                    x->i = -WORD(1);
+                    x->j = j + 1;
+                    x->p = p;
+                    x->next = NULL;
+                    _mpoly_heap_insert1(heap, exp2[x->j], x, &next_loc, &heap_len, maskhi);
+                }
             } else
             {
-               if (x->i == -WORD(1))
-                  fmpz_sub(qc, qc, poly2 + x->j);
-               else
-                  fmpz_addmul(qc, poly3[x->p]->coeffs + x->i,
-                                                   polyq[x->p]->coeffs + x->j);
+                if ( (i + 1 < poly3[p]->length)
+                   && (hinds[p][i + 1] == 2*j + 1)
+                   )
+                {
+                    x = chains[p] + i + 1;
+                    x->i = i + 1;
+                    x->j = j;
+                    x->p = p;
+                    x->next = NULL;
+                    hinds[p][x->i] = 2*(x->j + 1) + 0;
+                    _mpoly_heap_insert1(heap, exp3[x->p][x->i] +
+                                polyq[x->p]->exps[x->j], x, &next_loc, &heap_len, maskhi);
+                }
+                if (j == k[p])
+                {
+                    s[p]++;
+                } else if (  ((hinds[p][i] & 1) == 1)
+                          && ((i == 1) || (hinds[p][i - 1] >= 2*(j + 2) + 1))
+                          )
+                {
+                    x = chains[p] + i;
+                    x->i = i;
+                    x->j = j + 1;
+                    x->p = p;
+                    x->next = NULL;
+                    hinds[p][x->i] = 2*(x->j + 1) + 0;
+                    _mpoly_heap_insert1(heap, exp3[x->p][x->i] +
+                                polyq[x->p]->exps[x->j], x, &next_loc, &heap_len, maskhi);
+                }
             }
+        }
 
-            if (x->i != -WORD(1) || x->j < len2 - 1)
-               Q[Q_len++] = x;
-            else
-               reuse[reuse_len++] = x;
-         }
-      }
-
-      while (Q_len > 0)
-      {
-         x = Q[--Q_len];
-         
-         if (x->i == -WORD(1))
-         {
-            x->j++;
-            x->next = NULL;
-
-            _mpoly_heap_insert1(heap, exp2[x->j], x,
-                                                 &next_loc, &heap_len, maskhi);
-         } else if (x->j < k[x->p])
-         {
-            x->j++;
-            x->next = NULL;
-
-            _mpoly_heap_insert1(heap, exp3[x->p][x->i] +
-                                polyq[x->p]->exps[x->j], x,
-                                                 &next_loc, &heap_len, maskhi);
-         } else if (x->j == k[x->p])
-         {
-            s[x->p]++;
-            reuse[reuse_len++] = x;
-         }
-      }
-
-      if ((small && (c[2] != 0 || c[1] != 0 || c[0] != 0)) ||
+        if ((small && (c[2] != 0 || c[1] != 0 || c[0] != 0)) ||
                                                  (!small && !fmpz_is_zero(qc)))
-      {
-         div_flag = 0;
-
-         for (w = 0; w < len; w++)
-         {
-            d1 = mpoly_monomial_divides1(&texp, exp, exp3[w][0], mask);
-
-            if (d1)
+        {
+            div_flag = 0;
+            for (w = 0; w < len; w++)
             {
-               d2 = 0;
+                d1 = mpoly_monomial_divides1(&texp, exp, exp3[w][0], mask);
+                if (d1)
+                {
+                    d2 = 0;
+                    if (small)
+                    {
+                        ulong d[3];
+                        if (0 > (slong) c[2])
+                            mpn_neg(d, c, 3);
+                        else
+                            flint_mpn_copyi(d, c, 3);
 
-               if (small)
-               {
-                  ulong d[3];
-
-                  if (0 > (slong) c[2])
-                     mpn_neg(d, c, 3);
-                  else
-                     flint_mpn_copyi(d, c, 3);
-
-                  if (d[2] != 0 || ub[w] <= d[1] ||
-                   (ub[w] == 0 && 0 > (slong) d[0])) /* quotient not a small */
-                  {
-                     fmpz_set_signed_uiuiui(qc, c[2], c[1], c[0]);
-
-                     small = 0;
-                  } else /* quotient fits a small */
-                  {
-                     slong r1;
-                     slong tq;
-
-                     sdiv_qrnnd(tq, r1, c[1], c[0], mb[w]);
-
-                     if (COEFF_IS_MPZ(FLINT_ABS(tq))) /* quotient too large */
-                     {
-                        /* upgrade to multiprecision accumulated coeffs */
-                        fmpz_set_signed_uiuiui(qc, c[2], c[1], c[0]);
-
-                        small = 0;
-                     } else
-                     {
-                        div_flag = (r1 == 0);
-
-                        d2 = tq != 0;
-
+                        if (d[2] != 0 || ub[w] <= d[1] ||
+                          (ub[w] == 0 && 0 > (slong) d[0])) /* quotient not a small */
+                        {
+                            fmpz_set_signed_uiuiui(qc, c[2], c[1], c[0]);
+                            small = 0;
+                        } else /* quotient fits a small */
+                        {
+                            slong r1;
+                            slong tq;
+                            sdiv_qrnnd(tq, r1, c[1], c[0], mb[w]);
+                            if (COEFF_IS_MPZ(FLINT_ABS(tq))) /* quotient too large */
+                            {
+                                small = 0;
+                                fmpz_set_signed_uiuiui(qc, c[2], c[1], c[0]);
+                            } else
+                            {
+                                div_flag = (r1 == 0);
+                                d2 = tq != 0;
+                                if (d2)
+                                {
+                                    k[w]++;
+                                    fmpz_mpoly_fit_length(polyq[w], k[w] + 1, ctx);
+                                    fmpz_set_si(polyq[w]->coeffs + k[w], tq);
+                                    polyq[w]->exps[k[w]] = texp;
+                                }
+                                c[0] = r1;
+                                c[2] = c[1] = r1 < 0 ? ~WORD(0) : WORD(0);
+                            }
+                        }
+                    } 
+                    /* quotient non-small case */
+                    if (!small)
+                    {
+                        fmpz_fdiv_qr(q, qc, qc, mb + w);
+                        div_flag = fmpz_is_zero(qc);
+                        d2 = !fmpz_is_zero(q);
                         if (d2)
                         {
-                           k[w]++;
-
-                           fmpz_mpoly_fit_length(polyq[w], k[w] + 1, ctx);
-
-                           fmpz_set_si(polyq[w]->coeffs + k[w], tq);
-
-                           polyq[w]->exps[k[w]] = texp;
+                            k[w]++;
+                            fmpz_mpoly_fit_length(polyq[w], k[w] + 1, ctx);
+                            fmpz_set(polyq[w]->coeffs + k[w], q);                     
+                            polyq[w]->exps[k[w]] = texp;
                         }
-
-                        c[0] = r1;
-                        c[2] = c[1] = r1 < 0 ? ~WORD(0) : WORD(0);
-                     }
-                  }
-               } 
-
-               /* quotient non-small case */
-               if (!small)
-               {
-                  fmpz_fdiv_qr(q, qc, qc, mb + w);
-
-                  div_flag = fmpz_is_zero(qc);
-
-                  d2 = !fmpz_is_zero(q);
-
-                  if (d2)
-                  {
-                     k[w]++;
-
-                     fmpz_mpoly_fit_length(polyq[w], k[w] + 1, ctx);
-
-                     fmpz_set(polyq[w]->coeffs + k[w], q);
-                     
-                     polyq[w]->exps[k[w]] = texp;
-                  }
-               }
-
-               if (d2)
-               {
-                  for (i = 1; i < s[w]; i++)
-                  {
-                     if (reuse_len != 0)
-                        x2 = reuse[--reuse_len];
-                     else
-                        x2 = chain + next_free++;
-            
-                     x2->i = i;
-                     x2->j = k[w];
-                     x2->p = w;
-                     x2->next = NULL;
-
-                     _mpoly_heap_insert1(heap, exp3[w][i] +
-                                  polyq[w]->exps[k[w]], x2,
+                    }
+                    if (d2)
+                    {
+                        if (s[w] > 1)
+                        {
+                            i = 1;
+                            x = chains[w] + i;
+                            x->i = i;
+                            x->j = k[w];
+                            x->p = w;
+                            x->next = NULL;
+                            hinds[w][x->i] = 2*(x->j + 1) + 0;
+                            _mpoly_heap_insert1(heap, exp3[w][i] +
+                                                  polyq[w]->exps[k[w]], x,
                                                  &next_loc, &heap_len, maskhi);
-                  }
-                  s[w] = 1;
-               }
+                        }
+                        s[w] = 1;
+                    }
+                }
             }
-         }
-         
-         if (!div_flag)
-         {
-            l++;
-
-            _fmpz_mpoly_fit_length(&p2, &e2, allocr, l + 1, 1);
-
-            if (small)
+            if (!div_flag)
             {
-               fmpz_set_signed_uiuiui(p2 + l, c[2], c[1], c[0]);
-               fmpz_neg(p2 + l, p2 + l);
-            } else
-               fmpz_neg(p2 + l, qc);
+                l++;
+                _fmpz_mpoly_fit_length(&p2, &e2, allocr, l + 1, 1);
 
-            e2[l] = exp;
-         }
-      } 
-      
-      fmpz_zero(qc);  
-   }
+                if (small)
+                {
+                    fmpz_set_signed_uiuiui(p2 + l, c[2], c[1], c[0]);
+                    fmpz_neg(p2 + l, p2 + l);
+                } else
+                {
+                    fmpz_neg(p2 + l, qc);
+                }
+                e2[l] = exp;
+            }
+        }
+    }
 
 cleanup:
 
    for (i = 0; i < len; i++)
       _fmpz_mpoly_set_length(polyq[i], k[i] + 1, ctx); 
-
    for (i = 0; i < len; i++)
       fmpz_clear(mb + i);
    fmpz_clear(qc);
@@ -352,8 +310,19 @@ cleanup:
    (*expr) = e2;
    
    TMP_END;
-
    return l + 1;
+
+exp_overflow:
+    for (i = 0; i < l; i++)
+        _fmpz_demote(p2 + i);
+    for (w = 0; w < len; w++)
+    {
+        for (i = 0; i < k[w]; i++)
+            _fmpz_demote(polyq[w]->coeffs + i);
+        k[w] = -WORD(1); /* we add 1 to this before exit */
+    }
+    l = -WORD(2); /* we add 1 to this upon return */
+    goto cleanup;
 }
 
 /*
@@ -367,343 +336,306 @@ slong _fmpz_mpoly_divrem_ideal_monagan_pearce(fmpz_mpoly_struct ** polyq,
                      ulong * const * exp3, slong len, slong N, slong bits, 
                         const fmpz_mpoly_ctx_t ctx, ulong maskhi, ulong masklo)
 {
-   slong i, l, w;
-   slong next_loc;
-   slong next_free, Q_len = 0, len3;
-   slong reuse_len = 0, heap_len = 2; /* heap zero index unused */
-   mpoly_heap_s * heap;
-   mpoly_nheap_t * chain;
-   mpoly_nheap_t ** Q, ** reuse;
-   mpoly_nheap_t * x, * x2;
-   fmpz * p2 = *polyr;
-   ulong * e2 = *expr;
-   ulong * exp, * exps, * texp;
-   ulong ** exp_list;
-   ulong c[3]; /* for accumulating coefficients */
-   slong exp_next;
-   ulong mask = 0;
-   ulong * ub;
-   slong * k, * s;
-   fmpz_t qc, q;
-   fmpz * mb;
-   int small;
-   slong bits2, bits3;
-   int d1, d2, div_flag;
-   TMP_INIT;
+    slong i, j, p, l, w;
+    slong next_loc;
+    slong * store, * store_base;
+    slong len3;
+    slong heap_len = 2; /* heap zero index unused */
+    mpoly_heap_s * heap;
+    mpoly_nheap_t ** chains;
+    slong ** hinds;
+    mpoly_nheap_t * x;
+    fmpz * p2 = *polyr;
+    ulong * e2 = *expr;
+    ulong * exp, * exps, * texp;
+    ulong ** exp_list;
+    ulong c[3]; /* for accumulating coefficients */
+    slong exp_next;
+    ulong mask = 0;
+    ulong * ub;
+    slong * k, * s;
+    fmpz_t qc, q;
+    fmpz * mb;
+    int small;
+    slong bits2, bits3;
+    int d1, d2, div_flag;
+    TMP_INIT;
 
-   if (N == 1)
-      return _fmpz_mpoly_divrem_ideal_monagan_pearce1(polyq, polyr, expr,
+    if (N == 1)
+        return _fmpz_mpoly_divrem_ideal_monagan_pearce1(polyq, polyr, expr,
                allocr, poly2, exp2, len2, poly3, exp3, len, bits, ctx, maskhi);
 
-   TMP_START;
+    TMP_START;
 
-   fmpz_init(q);
-   fmpz_init(qc);
+    fmpz_init(q);
+    fmpz_init(qc);
 
-   bits2 = _fmpz_vec_max_bits(poly2, len2);
+    bits2 = _fmpz_vec_max_bits(poly2, len2);
    
-   bits3 = 0;
-   len3 = 0;
-   for (i = 0; i < len; i++)
-   {
-      slong b = FLINT_ABS(fmpz_mpoly_max_bits(poly3[i]));
-      bits3 = FLINT_MAX(bits3, b);
-      len3 += poly3[i]->length;
-   }
+    chains = (mpoly_nheap_t **) TMP_ALLOC(len*sizeof(mpoly_nheap_t *));
+    hinds = (slong **) TMP_ALLOC(len*sizeof(mpoly_heap_t *));
+    bits3 = 0;
+    len3 = 0;
+    for (w = 0; w < len; w++)
+    {
+        chains[w] = (mpoly_nheap_t *) TMP_ALLOC((poly3[w]->length)*sizeof(mpoly_nheap_t));
+        hinds[w] = (slong *) TMP_ALLOC((poly3[w]->length)*sizeof(slong));
+        bits3 = FLINT_MAX(bits3, FLINT_ABS(fmpz_mpoly_max_bits(poly3[w])));
+        len3 += poly3[w]->length;
+        for (i = 0; i < poly3[w]->length; i++)
+            hinds[w][i] = 1;
+    }
       
-   /* allow one bit for sign, one bit for subtraction */
-   small = FLINT_ABS(bits2) <= (FLINT_ABS(bits3) +
+    /* allow one bit for sign, one bit for subtraction */
+    small = FLINT_ABS(bits2) <= (FLINT_ABS(bits3) +
            FLINT_BIT_COUNT(len3) + FLINT_BITS - 2) &&
            FLINT_ABS(bits3) <= FLINT_BITS - 2;
 
-   next_loc = len3 + 4;   /* something bigger than heap can ever be */
-   heap = (mpoly_heap_s *) TMP_ALLOC((len3 + 1)*sizeof(mpoly_heap_s));
-   chain = (mpoly_nheap_t *) TMP_ALLOC(len3*sizeof(mpoly_nheap_t));
-   Q = (mpoly_nheap_t **) TMP_ALLOC(len3*sizeof(mpoly_nheap_t *));
-   reuse = (mpoly_nheap_t **) TMP_ALLOC(len3*sizeof(mpoly_nheap_t *));
-   exps = (ulong *) TMP_ALLOC(len3*N*sizeof(ulong));
-   exp_list = (ulong **) TMP_ALLOC(len3*sizeof(ulong *));
-   texp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-   exp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-   k = (slong *) TMP_ALLOC(len*sizeof(slong));
-   s = (slong *) TMP_ALLOC(len*sizeof(slong));
-   ub = (ulong *) TMP_ALLOC(len*sizeof(ulong));
-   mb = (fmpz * ) TMP_ALLOC(len*sizeof(fmpz));
+    next_loc = len3 + 4;   /* something bigger than heap can ever be */
+    heap = (mpoly_heap_s *) TMP_ALLOC((len3 + 1)*sizeof(mpoly_heap_s));
+    store = store_base = (slong *) TMP_ALLOC(3*len3*sizeof(mpoly_nheap_t *));
 
-   for (i = 0; i < len3; i++)
-      exp_list[i] = exps + i*N;
+    exps = (ulong *) TMP_ALLOC(len3*N*sizeof(ulong));
+    exp_list = (ulong **) TMP_ALLOC(len3*sizeof(ulong *));
+    texp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
+    exp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
+    k = (slong *) TMP_ALLOC(len*sizeof(slong));
+    s = (slong *) TMP_ALLOC(len*sizeof(slong));
+    ub = (ulong *) TMP_ALLOC(len*sizeof(ulong));
+    mb = (fmpz * ) TMP_ALLOC(len*sizeof(fmpz));
 
-   next_free = 0;
-   exp_next = 0;
+    exp_next = 0;
+    for (i = 0; i < len3; i++)
+        exp_list[i] = exps + i*N;
 
-   for (i = 0; i < FLINT_BITS/bits; i++)
-      mask = (mask << bits) + (UWORD(1) << (bits - 1));
+    mask = 0;
+    for (i = 0; i < FLINT_BITS/bits; i++)
+        mask = (mask << bits) + (UWORD(1) << (bits - 1));
 
-   for (i = 0; i < len; i++)
-   {
-      k[i] = -WORD(1);
-      s[i] = poly3[i]->length;
-   }
-   l = -WORD(1);
+    for (w = 0; w < len; w++)
+    {
+        k[w] = -WORD(1);
+        s[w] = poly3[w]->length;
+    }
+    l = -WORD(1);
    
-   x = chain + next_free++;
-   x->i = -WORD(1);
-   x->j = 0;
-   x->p = -WORD(1);
-   x->next = NULL;
+    x = chains[0] + 0;
+    x->i = -WORD(1);
+    x->j = 0;
+    x->p = -WORD(1);
+    x->next = NULL;
+    heap[1].next = x;
+    heap[1].exp = exp_list[exp_next++];
+    mpoly_monomial_set(heap[1].exp, exp2, N);
 
-   heap[1].next = x;
-   heap[1].exp = exp_list[exp_next++];
+    for (i = 0; i < len; i++)
+    {
+        fmpz_init(mb + i);
+        fmpz_neg(mb + i, poly3[i]->coeffs);
+        ub[i] = ((ulong) FLINT_ABS(mb[i])) >> 1; /* abs(poly3[0])/2 */
+    }
 
-   mpoly_monomial_set(heap[1].exp, exp2, N);
+    while (heap_len > 1)
+    {
+        mpoly_monomial_set(exp, heap[1].exp, N);
 
-   for (i = 0; i < len; i++)
-   {
-      fmpz_init(mb + i);
+        c[0] = c[1] = c[2] = 0;
+        fmpz_zero(qc);
 
-      fmpz_neg(mb + i, poly3[i]->coeffs);
+        if (mpoly_monomial_overflows(exp, N, mask))
+            goto exp_overflow;
 
-      ub[i] = ((ulong) FLINT_ABS(mb[i])) >> 1; /* abs(poly3[0])/2 */
-   }
-
-   while (heap_len > 1)
-   {
-      mpoly_monomial_set(exp, heap[1].exp, N);
-      
-      c[0] = c[1] = c[2] = 0;
-
-      /* check there has been no overflow */
-      if (mpoly_monomial_overflows(exp, N, mask))
-      {
-         for (i = 0; i < l; i++)
-               _fmpz_demote(p2 + i);
-         for (w = 0; w < len; w++)
-         {
-            for (i = 0; i < k[w]; i++)
-               _fmpz_demote(polyq[w]->coeffs + i);
-
-            k[w] = -WORD(1); /* we add 1 to this before exit */
-         }
-
-         l = -WORD(2); /* we add 1 to this upon return */
-
-         goto cleanup2;
-      }
-
-      while (heap_len > 1 && mpoly_monomial_equal(heap[1].exp, exp, N))
-      {
-         exp_list[--exp_next] = heap[1].exp;
-
-         x = _mpoly_heap_pop(heap, &heap_len, N, maskhi, masklo);
-
-         if (small)
-         {
-            if (x->i == -WORD(1))
-               _fmpz_mpoly_sub_uiuiui_fmpz(c, poly2 + x->j);
-            else
-               _fmpz_mpoly_addmul_uiuiui_fmpz(c,
-                         poly3[x->p]->coeffs[x->i], polyq[x->p]->coeffs[x->j]);
-         } else
-         {
-            if (x->i == -WORD(1))
-               fmpz_sub(qc, qc, poly2 + x->j);
-            else
-               fmpz_addmul(qc, poly3[x->p]->coeffs + x->i,
-                                                   polyq[x->p]->coeffs + x->j);
-         }
-
-         if (x->i != -WORD(1) || x->j < len2 - 1)
-            Q[Q_len++] = x;
-         else
-            reuse[reuse_len++] = x;
-
-         while ((x = x->next) != NULL)
-         {
-            if (small)
+        while (heap_len > 1 && mpoly_monomial_equal(heap[1].exp, exp, N))
+        {
+            exp_list[--exp_next] = heap[1].exp;
+            x = _mpoly_heap_pop(heap, &heap_len, N, maskhi, masklo);
+            do
             {
-               if (x->i == -WORD(1))
-                  _fmpz_mpoly_sub_uiuiui_fmpz(c, poly2 + x->j);
-               else
-                  _fmpz_mpoly_addmul_uiuiui_fmpz(c,
-                         poly3[x->p]->coeffs[x->i], polyq[x->p]->coeffs[x->j]);
+                *store++ = x->i;
+                *store++ = x->j;
+                *store++ = x->p;
+                if (x->i != -WORD(1))
+                    hinds[x->p][x->i] |= WORD(1);
+
+                if (small)
+                {
+                    if (x->i == -WORD(1))
+                        _fmpz_mpoly_sub_uiuiui_fmpz(c, poly2 + x->j);
+                    else
+                        _fmpz_mpoly_addmul_uiuiui_fmpz(c,
+                             poly3[x->p]->coeffs[x->i], polyq[x->p]->coeffs[x->j]);
+                } else
+                {
+                    if (x->i == -WORD(1))
+                        fmpz_sub(qc, qc, poly2 + x->j);
+                    else
+                        fmpz_addmul(qc, poly3[x->p]->coeffs + x->i,
+                                                       polyq[x->p]->coeffs + x->j);
+                }
+            } while ((x = x->next) != NULL);
+        }
+
+        while (store > store_base)
+        {
+            p = *--store;
+            j = *--store;
+            i = *--store;
+            if (i == -WORD(1))
+            {
+                if (j + 1 < len2)
+                {
+                    x = chains[0] + 0;
+                    x->i = -WORD(1);
+                    x->j = j + 1;
+                    x->p = p;
+                    x->next = NULL;
+                    mpoly_monomial_set(exp_list[exp_next], exp2 + x->j*N, N);
+                    if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
+                                              &next_loc, &heap_len, N, maskhi, masklo))
+                       exp_next--;
+                }
             } else
             {
-               if (x->i == -WORD(1))
-                  fmpz_sub(qc, qc, poly2 + x->j);
-               else
-                  fmpz_addmul(qc, poly3[x->p]->coeffs + x->i,
-                                                   polyq[x->p]->coeffs + x->j);
-            }
-
-            if (x->i != -WORD(1) || x->j < len2 - 1)
-               Q[Q_len++] = x;
-            else
-               reuse[reuse_len++] = x;
-         }
-      }
-
-      while (Q_len > 0)
-      {
-         x = Q[--Q_len];
-         
-         if (x->i == -WORD(1))
-         {
-            x->j++;
-            x->next = NULL;
-
-            mpoly_monomial_set(exp_list[exp_next], exp2 + x->j*N, N);
-
-            if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
-                                      &next_loc, &heap_len, N, maskhi, masklo))
-               exp_next--;
-         } else if (x->j < k[x->p])
-         {
-            x->j++;
-            x->next = NULL;
-
-            mpoly_monomial_add(exp_list[exp_next], exp3[x->p] + x->i*N,
-                                                polyq[x->p]->exps + x->j*N, N);
-
-            if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x, 
-                                      &next_loc, &heap_len, N, maskhi, masklo))
-               exp_next--;
-         } else if (x->j == k[x->p])
-         {
-            s[x->p]++;
-            reuse[reuse_len++] = x;
-         }
-      }
-
-      if ((small && (c[2] != 0 || c[1] != 0 || c[0] != 0)) ||
-                                                 (!small && !fmpz_is_zero(qc)))
-      {
-         div_flag = 0;
-
-         for (w = 0; w < len; w++)
-         {
-            d1 = mpoly_monomial_divides(texp, exp, exp3[w], N, mask);
-
-            if (d1)
-            {
-               d2 = 0;
-
-               if (small)
-               {
-                  ulong d[3];
-
-                  if (0 > (slong) c[2])
-                     mpn_neg(d, c, 3);
-                  else
-                     flint_mpn_copyi(d, c, 3);
-
-                  if (d[2] != 0 || ub[w] <= d[1] ||
-                   (ub[w] == 0 && 0 > (slong) d[0])) /* quotient not a small */
-                  {
-                     fmpz_set_signed_uiuiui(qc, c[2], c[1], c[0]);
-
-                     small = 0;
-                  } else /* quotient fits a small */
-                  {
-                     slong r1;
-                     slong tq;
-
-                     sdiv_qrnnd(tq, r1, c[1], c[0], mb[w]);
-
-                     if (COEFF_IS_MPZ(FLINT_ABS(tq))) /* quotient too large */
-                     {
-                        /* upgrade to multiprecision accumulated coeffs */
-                        fmpz_set_signed_uiuiui(qc, c[2], c[1], c[0]);
-
-                        small = 0;
-                     } else
-                     {
-                        d2 = tq != 0;
-
-                        div_flag = r1 == 0;
-
-                        if (d2)
-                        {
-                           k[w]++;
-
-                           fmpz_mpoly_fit_length(polyq[w], k[w] + 1, ctx);
-
-                           fmpz_set_si(polyq[w]->coeffs + k[w], tq);
-
-                           mpoly_monomial_set(polyq[w]->exps + k[w]*N, texp, N);
-                        }
-
-                        c[0] = r1;
-                        c[2] = c[1] = r1 < 0 ? ~WORD(0) : WORD(0);
-                     }
-                  }
-               } 
-
-               /* quotient non-small case */
-               if (!small)
-               {
-                  fmpz_fdiv_qr(q, qc, qc, mb + w);
-
-                  d2 = !fmpz_is_zero(q);
-
-                  div_flag = fmpz_is_zero(qc);
-
-                  if (d2)
-                  {
-                     k[w]++;
-
-                     fmpz_mpoly_fit_length(polyq[w], k[w] + 1, ctx);
-
-                     fmpz_set(polyq[w]->coeffs + k[w], q);
-                     
-                     mpoly_monomial_set(polyq[w]->exps + k[w]*N, texp, N);
-                  }
-               }
-
-               if (d2)
-               {
-                  for (i = 1; i < s[w]; i++)
-                  {
-                     if (reuse_len != 0)
-                        x2 = reuse[--reuse_len];
-                     else
-                        x2 = chain + next_free++;
-            
-                     x2->i = i;
-                     x2->j = k[w];
-                     x2->p = w;
-                     x2->next = NULL;
-
-                     mpoly_monomial_add(exp_list[exp_next], exp3[w] + i*N, 
-                                                   polyq[w]->exps + k[w]*N, N);
-
-                     if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x2,
+                /* should we go right */
+                if ( (i + 1 < poly3[p]->length)
+                   && (hinds[p][i + 1] == 2*j + 1)
+                   )
+                {
+                    x = chains[p] + i + 1;
+                    x->i = i + 1;
+                    x->j = j;
+                    x->p = p;
+                    x->next = NULL;
+                    hinds[p][x->i] = 2*(x->j + 1) + 0;
+                    mpoly_monomial_add(exp_list[exp_next], exp3[x->p] + x->i*N,
+                                                   polyq[x->p]->exps + x->j*N, N);
+                    if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
                                       &next_loc, &heap_len, N, maskhi, masklo))
                         exp_next--;
-                  }
-                  s[w] = 1;
-               }
+                }
+
+                /* should we go up? */
+                if (j == k[p])
+                {
+                    s[p]++;
+                } else if (  ((hinds[p][i] & 1) == 1)
+                          && ((i == 1) || (hinds[p][i - 1] >= 2*(j + 2) + 1))
+                          )
+                {
+                    x = chains[p] + i;
+                    x->i = i;
+                    x->j = j + 1;
+                    x->p = p;
+                    x->next = NULL;
+                    hinds[p][x->i] = 2*(x->j + 1) + 0;
+                    mpoly_monomial_add(exp_list[exp_next], exp3[x->p] + x->i*N,
+                                                   polyq[x->p]->exps + x->j*N, N);
+                    if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
+                                      &next_loc, &heap_len, N, maskhi, masklo))
+                        exp_next--;
+                }
             }
-         }
-         
-         if (!div_flag)
-         {
-            l++;
+        }
 
-            _fmpz_mpoly_fit_length(&p2, &e2, allocr, l + 1, N);
-
-            if (small)
+        if ((small && (c[2] != 0 || c[1] != 0 || c[0] != 0)) ||
+                                                 (!small && !fmpz_is_zero(qc)))
+        {
+            div_flag = 0;
+            for (w = 0; w < len; w++)
             {
-               fmpz_set_signed_uiuiui(p2 + l, c[2], c[1], c[0]);
-               fmpz_neg(p2 + l, p2 + l);
-            } else
-               fmpz_neg(p2 + l, qc);
+                d1 = mpoly_monomial_divides(texp, exp, exp3[w], N, mask);
+                if (d1)
+                {
+                    d2 = 0;
+                    if (small)
+                    {
+                        ulong d[3];
+                        if (0 > (slong) c[2])
+                            mpn_neg(d, c, 3);
+                        else
+                            flint_mpn_copyi(d, c, 3);
 
-            mpoly_monomial_set(e2 + l*N, exp, N);
-         }
-      } 
-      
-      fmpz_zero(qc);  
-   }
+                        if (d[2] != 0 || ub[w] <= d[1] ||
+                          (ub[w] == 0 && 0 > (slong) d[0])) /* quotient not a small */
+                        {
+                            small = 0;
+                            fmpz_set_signed_uiuiui(qc, c[2], c[1], c[0]);
+                        } else /* quotient fits a small */
+                        {
+                            slong r1;
+                            slong tq;
+                            sdiv_qrnnd(tq, r1, c[1], c[0], mb[w]);
+                            if (COEFF_IS_MPZ(FLINT_ABS(tq))) /* quotient too large */
+                            {
+                                small = 0;
+                                fmpz_set_signed_uiuiui(qc, c[2], c[1], c[0]);
+                            } else
+                            {
+                                d2 = tq != 0;
+                                div_flag = r1 == 0;
+                                if (d2)
+                                {
+                                    k[w]++;
+                                    fmpz_mpoly_fit_length(polyq[w], k[w] + 1, ctx);
+                                    fmpz_set_si(polyq[w]->coeffs + k[w], tq);
+                                    mpoly_monomial_set(polyq[w]->exps + k[w]*N, texp, N);
+                                }
+                                c[0] = r1;
+                                c[2] = c[1] = r1 < 0 ? ~WORD(0) : WORD(0);
+                            }
+                        }
+                    } 
+                    /* quotient non-small case */
+                    if (!small)
+                    {
+                        fmpz_fdiv_qr(q, qc, qc, mb + w);
+                        d2 = !fmpz_is_zero(q);
+                        div_flag = fmpz_is_zero(qc);
+                        if (d2)
+                        {
+                            k[w]++;
+                            fmpz_mpoly_fit_length(polyq[w], k[w] + 1, ctx);
+                            fmpz_set(polyq[w]->coeffs + k[w], q);
+                            mpoly_monomial_set(polyq[w]->exps + k[w]*N, texp, N);
+                        }
+                    }
+                    if (d2)
+                    {
+                        if (s[w] > 1)
+                        {
+                            i = 1;
+                            x = chains[w] + i;
+                            x->i = i;
+                            x->j = k[w];
+                            x->p = w;
+                            x->next = NULL;
+                            hinds[w][x->i] = 2*(x->j + 1) + 0;
+                            mpoly_monomial_add(exp_list[exp_next], exp3[w] + i*N, 
+                                                   polyq[w]->exps + k[w]*N, N);
+                            if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
+                                      &next_loc, &heap_len, N, maskhi, masklo))
+                                exp_next--;
+                        }
+                        s[w] = 1;
+                    }
+                }
+            }
+            if (!div_flag)
+            {
+                l++;
+                _fmpz_mpoly_fit_length(&p2, &e2, allocr, l + 1, N);
+                if (small)
+                {
+                    fmpz_set_signed_uiuiui(p2 + l, c[2], c[1], c[0]);
+                    fmpz_neg(p2 + l, p2 + l);
+                } else
+                {
+                    fmpz_neg(p2 + l, qc);
+                }
+                mpoly_monomial_set(e2 + l*N, exp, N);
+            }
+        } 
+    }
 
 cleanup2:
 
@@ -721,6 +653,19 @@ cleanup2:
    TMP_END;
 
    return l + 1;
+
+exp_overflow:
+    for (i = 0; i < l; i++)
+       _fmpz_demote(p2 + i);
+    for (w = 0; w < len; w++)
+    {
+        for (i = 0; i < k[w]; i++)
+           _fmpz_demote(polyq[w]->coeffs + i);
+        k[w] = -WORD(1);
+    }
+    l = -WORD(2);
+    goto cleanup2;
+
 }
 
 /* Assumes divisor polys don't alias any output polys */

--- a/fmpz_mpoly/divrem_monagan_pearce.c
+++ b/fmpz_mpoly/divrem_monagan_pearce.c
@@ -69,7 +69,7 @@ slong _fmpz_mpoly_divrem_monagan_pearce1(slong * lenr,
     bits3 = _fmpz_vec_max_bits(poly3, len3);
     /* allow one bit for sign, one bit for subtraction */
     small = FLINT_ABS(bits2) <= (FLINT_ABS(bits3) + FLINT_BIT_COUNT(len3) + FLINT_BITS - 2)
-         && FLINT_ABS(bits3) <= FLINT_BITS - 2;
+          && FLINT_ABS(bits3) <= FLINT_BITS - 2;
 
     /* alloc array of heap nodes which can be chained together */
     next_loc = len3 + 4;   /* something bigger than heap can ever be */
@@ -198,8 +198,7 @@ slong _fmpz_mpoly_divrem_monagan_pearce1(slong * lenr,
                 if (j + 1 == k)
                 {
                     s++;
-                } else if (  1 /* (j + 1 < k) must be true */
-                          && ((hind[i] & 1) == 1)
+                } else if (  ((hind[i] & 1) == 1)
                           && ((i == 1) || (hind[i - 1] >= 2*(j + 2) + 1))
                           )
                 {
@@ -528,7 +527,7 @@ slong _fmpz_mpoly_divrem_monagan_pearce(slong * lenr,
                 }
             } else
             {
-                /* should we go up */
+                /* should we go right? */
                 if (  (i + 1 < len3)
                    && (hind[i + 1] == 2*j + 1)
                    )
@@ -548,8 +547,7 @@ slong _fmpz_mpoly_divrem_monagan_pearce(slong * lenr,
                 if (j + 1 == k)
                 {
                     s++;
-                } else if (  1 /* (j + 1 < k) is always true */
-                          && ((hind[i] & 1) == 1)
+                } else if (  ((hind[i] & 1) == 1)
                           && ((i == 1) || (hind[i - 1] >= 2*(j + 2) + 1))
                           )
                 {


### PR DESCRIPTION
The `FLINT_SIGN` macro probably belongs in `flint.h`, but I put it in `fmpz_mpoly.h` as there was no such function in `flint.h`. This macro generates optimal machine code on x86 and arm for things such as
```
a = FLINT_SIGN(b) // one instruction on arm and on x86
a == FLINT_SIGN(b) // one instruction on arm, two on x86
```