### PR TITLE
Some improvements for the Hermite normal form algorithms

### DIFF
--- a/fmpz_mat.h
+++ b/fmpz_mat.h
@@ -451,6 +451,7 @@ FLINT_DLL void fmpz_mat_hnf_transform(fmpz_mat_t H, fmpz_mat_t U, const fmpz_mat
 FLINT_DLL void fmpz_mat_hnf_classical(fmpz_mat_t H, const fmpz_mat_t A);
 FLINT_DLL void fmpz_mat_hnf_xgcd(fmpz_mat_t H, const fmpz_mat_t A);
 FLINT_DLL void fmpz_mat_hnf_minors(fmpz_mat_t H, const fmpz_mat_t A);
+FLINT_DLL void fmpz_mat_hnf_minors_transform(fmpz_mat_t H, fmpz_mat_t U, const fmpz_mat_t A);
 FLINT_DLL void fmpz_mat_hnf_modular(fmpz_mat_t H, const fmpz_mat_t A, const fmpz_t D);
 FLINT_DLL void fmpz_mat_hnf_modular_eldiv(fmpz_mat_t A, const fmpz_t D);
 FLINT_DLL void fmpz_mat_hnf_pernet_stein(fmpz_mat_t H, const fmpz_mat_t A, flint_rand_t state);

--- a/fmpz_mat/hnf_minors_transform.c
+++ b/fmpz_mat/hnf_minors_transform.c
@@ -18,7 +18,7 @@
   Vol. 8, No. 4, pp. 499-507.
 */
 void
-fmpz_mat_hnf_minors(fmpz_mat_t H, const fmpz_mat_t A)
+fmpz_mat_hnf_minors_transform(fmpz_mat_t H, fmpz_mat_t U, const fmpz_mat_t A)
 {
     slong j, j2, i, k, l, m, n;
     fmpz_t u, v, d, r2d, r1d, q, b;
@@ -34,6 +34,7 @@ fmpz_mat_hnf_minors(fmpz_mat_t H, const fmpz_mat_t A)
     fmpz_init(q);
     fmpz_init(b);
     fmpz_mat_set(H, A);
+    fmpz_mat_one(U);
 
     /* put the kth principal minor in HNF */
     for (k = 0, l = m - 1; k < n; k++)
@@ -55,6 +56,10 @@ fmpz_mat_hnf_minors(fmpz_mat_t H, const fmpz_mat_t A)
                  {
                      fmpz_submul(fmpz_mat_entry(H, k, j2), b, fmpz_mat_entry(H, j, j2));
                  }
+                 for (j2 = 0; j2 < m; j2++)
+                 {
+                     fmpz_submul(fmpz_mat_entry(U, k, j2), b, fmpz_mat_entry(U, j, j2));
+                 }
                  continue;
             }
                 
@@ -71,12 +76,24 @@ fmpz_mat_hnf_minors(fmpz_mat_t H, const fmpz_mat_t A)
                             fmpz_mat_entry(H, j, j2));
                 fmpz_set(fmpz_mat_entry(H, j, j2), b);
             }
+            for (j2 = 0; j2 < m; j2++)
+            {
+                fmpz_mul(b, u, fmpz_mat_entry(U, j, j2));
+                fmpz_addmul(b, v, fmpz_mat_entry(U, k, j2));
+                fmpz_mul(fmpz_mat_entry(U, k, j2), r1d,
+                         fmpz_mat_entry(U, k, j2));
+                fmpz_submul(fmpz_mat_entry(U, k, j2), r2d,
+                            fmpz_mat_entry(U, j, j2));
+                fmpz_set(fmpz_mat_entry(U, j, j2), b);
+
+            }
         }
         /* if H_k,k is zero we swap row k for some other row (starting with the
            last) */
         if (fmpz_is_zero(fmpz_mat_entry(H, k, k)))
         {
             fmpz_mat_swap_rows(H, NULL, k, l);
+            fmpz_mat_swap_rows(U, NULL, k, l);
             l--;
             k--;
             continue;
@@ -87,6 +104,10 @@ fmpz_mat_hnf_minors(fmpz_mat_t H, const fmpz_mat_t A)
             for (j = k; j < n; j++)
             {
                 fmpz_neg(fmpz_mat_entry(H, k, j), fmpz_mat_entry(H, k, j));
+            }
+            for (j = 0; j < m; j++)
+            {
+                fmpz_neg(fmpz_mat_entry(U, k, j), fmpz_mat_entry(U, k, j));
             }
         }
         /* reduce above diagonal elements of each row i */
@@ -104,6 +125,11 @@ fmpz_mat_hnf_minors(fmpz_mat_t H, const fmpz_mat_t A)
                 {
                     fmpz_submul(fmpz_mat_entry(H, i, j2), q,
                                 fmpz_mat_entry(H, j, j2));
+                }
+                for (j2 = 0; j2 < m; j2++)
+                {
+                    fmpz_submul(fmpz_mat_entry(U, i, j2), q,
+                                fmpz_mat_entry(U, j, j2));
                 }
             }
         }
@@ -125,6 +151,11 @@ fmpz_mat_hnf_minors(fmpz_mat_t H, const fmpz_mat_t A)
                  {
                      fmpz_submul(fmpz_mat_entry(H, k, j2), b, fmpz_mat_entry(H, j, j2));
                  }
+                 for (j2 = 0; j2 < m; j2++)
+                 {
+                     fmpz_submul(fmpz_mat_entry(U, k, j2), b, fmpz_mat_entry(U, j, j2));
+                 }
+
                  continue;
             }
 
@@ -139,6 +170,16 @@ fmpz_mat_hnf_minors(fmpz_mat_t H, const fmpz_mat_t A)
                 fmpz_submul(fmpz_mat_entry(H, k, j2), r2d,
                             fmpz_mat_entry(H, j, j2));
                 fmpz_set(fmpz_mat_entry(H, j, j2), b);
+            }
+            for (j2 = 0; j2 < m; j2++)
+            {
+                fmpz_mul(b, u, fmpz_mat_entry(U, j, j2));
+                fmpz_addmul(b, v, fmpz_mat_entry(U, k, j2));
+                fmpz_mul(fmpz_mat_entry(U, k, j2), r1d,
+                         fmpz_mat_entry(U, k, j2));
+                fmpz_submul(fmpz_mat_entry(U, k, j2), r2d,
+                            fmpz_mat_entry(U, j, j2));
+                fmpz_set(fmpz_mat_entry(U, j, j2), b);
             }
         }
         /* reduce above diagonal elements of each row i */
@@ -157,6 +198,11 @@ fmpz_mat_hnf_minors(fmpz_mat_t H, const fmpz_mat_t A)
                 {
                     fmpz_submul(fmpz_mat_entry(H, i, j2), q,
                                 fmpz_mat_entry(H, j, j2));
+                }
+                for (j2 = 0; j2 < m; j2++)
+                {
+                    fmpz_submul(fmpz_mat_entry(U, i, j2), q,
+                                fmpz_mat_entry(U, j, j2));
                 }
             }
         }

--- a/fmpz_mat/test/t-hnf_minors_transform.c
+++ b/fmpz_mat/test/t-hnf_minors_transform.c
@@ -1,0 +1,100 @@
+/*
+    Copyright (C) 2014 Alex J. Best
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <gmp.h>
+#include "flint.h"
+#include "fmpz.h"
+#include "fmpz_mat.h"
+
+int
+main(void)
+{
+    slong iter;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("hnf_minors_transform....");
+    fflush(stdout);
+
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        fmpz_mat_t A, H, H2, U, UA;
+        slong m, n, b, d;
+        int equal;
+
+        n = n_randint(state, 10);
+        m = n + n_randint(state, 10);
+
+        fmpz_mat_init(A, m, n);
+        fmpz_mat_init(H, m, n);
+        fmpz_mat_init(H2, m, n);
+        fmpz_mat_init(U, m, m);
+        fmpz_mat_init(UA, m, n);
+
+        /* sparse */
+        b = 1 + n_randint(state, 10) * n_randint(state, 10);
+        fmpz_mat_randrank(A, state, n, b);
+
+        /* dense */
+        d = n_randint(state, 2*m*n + 1);
+        if (n_randint(state, 2))
+            fmpz_mat_randops(A, state, d);
+
+        fmpz_mat_hnf_minors_transform(H, U, A);
+        fmpz_mat_mul(UA, U, A);
+
+        if (!fmpz_mat_is_in_hnf(H) || !fmpz_mat_equal(UA, H))
+        {
+            flint_printf("FAIL:\n");
+            flint_printf("matrix not in hnf!\n");
+            fmpz_mat_print_pretty(A); flint_printf("\n\n");
+            fmpz_mat_print_pretty(H); flint_printf("\n\n");
+            abort();
+        }
+
+        fmpz_mat_hnf_classical(H2, A);
+        equal = fmpz_mat_equal(H, H2);
+
+        if (!equal)
+        {
+            flint_printf("FAIL:\n");
+            flint_printf("hnfs produced by different methods should be the same!\n");
+            fmpz_mat_print_pretty(A); flint_printf("\n\n");
+            fmpz_mat_print_pretty(H); flint_printf("\n\n");
+            fmpz_mat_print_pretty(H2); flint_printf("\n\n");
+            abort();
+        }
+
+        fmpz_mat_hnf_minors(H2, H);
+        equal = fmpz_mat_equal(H, H2);
+
+        if (!equal)
+        {
+            flint_printf("FAIL:\n");
+            flint_printf("hnf of a matrix in hnf should be the same!\n");
+            fmpz_mat_print_pretty(A); flint_printf("\n\n");
+            fmpz_mat_print_pretty(H); flint_printf("\n\n");
+            fmpz_mat_print_pretty(H2); flint_printf("\n\n");
+            abort();
+        }
+
+        fmpz_mat_clear(H2);
+        fmpz_mat_clear(H);
+        fmpz_mat_clear(A);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+
+    flint_printf("PASS\n");
+    return 0;
+}
+

--- a/fmpz_mat/test/t-hnf_transform.c
+++ b/fmpz_mat/test/t-hnf_transform.c
@@ -25,7 +25,8 @@ main(void)
     flint_printf("hnf_transform....");
     fflush(stdout);
 
-    for (iter = 0; iter < 10000 * flint_test_multiplier(); iter++)
+    /* Random rectangular matrices */
+    for (iter = 0; iter < 5000 * flint_test_multiplier(); iter++)
     {
         fmpz_mat_t A, H, H2, U;
         fmpz_t det;
@@ -35,6 +36,91 @@ main(void)
         m = n_randint(state, 10);
         n = n_randint(state, 10);
         r = n_randint(state, FLINT_MIN(m, n) + 1);
+
+        fmpz_mat_init(A, m, n);
+        fmpz_mat_init(H, m, n);
+        fmpz_mat_init(H2, m, n);
+        fmpz_mat_init(U, m, m);
+
+        /* sparse */
+        b = 1 + n_randint(state, 10) * n_randint(state, 10);
+        d = n_randint(state, 2*m*n + 1);
+        fmpz_mat_randrank(A, state, r, b);
+
+        /* dense */
+        if (n_randint(state, 2))
+            fmpz_mat_randops(A, state, d);
+
+        fmpz_mat_hnf_transform(H, U, A);
+
+        if (!fmpz_mat_is_in_hnf(H))
+        {
+            flint_printf("FAIL:\n");
+            flint_printf("matrix not in hnf!\n");
+            fmpz_mat_print_pretty(A); flint_printf("\n\n");
+            fmpz_mat_print_pretty(H); flint_printf("\n\n");
+            abort();
+        }
+
+        fmpz_init(det);
+
+        fmpz_mat_det(det, U);
+        if (!fmpz_is_pm1(det))
+        {
+            flint_printf("FAIL:\n");
+            flint_printf("transformation matrices should have determinant +-1, U does not!\n");
+            fmpz_mat_print_pretty(A); flint_printf("\n\n");
+            fmpz_mat_print_pretty(U); flint_printf("\n\n");
+            fmpz_mat_print_pretty(H); flint_printf("\n\n");
+            abort();
+        }
+
+        fmpz_clear(det);
+
+        fmpz_mat_mul(H2, U, A);
+        equal = fmpz_mat_equal(H, H2);
+
+        if (!equal)
+        {
+            flint_printf("FAIL:\n");
+            flint_printf("multiplying by the transformation matrix should give the same HNF!\n");
+            fmpz_mat_print_pretty(A); flint_printf("\n\n");
+            fmpz_mat_print_pretty(U); flint_printf("\n\n");
+            fmpz_mat_print_pretty(H); flint_printf("\n\n");
+            fmpz_mat_print_pretty(H2); flint_printf("\n\n");
+            abort();
+        }
+
+        fmpz_mat_hnf(H2, A);
+        equal = fmpz_mat_equal(H, H2);
+
+        if (!equal)
+        {
+            flint_printf("FAIL:\n");
+            flint_printf("hnfs produced by different methods should be the same!\n");
+            fmpz_mat_print_pretty(A); flint_printf("\n\n");
+            fmpz_mat_print_pretty(H); flint_printf("\n\n");
+            fmpz_mat_print_pretty(H2); flint_printf("\n\n");
+            abort();
+        }
+
+        fmpz_mat_clear(U);
+        fmpz_mat_clear(H2);
+        fmpz_mat_clear(H);
+        fmpz_mat_clear(A);
+    }
+
+    /* Now matrices with full column rank */
+    for (iter = 0; iter < 5000 * flint_test_multiplier(); iter++)
+    {
+        fmpz_mat_t A, H, H2, U;
+        fmpz_t det;
+        slong m, n, b, d, r;
+        int equal;
+
+        n = n_randint(state, 10);
+        m = n + n_randint(state, 10);
+        r = n;
 
         fmpz_mat_init(A, m, n);
         fmpz_mat_init(H, m, n);


### PR DESCRIPTION
- Tweaked fmpz_mat_hnf_minors a bit (some shortcuts when reducing
  rows). This brings the example from Frank from 3.3s to 1.6s on my
  machine.
- Added fmpz_mat_hnf_minors_transform.
- As fmpz_mat_hnf_minors_transform is usually much faster as the
  previous fmpz_mat_transform, I added some logic in fmpz_mat_transform
  to call it when applicable. Since it involves a rank computation mod p
  as a precomputation, this makes the function a bit slower in case the
  matrix has not full rank, but otherwise speeds up fmpz_mat_transform
  tremendously (In Frank's example from 120s to 6s on my machine).