### PR TITLE
various fixes to fmpq_poly_set_str

### DIFF
--- a/fmpq_poly.h
+++ b/fmpq_poly.h
@@ -148,7 +148,7 @@ FLINT_DLL void _fmpq_poly_set_array_mpq(fmpz * poly,
 FLINT_DLL void fmpq_poly_set_array_mpq(fmpq_poly_t poly, 
                                                      const mpq_t * a, slong n);
 
-FLINT_DLL int _fmpq_poly_set_str(fmpz * poly, fmpz_t den, const char * str);
+FLINT_DLL int _fmpq_poly_set_str(fmpz * poly, fmpz_t den, const char * str, slong len);
 
 FLINT_DLL int fmpq_poly_set_str(fmpq_poly_t poly, const char * str);
 

--- a/fmpq_poly/doc/fmpq_poly.txt
+++ b/fmpq_poly/doc/fmpq_poly.txt
@@ -223,31 +223,33 @@ void fmpq_poly_set_array_mpq(fmpq_poly_t poly, const mpq_t * a, slong n)
     The result is only guaranteed to be in canonical form if all 
     input coefficients are given in lowest terms.
 
-int _fmpq_poly_set_str(fmpz * poly, fmpz_t den, const char * str)
+int _fmpq_poly_set_str(fmpz * poly, fmpz_t den, const char * str, slong len)
 
-    Sets \code{(poly, den)} to the polynomial specified by the null-terminated 
-    string \code{str}.
+    Sets \code{(poly, den)} to the polynomial specified by the
+    null-terminated string \code{str} of \code{len} coefficients. The input
+    format is a sequence of coefficients separated by one space.
     
-    The result is only guaranteed to be in lowest terms if all 
+    The result is only guaranteed to be in lowest terms if all
     coefficients in the input string are in lowest terms.
     
-    Returns $0$ if no error occurred.  Otherwise, returns a non-zero value, 
+    Returns $0$ if no error occurred. Otherwise, returns -1
     in which case the resulting value of \code{(poly, den)} is undefined. 
-    If \code{str} is not null-terminated, calling this method might result 
+    If \code{str} is not null-terminated, calling this method might result
     in a segmentation fault.
 
 int fmpq_poly_set_str(fmpq_poly_t poly, const char * str)
 
-    Sets \code{poly} to the polynomial specified by the null-terminated 
-    string \code{str}.
+    Sets \code{poly} to the polynomial specified by the null-terminated
+    string \code{str}. The input format is the same as the output format
+    of \code{fmpq_poly_get_str}: the length given as a decimal integer,
+    then two spaces, then the list of coefficients separated by one space.
     
-    The result is only guaranteed to be in canonical for if all 
+    The result is only guaranteed to be in canonical form if all
     coefficients in the input string are in lowest terms.
     
-    Returns $0$ if no error occurred.  Otherwise, returns a non-zero 
-    value, in which case the resulting value of \code{poly} is undefined. 
-    If \code{str} is not null-terminated, calling this method might result 
-    in a segmentation fault.
+    Returns $0$ if no error occurred.  Otherwise, returns -1 in which case
+    the resulting value of \code{poly} is set to zero. If \code{str} is not
+    null-terminated, calling this method might result in a segmentation fault.
 
 char * fmpq_poly_get_str(const fmpq_poly_t poly)
 

--- a/fmpq_poly/set_str.c
+++ b/fmpq_poly/set_str.c
@@ -1,4 +1,5 @@
 /*
+    Copyright (C) 2018 Vincent Delecroix
     Copyright (C) 2010 Sebastian Pancratz
 
     This file is part of FLINT.
@@ -9,6 +10,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
@@ -20,25 +22,16 @@
 #include "fmpq_poly.h"
 
 int
-_fmpq_poly_set_str(fmpz * poly, fmpz_t den, const char * str)
+_fmpq_poly_set_str(fmpz * poly, fmpz_t den, const char * str, slong len)
 {
     char * w;
-    slong i, len;
+    slong i;
     mpq_t * a;
 
-    len = atol(str);
-    if (len < 0)
+    if (!len)
+        return *str == '\0';
+    if (*str == '\0')
         return -1;
-    if (len == 0)
-    {
-        fmpz_one(den);
-        return 0;
-    }
-
-    a = (mpq_t *) flint_malloc(len * sizeof(mpq_t));
-
-    while (*str++ != ' ')
-        ;
 
     /* Find maximal gap between spaces and allocate w */
     {
@@ -55,6 +48,9 @@ _fmpq_poly_set_str(fmpz * poly, fmpz_t den, const char * str)
         w = (char *) flint_malloc((max + 1) * sizeof(char));
     }
 
+    a = (mpq_t *) flint_malloc(len * sizeof(mpq_t));
+
+    str--;
     for (i = 0; i < len; i++)
     {
         char * v;
@@ -85,7 +81,10 @@ _fmpq_poly_set_str(fmpz * poly, fmpz_t den, const char * str)
     flint_free(a);
     flint_free(w);
 
-    return 0;
+    if (*str != '\0')
+        return -1;
+    else
+        return 0;
 }
 
 int
@@ -93,31 +92,49 @@ fmpq_poly_set_str(fmpq_poly_t poly, const char * str)
 {
     int ans;
     slong len;
+    char * endptr;
 
-    len = atol(str);
-    if (len < 0)
+    /* Get the length (a positive integer) */
+    if (*str < 48 || *str > 57)
+    {
+        fmpq_poly_zero(poly);
         return -1;
+    }
+    errno = 0;
+    len = strtol(str, &endptr, 10);
+    if (errno || len < 0)
+    {
+        fmpq_poly_zero(poly);
+        return -1;
+    }
     if (len == 0)
     {
         fmpq_poly_zero(poly);
+        if (*(str+1) != '\0')
+            return -1;
         return 0;
     }
 
+    /* Check that we have two spaces after the length */
+    endptr++;
+    if (*endptr != ' ')
+    {
+        fmpq_poly_zero(poly);
+        return -1;
+    }
+    endptr++;
+
+    /* Now get the coefficients */
     fmpq_poly_fit_length(poly, len);
-    
-    ans = _fmpq_poly_set_str(poly->coeffs, poly->den, str);
-    
-    if (ans == 0)
+    ans = _fmpq_poly_set_str(poly->coeffs, poly->den, endptr, len);
+
+    if (ans)
     {
-        _fmpq_poly_set_length(poly, len);
-        _fmpq_poly_normalise(poly);
+        fmpq_poly_zero(poly);
+        return -1;
     }
-    else
-    {
-        _fmpz_vec_zero(poly->coeffs, len);
-        fmpz_one(poly->den);
-        _fmpq_poly_set_length(poly, 0);
-    }
-    
-    return ans;
+
+    _fmpq_poly_set_length(poly, len);
+    _fmpq_poly_normalise(poly);
+    return 0;
 }

--- a/fmpq_poly/test/t-get_set_str.c
+++ b/fmpq_poly/test/t-get_set_str.c
@@ -1,4 +1,5 @@
 /*
+    Copyright (C) 2018 Vincent Delecroix
     Copyright (C) 2010 Sebastian Pancratz
     Copyright (C) 2009 William Hart
 
@@ -18,6 +19,23 @@
 #include "fmpq_poly.h"
 #include "ulong_extras.h"
 
+void check_invalid(char * s)
+{
+    fmpq_poly_t p;
+    int err;
+
+    fmpq_poly_init(p);
+    err = fmpq_poly_set_str(p, s);
+    if (!err)
+    {
+        printf("Got no error with s='%s'\n", s);
+        printf("p = "); fmpq_poly_print(p); printf("\n");
+        flint_abort();
+    }
+    fmpq_poly_clear(p);
+}
+
+
 int
 main(void)
 {
@@ -28,6 +46,27 @@ main(void)
 
     flint_printf("get_set_str....");
     fflush(stdout);
+
+    /* badly formatted input */
+    check_invalid("");
+    check_invalid("1");
+    check_invalid("x");
+    check_invalid("-");
+    check_invalid("-1");
+    check_invalid("-1  0");
+    check_invalid("2 X1 0");
+    check_invalid("3 X-2 0 1");
+    check_invalid("2 -1 0 1Y");
+    check_invalid("2 -1 0 1");
+    check_invalid("3   -1 0 1 ");
+    check_invalid("3  -1 0 1 ");
+    check_invalid("3  -1 0  1");
+    check_invalid("3  -1  0 1");
+
+    /* wrong length */
+    check_invalid("0  0");
+    check_invalid("2  -1 0 1");
+    check_invalid("4  0 0");
 
     for (i = 0; i < 1000 * flint_test_multiplier(); i++)
     {
@@ -49,6 +88,7 @@ main(void)
             flint_printf("FAIL:\n");
             flint_printf("f      = "), fmpq_poly_debug(f), flint_printf("\n\n");
             flint_printf("g      = "), fmpq_poly_debug(g), flint_printf("\n\n");
+            flint_printf("str    = %s\n\n", str);
             flint_printf("ans    = %d\n\n", ans);
             flint_printf("cflags = %wu\n\n", cflags);
             abort();


### PR DESCRIPTION
Change the signature of _fmpq_poly_set_str from

  int _fmpq_poly_set_str(fmpz * poly, fmpz_t den, const char * str)

to

  int _fmpq_poly_set_str(fmpz * poly, fmpz_t den, const char * str, slong len)

and make both _fmpq_poly_set_str and fmpq_poly_set_str more strict
about syntax.

Fixes Issue #474 