### PR TITLE
-std=c99 must not be used in c++ calls (with clang)

### DIFF
--- a/configure
+++ b/configure
@@ -614,6 +614,7 @@ if [ -z "$CFLAGS" ]; then
       CFLAGS="-O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG $OPENMP_FLAG"
    elif [ "$KERNEL" = FreeBSD ]; then
       CFLAGS="-std=c99 -pedantic -Wall -O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG $OPENMP_FLAG"
+      CXXFLAGS="-std=c++11 -pedantic -Wall -O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG $OPENMP_FLAG"
    else
       CFLAGS="-ansi -pedantic -Wall -O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG $OPENMP_FLAG"
    fi


### PR DESCRIPTION
this is to fix https://github.com/wbhart/flint2/issues/434