### PR TITLE
add mpoly_monomial_max and min

### DIFF
--- a/mpoly.h
+++ b/mpoly.h
@@ -172,6 +172,34 @@ void mpoly_monomial_sub(ulong * exp_ptr, const ulong * exp2,
 }
 
 MPOLY_INLINE
+void mpoly_monomial_max(ulong * exp1, const ulong * exp2, const ulong * exp3,
+                                               slong bits, slong N, ulong mask)
+{
+    ulong i, s, m;
+    for (i = 0; i < N; i++)
+    {
+        s = mask + exp2[i] - exp3[i];
+        m = mask & s;
+        m = m - (m >> (bits - 1));
+        exp1[i] = exp3[i] + (s & m);
+    }
+}
+
+MPOLY_INLINE
+void mpoly_monomial_min(ulong * exp1, const ulong * exp2, const ulong * exp3,
+                                               slong bits, slong N, ulong mask)
+{
+    ulong i, s, m;
+    for (i = 0; i < N; i++)
+    {
+        s = mask + exp2[i] - exp3[i];
+        m = mask & s;
+        m = m - (m >> (bits - 1));
+        exp1[i] = exp2[i] - (s & m);
+    }
+}
+
+MPOLY_INLINE
 int mpoly_monomial_overflows(ulong * exp2, slong N, ulong mask)
 {
    slong i;

--- a/mpoly/test/t-max_degrees.c
+++ b/mpoly/test/t-max_degrees.c
@@ -51,13 +51,15 @@ main(void)
                 max[j] = 0;
 
             for (i = 0; i < nfields*length; i += nfields)
+            {
                 for (j = 0; j < nfields; j++)
                 {
-                    a[i + j] = n_randint(state, 0) & (l_shift(UWORD(1), bits)
-                                                                          - 1);
+                    a[i + j] = n_randint(state, 0);
+                    a[i + j] &= (UWORD(1) << (bits - 1)) - 1;
                     max[nfields - j - 1] = FLINT_MAX(max[nfields - j - 1],
                                                                      a[i + j]);
                 }
+            }
 
             /* FLINT_BITS => bits */
             for (i = 0; i < length; i++)


### PR DESCRIPTION
This patch adds the missing max and min functions for packed exponents and also addresses the slight performance problem in mpoly_max_degrees.

old code: unpack each exponent, then calculate max on each component
new code: calculate max in packed format, then only one unpack for final answer.

With this adjustment, there should be no need for specialised unpacking code.