### PR TITLE
use '=' for string comparison in bash and not '-eq'

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -210,7 +210,7 @@ install: library
 	mkdir -p "$(DESTDIR)$(PREFIX)/include/flint/flintxx"
 	cp flintxx/*.h "$(DESTDIR)$(PREFIX)/include/flint/flintxx"
 	cp *xx.h "$(DESTDIR)$(PREFIX)/include/flint"
-	$(AT)if [ "$(OS)" -eq "Darwin" ]; then \
+	$(AT)if [ "$(OS)" = "Darwin" ]; then \
 		install_name_tool -id "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(FLINT_LIB)" "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(FLINT_LIBNAME)"; \
 	fi
 


### PR DESCRIPTION
-eq in bash is for comparing integers, not strings (http://tldp.org/LDP/abs/html/comparison-ops.html)