### PR TITLE
Add build directory to includes

### DIFF
--- a/configure
+++ b/configure
@@ -691,7 +691,7 @@ EXTRA_INC_DIRS="${EXTRA_INC_DIRS} ${EXTENSIONS}"
 
 #include paths
 
-INCS="-I\$(CURDIR)"
+INCS="-I\$(CURDIR) -I\$(CURDIR)/build"
 for INC_DIR in ${INC_DIRS} ${EXTRA_INC_DIRS}; do
    INCS="${INCS} -I${INC_DIR}"
 done

--- a/qadic/ctx_init_conway.c
+++ b/qadic/ctx_init_conway.c
@@ -18,11 +18,7 @@
 #include "qadic.h"
 
 int flint_conway_polynomials [] = {
-#if !defined( _MSC_VER)
-#include "../build/CPimport.h"
-#else
 #include "CPimport.h"
-#endif
   0
 };
 


### PR DESCRIPTION
Fixes https://github.com/wbhart/flint2/issues/460 and https://github.com/wbhart/flint2/issues/458

Instead of using relative paths like `../build/`, this adds the build directory to the include directories which is done in CMake builds. `../build` was okay because the build directory was always named `build` in configure/Makefile build system, but in CMake, user specifies the build directory and it has to be `build`, for `../build` to work.