### PR TITLE
to create libflint.so.X -> libflint.so.X.Y.Z link on SunOS

### DIFF
--- a/configure
+++ b/configure
@@ -503,7 +503,7 @@ fi
 
 # sometimes LDCONFIG is not to be found in the path. Look at some common places.
 case "$OS" in
-   MINGW*|CYGWIN*|Darwin|FreeBSD)
+   MINGW*|CYGWIN*|Darwin|FreeBSD|SunOS)
       LDCONFIG="true";;
    *)
       if [ -z "$LDCONFIG" ]; then


### PR DESCRIPTION
This is essentially the same workaround as for FreeBSD:
https://github.com/wbhart/flint2/pull/347
With the structure already in place we just need to special-case SunOS