### PR TITLE
use geobuckets in parsing

### DIFF
--- a/fmpz_mpoly.h
+++ b/fmpz_mpoly.h
@@ -69,6 +69,67 @@ typedef struct
 
 typedef fmpz_mpoly_univar_struct fmpz_mpoly_univar_t[1];
 
+/* geobuckets ****************************************************************/
+typedef struct fmpz_mpoly_geobucket
+{
+    fmpz_mpoly_struct polys[FLINT_BITS/2];
+    slong length;
+} fmpz_mpoly_geobucket_struct;
+
+typedef fmpz_mpoly_geobucket_struct fmpz_mpoly_geobucket_t[1];
+
+FLINT_DLL void fmpz_mpoly_geobucket_init(fmpz_mpoly_geobucket_t B,
+                                                   const fmpz_mpoly_ctx_t ctx);
+
+FLINT_DLL void fmpz_mpoly_geobucket_clear(fmpz_mpoly_geobucket_t B,
+                                                   const fmpz_mpoly_ctx_t ctx);
+
+FLINT_DLL void fmpz_mpoly_geobucket_empty(fmpz_mpoly_t p,
+                         fmpz_mpoly_geobucket_t B, const fmpz_mpoly_ctx_t ctx);
+
+FLINT_DLL void fmpz_mpoly_geobucket_print(fmpz_mpoly_geobucket_t B,
+                                  const char ** x, const fmpz_mpoly_ctx_t ctx);
+
+FLINT_DLL void fmpz_mpoly_geobucket_fit_length(fmpz_mpoly_geobucket_t B,
+                                          slong i, const fmpz_mpoly_ctx_t ctx);
+
+FLINT_DLL void _fmpz_mpoly_geobucket_fix(fmpz_mpoly_geobucket_t B, slong i,
+                                                   const fmpz_mpoly_ctx_t ctx);
+
+FLINT_DLL void fmpz_mpoly_geobucket_set(fmpz_mpoly_geobucket_t B,
+                                   fmpz_mpoly_t p, const fmpz_mpoly_ctx_t ctx);
+
+FLINT_DLL void fmpz_mpoly_geobucket_add(fmpz_mpoly_geobucket_t B,
+                                   fmpz_mpoly_t p, const fmpz_mpoly_ctx_t ctx);
+
+FLINT_DLL void fmpz_mpoly_geobucket_sub(fmpz_mpoly_geobucket_t B,
+                                   fmpz_mpoly_t p, const fmpz_mpoly_ctx_t ctx);
+
+FLINT_DLL void fmpz_mpoly_geobucket_set_fmpz(fmpz_mpoly_geobucket_t B,
+                                         fmpz_t c, const fmpz_mpoly_ctx_t ctx);
+
+FLINT_DLL void fmpz_mpoly_geobucket_gen(fmpz_mpoly_geobucket_t B, slong var,
+                                                   const fmpz_mpoly_ctx_t ctx);
+
+FLINT_DLL void fmpz_mpoly_geobucket_add_inplace(fmpz_mpoly_geobucket_t B1,
+                        fmpz_mpoly_geobucket_t B2, const fmpz_mpoly_ctx_t ctx);
+
+FLINT_DLL void fmpz_mpoly_geobucket_sub_inplace(fmpz_mpoly_geobucket_t B1,
+                        fmpz_mpoly_geobucket_t B2, const fmpz_mpoly_ctx_t ctx);
+
+FLINT_DLL void fmpz_mpoly_geobucket_neg_inplace(fmpz_mpoly_geobucket_t B1,
+                                                   const fmpz_mpoly_ctx_t ctx);
+
+FLINT_DLL void fmpz_mpoly_geobucket_mul_inplace(fmpz_mpoly_geobucket_t B1,
+                        fmpz_mpoly_geobucket_t B2, const fmpz_mpoly_ctx_t ctx);
+
+FLINT_DLL void fmpz_mpoly_geobucket_pow_inplace(fmpz_mpoly_geobucket_t B1,
+                                          slong k, const fmpz_mpoly_ctx_t ctx);
+
+FLINT_DLL int fmpz_mpoly_geobucket_divides_inplace(fmpz_mpoly_geobucket_t B1,
+                        fmpz_mpoly_geobucket_t B2, const fmpz_mpoly_ctx_t ctx);
+
+
 /* Context object ************************************************************/
 
 FLINT_DLL void fmpz_mpoly_ctx_init(fmpz_mpoly_ctx_t ctx, 

--- a/fmpz_mpoly/doc/fmpz_mpoly.txt
+++ b/fmpz_mpoly/doc/fmpz_mpoly.txt
@@ -1147,7 +1147,10 @@ int fmpz_mpoly_set_str_pretty(fmpz_mpoly_t poly, const char * str,
     Sets \code{poly} to the polynomial in the null-terminates string \code{str}
     given an array \code{x} of variable strings. If parsing \code{str} fails,
     \code{poly} is set to zero, and \code{-1} is returned. Otherwise, \code{0}
-    is returned.
+    is returned. The operations \code{+}, \code{-}, \code{*}, and \code{/} are
+    permitted along with integers and the variables in \code{x}. The character
+    \code{^} must be immediately followed by the (integer) exponent. If any
+    division is not exact, parsing fails.
 
 *******************************************************************************
 

--- a/fmpz_mpoly/geobuckets.c
+++ b/fmpz_mpoly/geobuckets.c
@@ -1,0 +1,231 @@
+/*
+    Copyright (C) 2017 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <gmp.h>
+#include "flint.h"
+#include "fmpz.h"
+#include "fmpz_mpoly.h"
+
+
+void fmpz_mpoly_geobucket_init(fmpz_mpoly_geobucket_t B,
+                                                    const fmpz_mpoly_ctx_t ctx)
+{
+    B->length = 0;
+}
+
+void fmpz_mpoly_geobucket_clear(fmpz_mpoly_geobucket_t B,
+                                                    const fmpz_mpoly_ctx_t ctx)
+{
+    slong i;
+    for (i = 0; i < B->length; i++)
+        fmpz_mpoly_clear(B->polys + i, ctx);
+}
+
+/* empty out bucket B into polynomial p */
+void fmpz_mpoly_geobucket_empty(fmpz_mpoly_t p, fmpz_mpoly_geobucket_t B,
+                                                    const fmpz_mpoly_ctx_t ctx)
+{
+    slong i;
+    fmpz_mpoly_zero(p, ctx);
+    for (i = 0; i < B->length; i++)
+    {
+        fmpz_mpoly_add(p, p, B->polys + i, ctx);
+        fmpz_mpoly_clear(B->polys + i, ctx);
+    }
+    B->length = 0;
+}
+
+void fmpz_mpoly_geobucket_print(fmpz_mpoly_geobucket_t B, const char ** x,
+                                                    const fmpz_mpoly_ctx_t ctx)
+{
+    slong i;
+    printf("{");
+    for (i = 0; i < B->length; i++)
+    {
+        fmpz_mpoly_print_pretty(B->polys + i, x, ctx);
+        if (i + 1 < B->length)
+            printf(", ");
+    }
+    printf("}");
+}
+
+/* ceiling(log_4(x)) */
+slong fmpz_mpoly_geobucket_clog4(slong x)
+{
+    x = FLINT_MAX(x - WORD(1), WORD(0));
+    return (FLINT_BIT_COUNT(x) - WORD(1))/2;
+}
+
+void fmpz_mpoly_geobucket_fit_length(fmpz_mpoly_geobucket_t B, slong len,
+                                                    const fmpz_mpoly_ctx_t ctx)
+{
+    slong j;
+    for (j = B->length; j < len; j++)
+    {
+        fmpz_mpoly_init(B->polys + j, ctx);
+        fmpz_mpoly_zero(B->polys + j, ctx);
+    }
+    B->length = j;
+}
+
+/* set bucket B to polynomial p */
+void fmpz_mpoly_geobucket_set(fmpz_mpoly_geobucket_t B, fmpz_mpoly_t p,
+                                                    const fmpz_mpoly_ctx_t ctx)
+{
+    slong i;
+    fmpz_mpoly_geobucket_clear(B, ctx);
+    i = fmpz_mpoly_geobucket_clog4(p->length);
+    fmpz_mpoly_geobucket_fit_length(B, i + 1, ctx);
+    fmpz_mpoly_set(B->polys + i, p, ctx);
+    B->length = i + 1;
+}
+
+/* internal function for fixing overflows */
+void _fmpz_mpoly_geobucket_fix(fmpz_mpoly_geobucket_t B, slong i,
+                                                    const fmpz_mpoly_ctx_t ctx)
+{
+    while (fmpz_mpoly_geobucket_clog4((B->polys + i)->length) > i)
+    {
+        FLINT_ASSERT(i + 1 <= B->length);
+        if (i + 1 == B->length)
+        {
+            fmpz_mpoly_init(B->polys + i + 1, ctx);
+            fmpz_mpoly_zero(B->polys + i + 1, ctx);
+            B->length = i + 2;
+        }
+        fmpz_mpoly_add(B->polys + i + 1, B->polys + i + 1, B->polys + i, ctx);
+        fmpz_mpoly_zero(B->polys + i, ctx);
+        i++;
+    }
+}
+
+/* add polynomial p to buckect B */
+void fmpz_mpoly_geobucket_add(fmpz_mpoly_geobucket_t B, fmpz_mpoly_t p,
+                                                    const fmpz_mpoly_ctx_t ctx)
+{
+    slong i;
+    i = fmpz_mpoly_geobucket_clog4(p->length);
+    fmpz_mpoly_geobucket_fit_length(B, i + 1, ctx);
+    fmpz_mpoly_add(B->polys + i, B->polys + i, p, ctx);
+    _fmpz_mpoly_geobucket_fix(B, i, ctx);
+}
+
+/* sub polynomial p to buckect B */
+void fmpz_mpoly_geobucket_sub(fmpz_mpoly_geobucket_t B, fmpz_mpoly_t p,
+                                                    const fmpz_mpoly_ctx_t ctx)
+{
+    slong i;
+    i = fmpz_mpoly_geobucket_clog4(p->length);
+    fmpz_mpoly_geobucket_fit_length(B, i + 1, ctx);
+    fmpz_mpoly_sub(B->polys + i, B->polys + i, p, ctx);
+    _fmpz_mpoly_geobucket_fix(B, i, ctx);
+}
+
+void fmpz_mpoly_geobucket_set_fmpz(fmpz_mpoly_geobucket_t B, fmpz_t c,
+                                                    const fmpz_mpoly_ctx_t ctx)
+{
+    slong i;
+    if (B->length == 0)
+        fmpz_mpoly_init(B->polys + 0, ctx);
+    for (i = 1; i < B->length; i++)
+        fmpz_mpoly_clear(B->polys + i, ctx);
+    B->length = 1;
+    fmpz_mpoly_set_fmpz(B->polys + 0, c, ctx);
+}
+
+void fmpz_mpoly_geobucket_gen(fmpz_mpoly_geobucket_t B, slong var,
+                                                    const fmpz_mpoly_ctx_t ctx)
+{
+    slong i;
+    if (B->length == 0)
+        fmpz_mpoly_init(B->polys + 0, ctx);
+    for (i = 1; i < B->length; i++)
+        fmpz_mpoly_clear(B->polys + i, ctx);
+    B->length = 1;
+    fmpz_mpoly_gen(B->polys + 0, var, ctx);
+}
+
+void fmpz_mpoly_geobucket_add_inplace(fmpz_mpoly_geobucket_t B1,
+                         fmpz_mpoly_geobucket_t B2, const fmpz_mpoly_ctx_t ctx)
+{
+    slong i;
+    for (i = 0; i < B2->length; i++)
+        fmpz_mpoly_geobucket_add(B1, B2->polys + i, ctx);
+
+}
+
+void fmpz_mpoly_geobucket_sub_inplace(fmpz_mpoly_geobucket_t B1,
+                         fmpz_mpoly_geobucket_t B2, const fmpz_mpoly_ctx_t ctx)
+{
+    slong i;
+    for (i = 0; i < B2->length; i++)
+        fmpz_mpoly_geobucket_sub(B1, B2->polys + i, ctx);
+}
+
+void fmpz_mpoly_geobucket_neg_inplace(fmpz_mpoly_geobucket_t B1,
+                                                    const fmpz_mpoly_ctx_t ctx)
+{
+    slong i;
+    for (i = 0; i < B1->length; i++)
+        fmpz_mpoly_neg(B1->polys + i, B1->polys + i, ctx);
+}
+
+void fmpz_mpoly_geobucket_mul_inplace(fmpz_mpoly_geobucket_t B1,
+                         fmpz_mpoly_geobucket_t B2, const fmpz_mpoly_ctx_t ctx)
+{
+    fmpz_mpoly_t a, b;
+    fmpz_mpoly_init(a, ctx);
+    fmpz_mpoly_init(b, ctx);
+
+    fmpz_mpoly_geobucket_empty(a, B1, ctx);
+    fmpz_mpoly_geobucket_empty(b, B2, ctx);
+    fmpz_mpoly_mul_johnson(a, a, b, ctx);
+    fmpz_mpoly_geobucket_set(B1, a, ctx);
+
+    fmpz_mpoly_clear(a, ctx);
+    fmpz_mpoly_clear(b, ctx);
+}
+
+void fmpz_mpoly_geobucket_pow_inplace(fmpz_mpoly_geobucket_t B1,
+                                           slong k, const fmpz_mpoly_ctx_t ctx)
+{
+    fmpz_mpoly_t a;
+    fmpz_mpoly_init(a, ctx);
+
+    fmpz_mpoly_geobucket_empty(a, B1, ctx);
+    fmpz_mpoly_pow_fps(a, a, k, ctx);
+    fmpz_mpoly_geobucket_set(B1, a, ctx);
+
+    fmpz_mpoly_clear(a, ctx);
+}
+
+
+int fmpz_mpoly_geobucket_divides_inplace(fmpz_mpoly_geobucket_t B1,
+                         fmpz_mpoly_geobucket_t B2, const fmpz_mpoly_ctx_t ctx)
+{
+    int ret;
+    fmpz_mpoly_t a, b;
+    fmpz_mpoly_init(a, ctx);
+    fmpz_mpoly_init(b, ctx);
+
+    fmpz_mpoly_geobucket_empty(a, B1, ctx);
+    fmpz_mpoly_geobucket_empty(b, B2, ctx);
+
+    ret = fmpz_mpoly_divides_monagan_pearce(a, a, b, ctx);
+    fmpz_mpoly_geobucket_set(B1, a, ctx);
+
+    fmpz_mpoly_clear(a, ctx);
+    fmpz_mpoly_clear(b, ctx);
+    return ret;
+}

--- a/fmpz_mpoly/parse_pretty.c
+++ b/fmpz_mpoly/parse_pretty.c
@@ -19,42 +19,53 @@
 #include <assert.h>
 
 
-int _fmpz_mpoly_parse_pretty_pop(fmpz_mpoly_struct ** estack,
-                        slong * ostack, slong * _ei, slong * _oi,
-                                    const fmpz_mpoly_ctx_t ctx, int all)
+int _fmpz_mpoly_parse_pretty_pop(fmpz_mpoly_geobucket_struct ** estack,
+                                 slong * ostack, slong * _ei, slong * _oi,
+                                           const fmpz_mpoly_ctx_t ctx, int all)
 {
     int ret = 0;
     slong ei = *_ei;
     slong oi = *_oi;
 
     while (oi > 0 && ((all && (ostack[oi - 1] == '+' || ostack[oi - 1] == '-'))
-           || ostack[oi - 1] == '*' || ostack[oi - 1] == 100 + '-'
-                                    || ostack[oi - 1] == 100 + '+'))
+                      || ostack[oi - 1] == '*'
+                      || ostack[oi - 1] == '/'
+                      || ostack[oi - 1] == 100 + '-'
+                      || ostack[oi - 1] == 100 + '+'
+                     )
+          )
     {
         oi--;
         if (ostack[oi] == '+')
         {
             if (ei < 2)
                 goto failed;
-            fmpz_mpoly_add(estack[ei - 2], estack[ei - 2], estack[ei - 1], ctx);
-            fmpz_mpoly_clear(estack[--ei], ctx);
+            fmpz_mpoly_geobucket_add_inplace(estack[ei - 2], estack[ei - 1], ctx);
+            fmpz_mpoly_geobucket_clear(estack[--ei], ctx);
         } else if (ostack[oi] == '-')
         {
             if (ei < 2)
                 goto failed;
-            fmpz_mpoly_sub(estack[ei - 2], estack[ei - 2], estack[ei - 1], ctx);
-            fmpz_mpoly_clear(estack[--ei], ctx);
+            fmpz_mpoly_geobucket_sub_inplace(estack[ei - 2], estack[ei - 1], ctx);
+            fmpz_mpoly_geobucket_clear(estack[--ei], ctx);
         } else if (ostack[oi] == '*')
         {
             if (ei < 2)
                 goto failed;
-            fmpz_mpoly_mul_johnson(estack[ei - 2], estack[ei - 2], estack[ei - 1], ctx);
-            fmpz_mpoly_clear(estack[--ei], ctx);
+            fmpz_mpoly_geobucket_mul_inplace(estack[ei - 2], estack[ei - 1], ctx);
+            fmpz_mpoly_geobucket_clear(estack[--ei], ctx);
+        } else if (ostack[oi] == '/')
+        {
+            if (ei < 2)
+                goto failed;
+            if (!fmpz_mpoly_geobucket_divides_inplace(estack[ei - 2], estack[ei - 1], ctx))
+                goto failed;
+            fmpz_mpoly_geobucket_clear(estack[--ei], ctx);
         } else if (ostack[oi] == 100 + '-')
         {
             if (ei < 1)
                 goto failed;
-            fmpz_mpoly_neg(estack[ei - 1], estack[ei - 1], ctx);
+            fmpz_mpoly_geobucket_neg_inplace(estack[ei - 1], ctx);
         } else {
             /* must be unary + */
             if (ei < 1)
@@ -72,19 +83,19 @@ failed:
     goto done;
 }
 
-void _fmpz_mpoly_parse_pretty_fit_estack(fmpz_mpoly_struct *** estack,
+void _fmpz_mpoly_parse_pretty_fit_estack(fmpz_mpoly_geobucket_struct *** estack,
                                                       slong ei, slong * ealloc)
 {
     if (ei >= *ealloc)
     {
         slong new_ealloc = ei + 8;
 
-        (*estack) = (fmpz_mpoly_struct **) flint_realloc(*estack,
-                                        new_ealloc*sizeof(fmpz_mpoly_struct*));
+        (* estack) = (fmpz_mpoly_geobucket_struct **) flint_realloc(* estack,
+                              new_ealloc*sizeof(fmpz_mpoly_geobucket_struct*));
         for (; ei < new_ealloc; ei++)
         {
-            (*estack)[ei] = (fmpz_mpoly_struct*)
-                                       flint_malloc(sizeof(fmpz_mpoly_struct));            
+            (* estack)[ei] = (fmpz_mpoly_geobucket_struct *)
+                             flint_malloc(sizeof(fmpz_mpoly_geobucket_struct));
         }
         *ealloc = new_ealloc;
     }
@@ -120,7 +131,7 @@ const char * _fmpz_mpoly_parse_pretty_int(const char * s, const char * end,
 int _fmpz_mpoly_parse_pretty(fmpz_mpoly_t poly, const char * s, slong sn,
                                          char ** x, const fmpz_mpoly_ctx_t ctx)
 {
-    fmpz_mpoly_struct ** estack;
+    fmpz_mpoly_geobucket_struct ** estack;
     slong * ostack;
     slong ealloc = 8, oalloc = 8;
     slong ei = 0, oi = 0;
@@ -136,9 +147,13 @@ int _fmpz_mpoly_parse_pretty(fmpz_mpoly_t poly, const char * s, slong sn,
 
     fmpz_init(c);
     ostack = (slong *) flint_malloc(ealloc*sizeof(slong));
-    estack = (fmpz_mpoly_struct **) flint_malloc(ealloc*sizeof(fmpz_mpoly_struct*));
+    estack = (fmpz_mpoly_geobucket_struct **) flint_malloc(ealloc
+                                       * sizeof(fmpz_mpoly_geobucket_struct*));
     for (k = 0; k < ealloc; k++)
-        estack[k] = (fmpz_mpoly_struct*) flint_malloc(sizeof(fmpz_mpoly_struct));
+    {
+        estack[k] = (fmpz_mpoly_geobucket_struct*) flint_malloc(
+                                          sizeof(fmpz_mpoly_geobucket_struct));
+    }
 
     while (s < end)
     {
@@ -148,8 +163,8 @@ int _fmpz_mpoly_parse_pretty(fmpz_mpoly_t poly, const char * s, slong sn,
             if (!(expecting & 1) || ret)
                 goto failed;
             _fmpz_mpoly_parse_pretty_fit_estack(&estack, ei, &ealloc);
-            fmpz_mpoly_init(estack[ei], ctx);
-            fmpz_mpoly_set_fmpz(estack[ei++], c, ctx);
+            fmpz_mpoly_geobucket_init(estack[ei], ctx);
+            fmpz_mpoly_geobucket_set_fmpz(estack[ei++], c, ctx);
             expecting = 2;
 
         } else if (*s == '^')
@@ -157,7 +172,7 @@ int _fmpz_mpoly_parse_pretty(fmpz_mpoly_t poly, const char * s, slong sn,
             s = _fmpz_mpoly_parse_pretty_int(++s, end, c, &ret);
             if (!(expecting & 2) || ret || !fmpz_fits_si(c))
                 goto failed;
-            fmpz_mpoly_pow_fps(estack[ei - 1], estack[ei - 1], fmpz_get_si(c), ctx);
+            fmpz_mpoly_geobucket_pow_inplace(estack[ei - 1], fmpz_get_si(c), ctx);
             expecting = 2;
 
         } else if ((*s == '+' || *s == '-') && (expecting & 2))
@@ -177,6 +192,15 @@ int _fmpz_mpoly_parse_pretty(fmpz_mpoly_t poly, const char * s, slong sn,
             expecting = 1;
 
         } else if (*s == '*')
+        {
+            if (!(expecting & 2)
+                 || _fmpz_mpoly_parse_pretty_pop(estack, ostack, &ei, &oi, ctx, 0))
+                goto failed;
+            _fmpz_mpoly_parse_pretty_fit_ostack(&ostack, oi, &oalloc);
+            ostack[oi++] = *s++;
+            expecting = 1;
+
+        } else if (*s == '/')
         {
             if (!(expecting & 2)
                  || _fmpz_mpoly_parse_pretty_pop(estack, ostack, &ei, &oi, ctx, 0))
@@ -216,8 +240,8 @@ int _fmpz_mpoly_parse_pretty(fmpz_mpoly_t poly, const char * s, slong sn,
             if (!(expecting & 1) || k >= nvars)
                 goto failed;
             _fmpz_mpoly_parse_pretty_fit_estack(&estack, ei, &ealloc);
-            fmpz_mpoly_init(estack[ei], ctx);
-            fmpz_mpoly_gen(estack[ei], k, ctx);
+            fmpz_mpoly_geobucket_init(estack[ei], ctx);
+            fmpz_mpoly_geobucket_gen(estack[ei], k, ctx);
             ei++;
             s += l;
             expecting = 2;
@@ -229,8 +253,8 @@ int _fmpz_mpoly_parse_pretty(fmpz_mpoly_t poly, const char * s, slong sn,
         goto failed;
 
     ret = 0;
-    fmpz_mpoly_swap(poly, estack[0], ctx);
-    fmpz_mpoly_clear(estack[0], ctx);
+    fmpz_mpoly_geobucket_empty(poly, estack[0], ctx);
+    fmpz_mpoly_geobucket_clear(estack[0], ctx);
 
 done:
     for (k = 0; k < ealloc; k++)
@@ -244,7 +268,7 @@ failed:
     ret = -1;
     fmpz_mpoly_set_ui(poly, 0, ctx);
     for (k = 0; k < ei; k++)
-        fmpz_mpoly_clear(estack[k], ctx);
+        fmpz_mpoly_geobucket_clear(estack[k], ctx);
     goto done;
 }
 

--- a/fmpz_mpoly/test/t-print_parse.c
+++ b/fmpz_mpoly/test/t-print_parse.c
@@ -1,0 +1,73 @@
+/*
+    Copyright (C) 2017 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <gmp.h>
+#include "flint.h"
+#include "fmpz.h"
+#include "fmpz_mpoly.h"
+#include "ulong_extras.h"
+
+int
+main(void)
+{
+    slong i;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("print_parse....");
+    fflush(stdout);
+
+    {
+        ordering_t ord;
+        slong nvars, len1, exp_bound1, coeff_bits;
+        fmpz_mpoly_ctx_t ctx;
+        fmpz_mpoly_t f, f1;
+        char * str;
+        const char * vars[] = {"x","y","z","w","u","v"};
+
+        for (i = 0; i < flint_test_multiplier(); i++)
+        {
+            ord = mpoly_ordering_randtest(state);
+            nvars = n_randint(state, 6) + 1;
+
+            fmpz_mpoly_ctx_init(ctx, nvars, ord);
+            fmpz_mpoly_init(f, ctx);
+            fmpz_mpoly_init(f1, ctx);
+
+            for (len1 = 3; len1 < 1000; len1 += len1/2)
+            {
+                exp_bound1 = 1000;
+                coeff_bits = 10;
+                fmpz_mpoly_randtest(f, state, len1, exp_bound1, coeff_bits, ctx);
+
+                str = fmpz_mpoly_get_str_pretty(f, vars, ctx);
+                fmpz_mpoly_set_str_pretty(f1, str, vars, ctx);
+                flint_free(str);
+
+                if (!fmpz_mpoly_equal(f, f1, ctx))
+                {
+                    flint_printf("FAIL\n");
+                    flint_abort();
+                }
+            }
+
+            fmpz_mpoly_clear(f, ctx);
+            fmpz_mpoly_clear(f1, ctx);
+        }
+    }
+
+    printf("PASS\n");
+    FLINT_TEST_CLEANUP(state);
+
+    return 0;
+}
+


### PR DESCRIPTION
This patch adds geobuckets and applies them to parsing. Geobuckets should be useful for certain accumulations in the future as well.

The timings for printing a polynomial of length _length_ and the timings for parsing it with the new and old code are
```
length: 79   PRINT: 1  NEW: 2  OLD: 1
length: 95   PRINT: 0  NEW: 3  OLD: 2
length: 123   PRINT: 1  NEW: 4  OLD: 2
length: 157   PRINT: 1  NEW: 3  OLD: 3
length: 197   PRINT: 1  NEW: 5  OLD: 3
length: 241   PRINT: 1  NEW: 6  OLD: 4
length: 297   PRINT: 1  NEW: 7  OLD: 5
length: 382   PRINT: 2  NEW: 10  OLD: 7
length: 468   PRINT: 2  NEW: 12  OLD: 9
length: 592   PRINT: 3  NEW: 15  OLD: 12
length: 731   PRINT: 4  NEW: 19  OLD: 15
length: 935   PRINT: 4  NEW: 25  OLD: 20
length: 1131   PRINT: 5  NEW: 30  OLD: 26
length: 1444   PRINT: 6  NEW: 40  OLD: 37
length: 1788   PRINT: 8  NEW: 48  OLD: 49
length: 2249   PRINT: 9  NEW: 62  OLD: 68
length: 2784   PRINT: 12  NEW: 76  OLD: 92
length: 3522   PRINT: 15  NEW: 96  OLD: 132
length: 4377   PRINT: 19  NEW: 120  OLD: 187
length: 5450   PRINT: 23  NEW: 150  OLD: 269
length: 6802   PRINT: 29  NEW: 187  OLD: 390
length: 8480   PRINT: 37  NEW: 233  OLD: 570
length: 10712   PRINT: 46  NEW: 294  OLD: 859
length: 13294   PRINT: 57  NEW: 367  OLD: 1275
length: 16638   PRINT: 72  NEW: 461  OLD: 1928
length: 20777   PRINT: 89  NEW: 575  OLD: 2916
length: 26049   PRINT: 112  NEW: 721  OLD: 4467
length: 32519   PRINT: 140  NEW: 898  OLD: 6812
length: 40780   PRINT: 174  NEW: 1127  OLD: 10526
length: 50591   PRINT: 215  NEW: 1403  OLD: 16026
length: 63530   PRINT: 272  NEW: 1772  OLD: 25354
length: 79120   PRINT: 337  NEW: 2190  OLD: 39257
```
The confirms that the old code was quadratic, and shows that the new code appears to be linear. In theory it should be n log n, but I guess n is not big enough to see this.
![screenshot from 2017-11-12 19 45 43](https://user-images.githubusercontent.com/6055563/32702679-9802d210-c7ea-11e7-81c1-7d9056d5390f.png)


