### PR TITLE
Fix documentation: s/res/rop/ when needed.

### DIFF
--- a/fmpz_mod_poly/doc/fmpz_mod_poly.txt
+++ b/fmpz_mod_poly/doc/fmpz_mod_poly.txt
@@ -75,7 +75,7 @@ void fmpz_mod_poly_truncate(fmpz_mod_poly_t poly, slong len)
     is truncated to have the given length.  Discarded coefficients are
     not necessarily set to zero.
 
-void fmpz_mod_poly_set_trunc(fmpz_mod_poly_t res, 
+void fmpz_mod_poly_set_trunc(fmpz_mod_poly_t res,
                                            const fmpz_mod_poly_t poly, slong n)
 
     Notionally truncate \code{poly} to length $n$ and set \code{res} to the
@@ -428,17 +428,17 @@ void fmpz_mod_poly_scalar_mul_fmpz(fmpz_mod_poly_t res,
 
 *******************************************************************************
 
-void _fmpz_mod_poly_scalar_div_fmpz(fmpz *res, const fmpz *poly, slong len, 
+void _fmpz_mod_poly_scalar_div_fmpz(fmpz *res, const fmpz *poly, slong len,
                                                 const fmpz_t x, const fmpz_t p)
 
-    Sets \code{(res, len}) to \code{(poly, len)} divided by $x$ (i.e. 
+    Sets \code{(res, len}) to \code{(poly, len)} divided by $x$ (i.e.
     multiplied by the inverse of $x \pmod{p}$). The result is reduced modulo
     $p$.
 
-void fmpz_mod_poly_scalar_div_fmpz(fmpz_mod_poly_t res, 
+void fmpz_mod_poly_scalar_div_fmpz(fmpz_mod_poly_t res,
                                     const fmpz_mod_poly_t poly, const fmpz_t x)
 
-    Sets \code{res} to \code{poly} divided by $x$, (i.e. multiplied by the 
+    Sets \code{res} to \code{poly} divided by $x$, (i.e. multiplied by the
     inverse of $x \pmod{p}$). The result is reduced modulo $p$.
 
 *******************************************************************************
@@ -542,7 +542,7 @@ void _fmpz_mod_poly_product_roots_fmpz_vec(fmpz * poly, const fmpz * xs, slong n
     of $(x - x_0)(x - x_1) \cdots (x - x_{n-1})$, the roots $x_i$ being
     given by \code{xs}. The coefficients reduced modulo \code{f}.
 
-    Aliasing of the input and output is not allowed. It is required that 
+    Aliasing of the input and output is not allowed. It is required that
     \code{poly} is reduced modulo \code{f}.
 
 
@@ -564,13 +564,13 @@ void fmpz_mod_poly_product_roots_fmpz_vec(fmpz_poly_t poly, const fmpz * xs,
 void _fmpz_mod_poly_pow(fmpz *rop, const fmpz *op, slong len, ulong e,
                         const fmpz_t p)
 
-    Sets \code{res = poly^e}, assuming that $e > 1$ and \code{elen > 0},
+    Sets \code{rop = poly^e}, assuming that $e > 1$ and \code{elen > 0},
     and that \code{res} has space for \code{e*(len - 1) + 1} coefficients.
     Does not support aliasing.
 
 void fmpz_mod_poly_pow(fmpz_mod_poly_t rop, const fmpz_mod_poly_t op, ulong e)
 
-    Computes \code{res = poly^e}.  If $e$ is zero, returns one,
+    Computes \code{rop = poly^e}.  If $e$ is zero, returns one,
     so that in particular \code{0^0 = 1}.
 
 void _fmpz_mod_poly_pow_trunc(fmpz * res, const fmpz * poly,
@@ -691,7 +691,7 @@ void fmpz_mod_poly_powmod_fmpz_binexp_preinv(fmpz_mod_poly_t res,
     modulo \code{f}, using binary exponentiation. We require \code{e >= 0}.
     We require \code{finv} to be the inverse of the reverse of \code{f}.
 
-void _fmpz_mod_poly_powmod_x_fmpz_preinv(fmpz * res, const fmpz_t e, 
+void _fmpz_mod_poly_powmod_x_fmpz_preinv(fmpz * res, const fmpz_t e,
                   const fmpz * f, slong lenf, const fmpz* finv, slong lenfinv,
                                   const fmpz_t p)
 
@@ -702,7 +702,7 @@ void _fmpz_mod_poly_powmod_x_fmpz_preinv(fmpz * res, const fmpz_t e,
     We require \code{lenf > 2}. The output \code{res} must have room for
     \code{lenf - 1} coefficients.
 
-void fmpz_mod_poly_powmod_x_fmpz_preinv(fmpz_mod_poly_t res, 
+void fmpz_mod_poly_powmod_x_fmpz_preinv(fmpz_mod_poly_t res,
            const fmpz_t e, const fmpz_mod_poly_t f, const fmpz_mod_poly_t finv)
 
     Sets \code{res} to \code{x} raised to the power \code{e}
@@ -710,13 +710,13 @@ void fmpz_mod_poly_powmod_x_fmpz_preinv(fmpz_mod_poly_t res,
     \code{e >= 0}. We require \code{finv} to be the inverse of the reverse of
     \code{f}.
 
-void 
+void
 fmpz_mod_poly_frobenius_powers_2exp_precomp(
-                   fmpz_mod_poly_frobenius_powers_2exp_t pow, 
+                   fmpz_mod_poly_frobenius_powers_2exp_t pow,
                   const fmpz_mod_poly_t f, const fmpz_mod_poly_t finv, ulong m)
 
-    If \code{p = f->p}, compute $x^(p^1)$, $x^(p^2)$, $x^(p^4)$, ..., 
-    $x^(p^(2^l)) \pmod{f}$ where $2^l$ is the greatest power of $2$ less than 
+    If \code{p = f->p}, compute $x^(p^1)$, $x^(p^2)$, $x^(p^4)$, ...,
+    $x^(p^(2^l)) \pmod{f}$ where $2^l$ is the greatest power of $2$ less than
     or equal to $m$.
 
     Allows construction of $x^(p^k)$ for $k = 0$, $1$, ..., $x^(p^m) \pmod{f}$
@@ -724,15 +724,15 @@ fmpz_mod_poly_frobenius_powers_2exp_precomp(
 
     Requires precomputed inverse of $f$, i.e. newton inverse.
 
-void 
+void
 fmpz_mod_poly_frobenius_powers_2exp_clear(fmpz_mod_poly_frobenius_powers_2exp_t
                                           pow)
 
-    Clear resources used by the \code{fmpz_mod_poly_frobenius_powers_2exp_t} 
+    Clear resources used by the \code{fmpz_mod_poly_frobenius_powers_2exp_t}
     struct.
 
 void fmpz_mod_poly_frobenius_power(fmpz_mod_poly_t res,
-                             fmpz_mod_poly_frobenius_powers_2exp_t pow, 
+                             fmpz_mod_poly_frobenius_powers_2exp_t pow,
                                               const fmpz_mod_poly_t f, ulong m)
 
     If \code{p = f->p}, compute $x^(p^m) \pmod{f}$.
@@ -740,15 +740,15 @@ void fmpz_mod_poly_frobenius_power(fmpz_mod_poly_t res,
     Requires precomputed frobenius powers supplied by
     \code{fmpz_mod_poly_frobenius_powers_2exp_precomp}.
 
-    If $m == 0$ and $f$ has degree $0$ or $1$, this performs a division. 
+    If $m == 0$ and $f$ has degree $0$ or $1$, this performs a division.
     However an impossible inverse by the leading coefficient of $f$ will have
     been caught by \code{fmpz_mod_poly_frobenius_powers_2exp_precomp}.
 
 void
-fmpz_mod_poly_frobenius_powers_precomp(fmpz_mod_poly_frobenius_powers_t pow, 
+fmpz_mod_poly_frobenius_powers_precomp(fmpz_mod_poly_frobenius_powers_t pow,
                   const fmpz_mod_poly_t f, const fmpz_mod_poly_t finv, ulong m)
 
-    If \code{p = f->p}, compute $x^(p^0)$, $x^(p^1)$, $x^(p^2)$, $x^(p^3)$, 
+    If \code{p = f->p}, compute $x^(p^0)$, $x^(p^1)$, $x^(p^2)$, $x^(p^3)$,
     ..., $x^(p^m) \pmod{f}$.
 
     Requires precomputed inverse of $f$, i.e. newton inverse.
@@ -756,7 +756,7 @@ fmpz_mod_poly_frobenius_powers_precomp(fmpz_mod_poly_frobenius_powers_t pow,
 void
 fmpz_mod_poly_frobenius_powers_clear(fmpz_mod_poly_frobenius_powers_t pow);
 
-    Clear resources used by the \code{fmpz_mod_poly_frobenius_powers_t} 
+    Clear resources used by the \code{fmpz_mod_poly_frobenius_powers_t}
     struct.
 
 *******************************************************************************
@@ -983,7 +983,7 @@ void _fmpz_mod_poly_rem_f(fmpz_t f, fmpz *R,
                         const fmpz_t invB, const fmpz_t p)
 
     If $f$ returns with the value $1$ then the function operates as
-    \code{_fmpz_mod_poly_rem}, otherwise $f$ will be set to a nontrivial 
+    \code{_fmpz_mod_poly_rem}, otherwise $f$ will be set to a nontrivial
     factor of $p$.
 
 void fmpz_mod_poly_rem(fmpz_mod_poly_t R,
@@ -1016,7 +1016,7 @@ void fmpz_mod_poly_inv_series_newton(fmpz_mod_poly_t Qinv,
     where $n \geq 1$, assuming that the bottom coefficient of
     $Q$ is a unit.
 
-void fmpz_mod_poly_inv_series_newton_f(fmpz_t f, fmpz_mod_poly_t Qinv, 
+void fmpz_mod_poly_inv_series_newton_f(fmpz_t f, fmpz_mod_poly_t Qinv,
     const fmpz_mod_poly_t Q, slong n)
 
     Either sets $f$ to a nontrivial factor of $p$ with the value of
@@ -1037,7 +1037,7 @@ void fmpz_mod_poly_inv_series(fmpz_mod_poly_t Qinv,
     where $n \geq 1$, assuming that the bottom coefficient of
     $Q$ is a unit.
 
-void fmpz_mod_poly_inv_series_f(fmpz_t f, fmpz_mod_poly_t Qinv, 
+void fmpz_mod_poly_inv_series_f(fmpz_t f, fmpz_mod_poly_t Qinv,
     const fmpz_mod_poly_t Q, slong n)
 
     Either sets $f$ to a nontrivial factor of $p$ with the value of
@@ -1057,7 +1057,7 @@ void _fmpz_mod_poly_div_series(fmpz * Q, const fmpz * A, slong Alen,
     \code{(B, Blen)} assuming \code{Alen, Blen <= n}. We assume the bottom
     coefficient of \code{B} is invertible modulo $p$.
 
-void fmpz_mod_poly_div_series(fmpz_mod_poly_t Q, const fmpz_mod_poly_t A, 
+void fmpz_mod_poly_div_series(fmpz_mod_poly_t Q, const fmpz_mod_poly_t A,
                                               const fmpz_mod_poly_t B, slong n)
 
     Set $Q$ to the quotient of the series $A$ by $B$, thinking of the series as
@@ -1078,10 +1078,10 @@ void fmpz_mod_poly_make_monic(fmpz_mod_poly_t res, const fmpz_mod_poly_t poly)
 
     Otherwise, if \code{poly} is zero, sets \code{res} to zero.
 
-void fmpz_mod_poly_make_monic_f(fmpz_t f, fmpz_mod_poly_t res, 
+void fmpz_mod_poly_make_monic_f(fmpz_t f, fmpz_mod_poly_t res,
                                                     const fmpz_mod_poly_t poly)
 
-    Either set $f$ to $1$ and \code{res} to \code{poly} divided by its leading 
+    Either set $f$ to $1$ and \code{res} to \code{poly} divided by its leading
     coefficient or set $f$ to a nontrivial factor of $p$ and leave \code{res}
     undefined.
 
@@ -1181,9 +1181,9 @@ void fmpz_mod_poly_gcd_f(fmpz_t f, fmpz_mod_poly_t G,
     ring $(\mathbf{Z}/(p \mathbf{Z}))[X]$ if and only if $p$ is a prime
     number.
 
-slong _fmpz_mod_poly_hgcd(fmpz **M, slong *lenM, 
-                     fmpz *A, slong *lenA, fmpz *B, slong *lenB, 
-                     const fmpz *a, slong lena, const fmpz *b, slong lenb, 
+slong _fmpz_mod_poly_hgcd(fmpz **M, slong *lenM,
+                     fmpz *A, slong *lenA, fmpz *B, slong *lenB,
+                     const fmpz *a, slong lena, const fmpz *b, slong lenb,
                      const fmpz_t mod)
 
     Computes the HGCD of $a$ and $b$, that is, a matrix~$M$, a sign~$\sigma$
@@ -1201,7 +1201,7 @@ slong _fmpz_mod_poly_hgcd(fmpz **M, slong *lenM,
     Assumes that \code{M[0]}, \code{M[1]}, \code{M[2]}, and \code{M[3]}
     each point to a vector of size at least $\len(a)$.
 
-slong _fmpz_mod_poly_gcd_hgcd(fmpz *G, const fmpz *A, slong lenA, 
+slong _fmpz_mod_poly_gcd_hgcd(fmpz *G, const fmpz *A, slong lenA,
                                    const fmpz *B, slong lenB, const fmpz_t mod)
 
     Computes the monic GCD of $A$ and $B$, assuming that
@@ -1210,7 +1210,7 @@ slong _fmpz_mod_poly_gcd_hgcd(fmpz *G, const fmpz *A, slong lenA,
     Assumes that $G$ has space for $\len(B)$ coefficients and
     returns the length of $G$ on output.
 
-void fmpz_mod_poly_gcd_hgcd(fmpz_mod_poly_t G, 
+void fmpz_mod_poly_gcd_hgcd(fmpz_mod_poly_t G,
                               const fmpz_mod_poly_t A, const fmpz_mod_poly_t B)
 
     Computes the monic GCD of $A$ and $B$ using the HGCD algorithm.
@@ -1218,7 +1218,7 @@ void fmpz_mod_poly_gcd_hgcd(fmpz_mod_poly_t G,
     As a special case, the GCD of two zero polynomials is defined to be
     the zero polynomial.
 
-    The time complexity of the algorithm is $\mathcal{O}(n \log^2 n)$ 
+    The time complexity of the algorithm is $\mathcal{O}(n \log^2 n)$
     ring operations. For further details, see~\citep{ThullYap1990}.
 
 slong _fmpz_mod_poly_xgcd_euclidean(fmpz *G, fmpz *S, fmpz *T,
@@ -1249,7 +1249,7 @@ slong _fmpz_mod_poly_xgcd_euclidean_f(fmpz_t f, fmpz *G, fmpz *S, fmpz *T,
     If $f$ returns with the value $1$ then the function operates as per
     \code{_fmpz_mod_poly_xgcd_euclidean}, otherwise $f$ is set to a nontrivial
     factor of $p$.
- 
+
 void fmpz_mod_poly_xgcd_euclidean(fmpz_mod_poly_t G,
                              fmpz_mod_poly_t S, fmpz_mod_poly_t T,
                              const fmpz_mod_poly_t A, const fmpz_mod_poly_t B)
@@ -1271,8 +1271,8 @@ void fmpz_mod_poly_xgcd_euclidean_f(fmpz_t f, fmpz_mod_poly_t G,
     \code{fmpz_mod_poly_xgcd_euclidean}, otherwise $f$ is set to a nontrivial
     factor of $p$.
 
-slong _fmpz_mod_poly_xgcd_hgcd(fmpz *G, fmpz *S, fmpz *T, 
-               const fmpz *A, slong lenA, const fmpz *B, slong lenB, 
+slong _fmpz_mod_poly_xgcd_hgcd(fmpz *G, fmpz *S, fmpz *T,
+               const fmpz *A, slong lenA, const fmpz *B, slong lenB,
                                                               const fmpz_t mod)
 
     Computes the GCD of $A$ and $B$, where $\len(A) \geq \len(B) > 0$,
@@ -1290,7 +1290,7 @@ slong _fmpz_mod_poly_xgcd_hgcd(fmpz *G, fmpz *S, fmpz *T,
 
     No aliasing of input and output operands is permitted.
 
-void fmpz_mod_poly_xgcd_hgcd(fmpz_mod_poly_t G, fmpz_mod_poly_t S, 
+void fmpz_mod_poly_xgcd_hgcd(fmpz_mod_poly_t G, fmpz_mod_poly_t S,
            fmpz_mod_poly_t T, const fmpz_mod_poly_t A, const fmpz_mod_poly_t B)
 
     Computes the GCD of $A$ and $B$. The GCD of zero polynomials is
@@ -1366,14 +1366,14 @@ slong _fmpz_mod_poly_gcdinv_euclidean_f(fmpz_t f, fmpz *G, fmpz *S,
                          const fmpz_t p)
 
     If $f$ returns with value $1$ then the function operates as per
-    \code{_fmpz_mod_poly_gcdinv_euclidean}, otherwise $f$ is set to a 
+    \code{_fmpz_mod_poly_gcdinv_euclidean}, otherwise $f$ is set to a
     nontrivial factor of $p$.
 
 void fmpz_mod_poly_gcdinv_euclidean_f(fmpz_t f, fmpz_mod_poly_t G,
        fmpz_mod_poly_t S, const fmpz_mod_poly_t A, const fmpz_mod_poly_t B)
 
     If $f$ returns with value $1$ then the function operates as per
-    \code{fmpz_mod_poly_gcdinv_euclidean}, otherwise $f$ is set to a 
+    \code{fmpz_mod_poly_gcdinv_euclidean}, otherwise $f$ is set to a
     nontrivial factor of the modulus of $A$.
 
 slong _fmpz_mod_poly_gcdinv(fmpz *G, fmpz *S,
@@ -1431,7 +1431,7 @@ int _fmpz_mod_poly_invmod_f(fmpz_t f, fmpz *A,
     If $f$ returns with the value $1$, then the function operates as per
     \code{_fmpz_mod_poly_invmod}. Otherwise $f$ is set to a nontrivial
     factor of $p$.
-    
+
 int fmpz_mod_poly_invmod(fmpz_mod_poly_t A,
                          const fmpz_mod_poly_t B, const fmpz_mod_poly_t P)
 
@@ -1458,15 +1458,15 @@ int fmpz_mod_poly_invmod_f(fmpz_t f, fmpz_mod_poly_t A,
 
 *******************************************************************************
 
-slong _fmpz_mod_poly_minpoly_bm(fmpz* poly, 
+slong _fmpz_mod_poly_minpoly_bm(fmpz* poly,
                                 const fmpz* seq, slong len, const fmpz_t p)
-    
+
     Sets \code{poly} to the coefficients of a minimal generating
     polynomial for sequence \code{(seq, len)} modulo $p$.
 
     The return value equals the length of \code{poly}.
 
-    It is assumed that $p$ is prime and \code{poly} has space for at least 
+    It is assumed that $p$ is prime and \code{poly} has space for at least
     $len+1$ coefficients. No aliasing between inputs and outputs is
     allowed.
 
@@ -1480,15 +1480,15 @@ void fmpz_mod_poly_minpoly_bm(fmpz_mod_poly_t poly, const fmpz* seq, slong len)
     This version uses the Berlekamp-Massey algorithm, whose running time
     is proportional to \code{len} times the size of the minimal generator.
 
-slong _fmpz_mod_poly_minpoly_hgcd(fmpz* poly, 
+slong _fmpz_mod_poly_minpoly_hgcd(fmpz* poly,
                  const fmpz* seq, slong len, const fmpz_t p)
-    
+
     Sets \code{poly} to the coefficients of a minimal generating
     polynomial for sequence \code{(seq, len)} modulo $p$.
 
     The return value equals the length of \code{poly}.
 
-    It is assumed that $p$ is prime and \code{poly} has space for at least 
+    It is assumed that $p$ is prime and \code{poly} has space for at least
     $len+1$ coefficients. No aliasing between inputs and outputs is
     allowed.
 
@@ -1510,7 +1510,7 @@ slong _fmpz_mod_poly_minpoly(fmpz* poly, const fmpz* seq, slong len, const fmpz_
 
     The return value equals the length of \code{poly}.
 
-    It is assumed that $p$ is prime and \code{poly} has space for at least 
+    It is assumed that $p$ is prime and \code{poly} has space for at least
     $len+1$ coefficients. No aliasing between inputs and outputs is
     allowed.
 
@@ -1538,8 +1538,8 @@ void fmpz_mod_poly_minpoly(fmpz_mod_poly_t poly, const fmpz* seq, slong len)
 
 *******************************************************************************
 
-void _fmpz_mod_poly_resultant_euclidean(fmpz_t res, 
-                                     const fmpz *poly1, slong len1, 
+void _fmpz_mod_poly_resultant_euclidean(fmpz_t res,
+                                     const fmpz *poly1, slong len1,
                                const fmpz *poly2, slong len2, const fmpz_t mod)
 
     Sets $r$ to the resultant of \code{(poly1, len1)} and
@@ -1549,7 +1549,7 @@ void _fmpz_mod_poly_resultant_euclidean(fmpz_t res,
 
     Asumes that the modulus is prime.
 
-void fmpz_mod_poly_resultant_euclidean(fmpz_t r, 
+void fmpz_mod_poly_resultant_euclidean(fmpz_t r,
                               const fmpz_mod_poly_t f, const fmpz_mod_poly_t g)
 
     Computes the resultant of $f$ and $g$ using the Euclidean algorithm.
@@ -1563,13 +1563,13 @@ void fmpz_mod_poly_resultant_euclidean(fmpz_t r,
     For convenience, we define the resultant to be equal to zero if either
     of the two polynomials is zero.
 
-void _fmpz_mod_poly_resultant_hgcd(fmpz_t res, const fmpz *A, slong lenA, 
+void _fmpz_mod_poly_resultant_hgcd(fmpz_t res, const fmpz *A, slong lenA,
                                    const fmpz *B, slong lenB, const fmpz_t mod)
 
     Sets \code{res} to the resultant of \code{(A, lenA)} and
     \code{(B, lenB)} using the half-gcd algorithm.
 
-    This algorithm computes the half-gcd as per 
+    This algorithm computes the half-gcd as per
     \code{_fmpz_mod_poly_gcd_hgcd()}
     but additionally updates the resultant every time a division occurs. The
     half-gcd algorithm computes the GCD recursively. Given inputs $a$ and $b$
@@ -1577,10 +1577,10 @@ void _fmpz_mod_poly_resultant_hgcd(fmpz_t res, const fmpz *A, slong lenA,
     the Euclidean algorithm which do not require the low $m$ coefficients of
     $a$ and $b$.
 
-    This performs quotients in exactly the same order as the ordinary 
+    This performs quotients in exactly the same order as the ordinary
     Euclidean algorithm except that the low $m$ coefficients of the polynomials
-    in the remainder sequence are not computed. A correction step after hgcd 
-    has been called computes these low $m$ coefficients (by matrix 
+    in the remainder sequence are not computed. A correction step after hgcd
+    has been called computes these low $m$ coefficients (by matrix
     multiplication by a transformation matrix also computed by hgcd).
 
     This means that from the point of view of the resultant, all but the last
@@ -1591,8 +1591,8 @@ void _fmpz_mod_poly_resultant_hgcd(fmpz_t res, const fmpz *A, slong lenA,
 
     To compute the adjustments to the resultant coming from this corrected
     quotient, we save the relevant information in an \code{nmod_poly_res_t}
-    struct at the time the quotient is performed so that when the correction 
-    step is performed later, the adjustments to the resultant can be computed 
+    struct at the time the quotient is performed so that when the correction
+    step is performed later, the adjustments to the resultant can be computed
     at that time also.
 
     The only time an adjustment to the resultant is not required after a
@@ -1603,7 +1603,7 @@ void _fmpz_mod_poly_resultant_hgcd(fmpz_t res, const fmpz *A, slong lenA,
 
     Asumes that the modulus is prime.
 
-void fmpz_mod_poly_resultant_hgcd(fmpz_t res, const fmpz_mod_poly_t f, 
+void fmpz_mod_poly_resultant_hgcd(fmpz_t res, const fmpz_mod_poly_t f,
                                                        const fmpz_mod_poly_t g)
 
     Computes the resultant of $f$ and $g$ using the half-gcd algorithm.
@@ -1617,7 +1617,7 @@ void fmpz_mod_poly_resultant_hgcd(fmpz_t res, const fmpz_mod_poly_t f,
     For convenience, we define the resultant to be equal to zero if either
     of the two polynomials is zero.
 
-void _fmpz_mod_poly_resultant(fmpz_t res, const fmpz *poly1, slong len1, 
+void _fmpz_mod_poly_resultant(fmpz_t res, const fmpz *poly1, slong len1,
                               const fmpz *poly2, slong len2, const fmpz_t mod)
 
     Returns the resultant of \code{(poly1, len1)} and
@@ -1627,7 +1627,7 @@ void _fmpz_mod_poly_resultant(fmpz_t res, const fmpz *poly1, slong len1,
 
     Asumes that the modulus is prime.
 
-void fmpz_mod_poly_resultant(fmpz_t res, const fmpz_mod_poly_t f, 
+void fmpz_mod_poly_resultant(fmpz_t res, const fmpz_mod_poly_t f,
                                                        const fmpz_mod_poly_t g)
     Computes the resultant of $f$ and $g$.
 
@@ -1646,7 +1646,7 @@ void fmpz_mod_poly_resultant(fmpz_t res, const fmpz_mod_poly_t f,
 
 *******************************************************************************
 
-void _fmpz_mod_poly_discriminant(fmpz_t d, const fmpz *poly, 
+void _fmpz_mod_poly_discriminant(fmpz_t d, const fmpz *poly,
                                                    slong len, const fmpz_t mod)
 
     Set $d$ to the discriminant of \code{(poly, len)}. Assumes \code{len > 1}.

--- a/fq_nmod_poly/doc/fq_nmod_poly.txt
+++ b/fq_nmod_poly/doc/fq_nmod_poly.txt
@@ -89,7 +89,7 @@ void fq_nmod_poly_truncate(fq_nmod_poly_t poly, slong newlen,
 
     Truncates the polynomial to length at most~$n$.
 
-void fq_nmod_poly_set_trunc(fq_nmod_poly_t poly1, fq_nmod_poly_t poly2, 
+void fq_nmod_poly_set_trunc(fq_nmod_poly_t poly1, fq_nmod_poly_t poly2,
                                            slong newlen, const fq_ctx_t ctx)
 
     Sets \code{poly1} to \code{poly2} truncated to length~$n$.
@@ -309,7 +309,7 @@ void fq_nmod_poly_add(fq_nmod_poly_t res, const fq_nmod_poly_t poly1,
 
     Sets \code{res} to the sum of \code{poly1} and \code{poly2}.
 
-void fq_nmod_poly_add_series(fq_poly_t res, const fq_poly_t poly1, 
+void fq_nmod_poly_add_series(fq_poly_t res, const fq_poly_t poly1,
            const fq_poly_t poly2, slong n, const fq_ctx_t ctx)
 
     Notionally truncate \code{poly1} and \code{poly2} to length \code{n} and set
@@ -328,7 +328,7 @@ void fq_nmod_poly_sub(fq_nmod_poly_t res, const fq_nmod_poly_t poly1,
 
     Sets \code{res} to the difference of \code{poly1} and \code{poly2}.
 
-void fq_nmod_poly_sub_series(fq_poly_t res, const fq_poly_t poly1, 
+void fq_nmod_poly_sub_series(fq_poly_t res, const fq_poly_t poly1,
            const fq_poly_t poly2, slong n, const fq_ctx_t ctx)
 
     Notionally truncate \code{poly1} and \code{poly2} to length \code{n} and set
@@ -337,7 +337,7 @@ void fq_nmod_poly_sub_series(fq_poly_t res, const fq_poly_t poly1,
 void _fq_nmod_poly_neg(fq_nmod_struct *rop, const fq_nmod_struct *op, slong len,
                   const fq_nmod_ctx_t ctx)
 
-    Sets \code{res} to the additive inverse of \code{(poly,len)}.
+    Sets \code{rop} to the additive inverse of \code{(poly,len)}.
 
 void fq_nmod_poly_neg(fq_nmod_poly_t res, const fq_nmod_poly_t poly,
                       const fq_nmod_ctx_t ctx)
@@ -517,8 +517,8 @@ void _fq_nmod_poly_mullow_classical(fq_nmod_struct *rop,
                                     const fq_nmod_struct *op2, slong len2, slong n,
                                     const fq_nmod_ctx_t ctx)
 
-    Sets \code{(res, n)} to the first $n$ coefficients of
-    \code{(poly1, len1)} multiplied by \code{(poly2, len2)}.
+    Sets \code{(rop, n)} to the first $n$ coefficients of
+    \code{(op1, len1)} multiplied by \code{(op2, len2)}.
 
     Assumes \code{0 < n <= len1 + len2 - 1}.  Assumes neither
     \code{len1} nor \code{len2} is zero.
@@ -526,7 +526,7 @@ void _fq_nmod_poly_mullow_classical(fq_nmod_struct *rop,
 void fq_nmod_poly_mullow_classical(fq_nmod_poly_t rop,
     const fq_nmod_poly_t op1, const fq_nmod_poly_t op2, slong n, const fq_nmod_ctx_t ctx)
 
-    Sets \code{res} to the product of \code{poly1} and \code{poly2},
+    Sets \code{rop} to the product of \code{op1} and \code{op2},
     computed using the classical or schoolbook method.
 
 void _fq_nmod_poly_mullow_univariate(fq_nmod_struct *rop,
@@ -534,20 +534,20 @@ void _fq_nmod_poly_mullow_univariate(fq_nmod_struct *rop,
                              const fq_nmod_struct *op2, slong len2, slong n,
                              const fq_nmod_ctx_t ctx)
 
-    Sets \code{(res, n)} to the lowest $n$ coefficients of the product of
-    \code{(poly1, len1)} and \code{(poly2, len2)}, computed using a
+    Sets \code{(rop, n)} to the lowest $n$ coefficients of the product of
+    \code{(op1, len1)} and \code{(op2, len2)}, computed using a
     bivariate to univariate transformation.
 
     Assumes that \code{len1} and \code{len2} are positive, but does allow
     for the polynomials to be zero-padded.  The polynomials may be zero,
-    too.  Assumes $n$ is positive.  Supports aliasing between \code{res},
-    \code{poly1} and \code{poly2}.
+    too.  Assumes $n$ is positive.  Supports aliasing between \code{rop},
+    \code{op1} and \code{op2}.
 
 void fq_nmod_poly_mullow_univariate(fq_nmod_poly_t rop,
                             const fq_nmod_poly_t op1, const fq_nmod_poly_t op2,
                             slong n, const fq_nmod_ctx_t ctx)
 
-    Sets \code{res} to the lowest $n$ coefficients of the product of
+    Sets \code{rop} to the lowest $n$ coefficients of the product of
     \code{poly1} and \code{poly2}, computed using a bivariate to
     univariate transformation.
 
@@ -556,27 +556,27 @@ void _fq_nmod_poly_mullow_KS(fq_nmod_struct *rop,
                              const fq_nmod_struct *op2, slong len2, slong n,
                              const fq_nmod_ctx_t ctx)
 
-    Sets \code{(res, n)} to the lowest $n$ coefficients of the product of
-    \code{(poly1, len1)} and \code{(poly2, len2)}.
+    Sets \code{(rop, n)} to the lowest $n$ coefficients of the product of
+    \code{(op1, len1)} and \code{(op2, len2)}.
 
     Assumes that \code{len1} and \code{len2} are positive, but does allow
     for the polynomials to be zero-padded.  The polynomials may be zero,
-    too.  Assumes $n$ is positive.  Supports aliasing between \code{res},
-    \code{poly1} and \code{poly2}.
+    too.  Assumes $n$ is positive.  Supports aliasing between \code{rop},
+    \code{op1} and \code{op2}.
 
 void fq_nmod_poly_mullow_KS(fq_nmod_poly_t rop,
                             const fq_nmod_poly_t op1, const fq_nmod_poly_t op2,
                             slong n, const fq_nmod_ctx_t ctx)
 
-    Sets \code{res} to the product of \code{poly1} and \code{poly2}.
+    Sets \code{rop} to the product of \code{op1} and \code{op2}.
 
 void _fq_nmod_poly_mullow(fq_nmod_struct *rop,
                           const fq_nmod_struct *op1, slong len1,
                           const fq_nmod_struct *op2, slong len2, slong n,
                           const fq_nmod_ctx_t ctx)
 
-    Sets \code{(res, n)} to the lowest $n$ coefficients of the product of
-    \code{(poly1, len1)} and \code{(poly2, len2)}.
+    Sets \code{(rop, n)} to the lowest $n$ coefficients of the product of
+    \code{(op1, len1)} and \code{(op2, len2)}.
 
     Assumes \code{0 < n <= len1 + len2 - 1}.  Allows for zero-padding in
     the inputs.  Does not support aliasing between the inputs and the output.
@@ -585,8 +585,8 @@ void fq_nmod_poly_mullow(fq_nmod_poly_t rop,
                          const fq_nmod_poly_t op1, const fq_nmod_poly_t op2, slong n,
                          const fq_nmod_ctx_t ctx)
 
-    Sets \code{res} to the lowest $n$ coefficients of the product of
-    \code{poly1} and \code{poly2}.
+    Sets \code{rop} to the lowest $n$ coefficients of the product of
+    \code{op1} and \code{op2}.
 
 void _fq_nmod_poly_mulhigh_classical(fq_nmod_struct *res,
                                      const fq_nmod_struct *poly1, slong len1,
@@ -743,14 +743,14 @@ void fq_nmod_poly_sqr(fq_nmod_poly_t rop, const fq_nmod_poly_t op,
 void _fq_nmod_poly_pow(fq_nmod_struct *rop, const fq_nmod_struct *op, slong len,
                        ulong e, const fq_nmod_ctx_t ctx)
 
-    Sets \code{res = poly^e}, assuming that \code{e, len > 0} and that
-    \code{res} has space for \code{e*(len - 1) + 1} coefficients.  Does
+    Sets \code{rop = op^e}, assuming that \code{e, len > 0} and that
+    \code{rop} has space for \code{e*(len - 1) + 1} coefficients.  Does
     not support aliasing.
 
 void fq_nmod_poly_pow(fq_nmod_poly_t rop, const fq_nmod_poly_t op, ulong e,
                       const fq_nmod_ctx_t ctx)
 
-    Computes \code{res = poly^e}.  If $e$ is zero, returns one,
+    Computes \code{rop = op^e}.  If $e$ is zero, returns one,
     so that in particular \code{0^0 = 1}.
 
 void _fq_nmod_poly_powmod_ui_binexp(fq_nmod_struct* res,
@@ -917,37 +917,37 @@ fq_nmod_poly_powmod_x_fmpz_preinv(fq_nmod_poly_t res, const fmpz_t e,
 void _fq_nmod_poly_shift_left(fq_nmod_struct *rop, const fq_nmod_struct *op,
                               slong len, slong n, const fq_nmod_ctx_t ctx)
 
-    Sets \code{(res, len + n)} to \code{(poly, len)} shifted left by
+    Sets \code{(rop, len + n)} to \code{(op, len)} shifted left by
     $n$ coefficients.
 
     Inserts zero coefficients at the lower end.  Assumes that
-    \code{len} and $n$ are positive, and that \code{res} fits
-    \code{len + n} elements.  Supports aliasing between \code{res} and
-    \code{poly}.
+    \code{len} and $n$ are positive, and that \code{rop} fits
+    \code{len + n} elements.  Supports aliasing between \code{rop} and
+    \code{op}.
 
 void fq_nmod_poly_shift_left(fq_nmod_poly_t rop, const fq_nmod_poly_t op, slong n,
                              const fq_nmod_ctx_t ctx)
 
-    Sets \code{res} to \code{poly} shifted left by $n$ coeffs.  Zero
+    Sets \code{rop} to \code{op} shifted left by $n$ coeffs.  Zero
     coefficients are inserted.
 
 void _fq_nmod_poly_shift_right(fq_nmod_struct *rop, const fq_nmod_struct *op,
                                slong len, slong n, const fq_nmod_ctx_t ctx)
 
-    Sets \code{(res, len - n)} to \code{(poly, len)} shifted right by
+    Sets \code{(rop, len - n)} to \code{(op, len)} shifted right by
     $n$ coefficients.
 
     Assumes that \code{len} and $n$ are positive, that \code{len > n},
-    and that \code{res} fits \code{len - n} elements.  Supports
-    aliasing between \code{res} and \code{poly}, although in this case
-    the top coefficients of \code{poly} are not set to zero.
+    and that \code{rop} fits \code{len - n} elements.  Supports
+    aliasing between \code{rop} and \code{op}, although in this case
+    the top coefficients of \code{op} are not set to zero.
 
 void fq_nmod_poly_shift_right(fq_nmod_poly_t rop, const fq_nmod_poly_t op,
                               slong n, const fq_nmod_ctx_t ctx)
 
-    Sets \code{res} to \code{poly} shifted right by $n$ coefficients.
+    Sets \code{rop} to \code{op} shifted right by $n$ coefficients.
     If $n$ is equal to or greater than the current length of
-    \code{poly}, \code{res} is set to the zero polynomial.
+    \code{op}, \code{rop} is set to the zero polynomial.
 
 *******************************************************************************
 
@@ -1221,7 +1221,7 @@ void _fq_nmod_poly_div_series(fmpz * Q, const fmpz * A, slong Alen,
     \code{(B, Blen)} assuming \code{Alen, Blen <= n}. We assume the bottom
     coefficient of \code{B} is invertible.
 
-void fq_nmod_poly_div_series(fmpz_mod_poly_t Q, const fmpz_mod_poly_t A, 
+void fq_nmod_poly_div_series(fmpz_mod_poly_t Q, const fmpz_mod_poly_t A,
                                 const fmpz_mod_poly_t B, slong n, fq_ctx_t ctx)
 
     Set $Q$ to the quotient of the series $A$ by $B$, thinking of the series as
@@ -1493,13 +1493,13 @@ int fq_nmod_poly_divides(fq_nmod_poly_t Q, const fq_nmod_poly_t A, const fq_nmod
 void _fq_nmod_poly_derivative(fq_nmod_struct *rop, const fq_nmod_struct *op, slong len,
                                          const fq_nmod_ctx_t ctx)
 
-    Sets \code{(rpoly, len - 1)} to the derivative of \code{(poly, len)}.
+    Sets \code{(rop, len - 1)} to the derivative of \code{(op, len)}.
     Also handles the cases where \code{len} is $0$ or $1$ correctly.
-    Supports aliasing of \code{rpoly} and \code{poly}.
+    Supports aliasing of \code{rop} and \code{op}.
 
 void fq_nmod_poly_derivative(fq_nmod_poly_t rop, const fq_nmod_poly_t op, const fq_nmod_ctx_t ctx)
 
-    Sets \code{res} to the derivative of \code{poly}.
+    Sets \code{rop} to the derivative of \code{op}.
 
 *******************************************************************************
 

--- a/fq_poly/doc/fq_poly.txt
+++ b/fq_poly/doc/fq_poly.txt
@@ -83,7 +83,7 @@ void fq_poly_truncate(fq_poly_t poly, slong newlen, const fq_ctx_t ctx)
 
     Truncates the polynomial to length at most~$n$.
 
-void fq_poly_set_trunc(fq_poly_t poly1, fq_poly_t poly2, 
+void fq_poly_set_trunc(fq_poly_t poly1, fq_poly_t poly2,
                                            slong newlen, const fq_ctx_t ctx)
 
     Sets \code{poly1} to \code{poly2} truncated to length~$n$.
@@ -241,7 +241,7 @@ fq_poly_set_coeff_fmpz(fq_poly_t poly, slong n, const fmpz_t x,
 
 *******************************************************************************
 
-int fq_poly_equal(const fq_poly_t poly1, const fq_poly_t poly2, 
+int fq_poly_equal(const fq_poly_t poly1, const fq_poly_t poly2,
                                                             const fq_ctx_t ctx)
 
     Returns nonzero if the two polynomials \code{poly1} and \code{poly2}
@@ -322,7 +322,7 @@ void fq_poly_sub_series(fq_poly_t res, const fq_poly_t poly1, const fq_poly_t po
 void _fq_poly_neg(fq_struct *rop, const fq_struct *op, slong len,
                   const fq_ctx_t ctx)
 
-    Sets \code{res} to the additive inverse of \code{(poly,len)}.
+    Sets \code{rop} to the additive inverse of \code{(poly,len)}.
 
 void fq_poly_neg(fq_poly_t res, const fq_poly_t poly, const fq_ctx_t ctx)
 
@@ -490,8 +490,8 @@ void _fq_poly_mullow_classical(fq_struct *rop,
                                const fq_struct *op2, slong len2, slong n,
                                const fq_ctx_t ctx)
 
-    Sets \code{(res, n)} to the first $n$ coefficients of \code{(poly1, len1)}
-    multiplied by \code{(poly2, len2)}.
+    Sets \code{(rop, n)} to the first $n$ coefficients of \code{(op1, len1)}
+    multiplied by \code{(op2, len2)}.
 
     Assumes \code{0 < n <= len1 + len2 - 1}.  Assumes neither \code{len1} nor
     \code{len2} is zero.
@@ -499,7 +499,7 @@ void _fq_poly_mullow_classical(fq_struct *rop,
 void fq_poly_mullow_classical(fq_poly_t rop,
     const fq_poly_t op1, const fq_poly_t op2, slong n, const fq_ctx_t ctx)
 
-    Sets \code{res} to the product of \code{poly1} and \code{poly2}, computed
+    Sets \code{rop} to the product of \code{poly1} and \code{poly2}, computed
     using the classical or schoolbook method.
 
 void _fq_poly_mullow_univariate(fq_struct *rop,
@@ -507,8 +507,8 @@ void _fq_poly_mullow_univariate(fq_struct *rop,
                         const fq_struct *op2, slong len2, slong n,
                         const fq_ctx_t ctx)
 
-    Sets \code{(res, n)} to the lowest $n$ coefficients of the product of
-    \code{(poly1, len1)} and \code{(poly2, len2)}, computed using a
+    Sets \code{(rop, n)} to the lowest $n$ coefficients of the product of
+    \code{(op1, len1)} and \code{(op2, len2)}, computed using a
     bivariate to univariate transformation.
 
     Assumes that \code{len1} and \code{len2} are positive, but does allow
@@ -520,37 +520,37 @@ void fq_poly_mullow_univariate(fq_poly_t rop,
                        const fq_poly_t op1, const fq_poly_t op2, slong n,
                        const fq_ctx_t ctx)
 
-    Sets \code{res} to the lowest $n$ coefficients of the product of
-    \code{poly1} and \code{poly2}, computed using a bivariate to
-    univariate transformation.
+    Sets \code{rop} to the lowest $n$ coefficients of the product of
+    \code{op1} and \code{op2}, computed using a bivariate to univariate
+    transformation.
 
 void _fq_poly_mullow_KS(fq_struct *rop,
                         const fq_struct *op1, slong len1,
                         const fq_struct *op2, slong len2, slong n,
                         const fq_ctx_t ctx)
 
-    Sets \code{(res, n)} to the lowest $n$ coefficients of the product of
-    \code{(poly1, len1)} and \code{(poly2, len2)}.
+    Sets \code{(rop, n)} to the lowest $n$ coefficients of the product of
+    \code{(op1, len1)} and \code{(op2, len2)}.
 
     Assumes that \code{len1} and \code{len2} are positive, but does allow
     for the polynomials to be zero-padded.  The polynomials may be zero,
-    too.  Assumes $n$ is positive.  Supports aliasing between \code{res},
-    \code{poly1} and \code{poly2}.
+    too.  Assumes $n$ is positive.  Supports aliasing between \code{rop},
+    \code{op1} and \code{op2}.
 
 void fq_poly_mullow_KS(fq_poly_t rop,
                        const fq_poly_t op1, const fq_poly_t op2, slong n,
                        const fq_ctx_t ctx)
 
-    Sets \code{res} to the lowest $n$ coefficients of the product of
-    \code{poly1} and \code{poly2}.
+    Sets \code{rop} to the lowest $n$ coefficients of the product of
+    \code{op1} and \code{op2}.
 
 void _fq_poly_mullow(fq_struct *rop,
                      const fq_struct *op1, slong len1,
                      const fq_struct *op2, slong len2, slong n,
                      const fq_ctx_t ctx)
 
-    Sets \code{(res, n)} to the lowest $n$ coefficients of the product of
-    \code{(poly1, len1)} and \code{(poly2, len2)}.
+    Sets \code{(rop, n)} to the lowest $n$ coefficients of the product of
+    \code{(op1, len1)} and \code{(op2, len2)}.
 
     Assumes \code{0 < n <= len1 + len2 - 1}.  Allows for zero-padding in
     the inputs.  Does not support aliasing between the inputs and the output.
@@ -559,8 +559,8 @@ void fq_poly_mullow(fq_poly_t rop,
                     const fq_poly_t op1, const fq_poly_t op2, slong n,
                     const fq_ctx_t ctx)
 
-    Sets \code{res} to the lowest $n$ coefficients of the product of
-    \code{poly1} and \code{poly2}.
+    Sets \code{rop} to the lowest $n$ coefficients of the product of
+    \code{op1} and \code{op2}.
 
 void _fq_poly_mulhigh_classical(fq_struct *res,
                                 const fq_struct *poly1, slong len1,
@@ -727,14 +727,14 @@ void fq_poly_sqr(fq_poly_t rop, const fq_poly_t op, const fq_ctx_t ctx)
 void _fq_poly_pow(fq_struct *rop, const fq_struct *op, slong len, ulong e,
                                   const fq_ctx_t ctx)
 
-    Sets \code{res = poly^e}, assuming that \code{e, len > 0} and that
-    \code{res} has space for \code{e*(len - 1) + 1} coefficients.  Does
+    Sets \code{rop = op^e}, assuming that \code{e, len > 0} and that
+    \code{rop} has space for \code{e*(len - 1) + 1} coefficients.  Does
     not support aliasing.
 
 void fq_poly_pow(fq_poly_t rop, const fq_poly_t op, ulong e,
                  const fq_ctx_t ctx)
 
-    Computes \code{res = poly^e}.  If $e$ is zero, returns one,
+    Computes \code{rop = op^e}.  If $e$ is zero, returns one,
     so that in particular \code{0^0 = 1}.
 
 void _fq_poly_powmod_ui_binexp(fq_struct* res, const fq_struct* poly,
@@ -887,37 +887,37 @@ fq_poly_powmod_x_fmpz_preinv(fq_poly_t res, const fmpz_t e,
 void _fq_poly_shift_left(fq_struct *rop, const fq_struct *op, slong len, slong n,
                          const fq_ctx_t ctx)
 
-    Sets \code{(res, len + n)} to \code{(poly, len)} shifted left by
+    Sets \code{(rop, len + n)} to \code{(op, len)} shifted left by
     $n$ coefficients.
 
     Inserts zero coefficients at the lower end.  Assumes that
-    \code{len} and $n$ are positive, and that \code{res} fits
-    \code{len + n} elements.  Supports aliasing between \code{res} and
-    \code{poly}.
+    \code{len} and $n$ are positive, and that \code{rop} fits
+    \code{len + n} elements.  Supports aliasing between \code{rop} and
+    \code{op}.
 
 void fq_poly_shift_left(fq_poly_t rop, const fq_poly_t op, slong n,
                         const fq_ctx_t ctx)
 
-    Sets \code{res} to \code{poly} shifted left by $n$ coeffs.  Zero
+    Sets \code{rop} to \code{op} shifted left by $n$ coeffs.  Zero
     coefficients are inserted.
 
 void _fq_poly_shift_right(fq_struct *rop, const fq_struct *op, slong len,
                           slong n, const fq_ctx_t ctx)
 
-    Sets \code{(res, len - n)} to \code{(poly, len)} shifted right by
+    Sets \code{(rop, len - n)} to \code{(op, len)} shifted right by
     $n$ coefficients.
 
     Assumes that \code{len} and $n$ are positive, that \code{len > n},
-    and that \code{res} fits \code{len - n} elements.  Supports
-    aliasing between \code{res} and \code{poly}, although in this case
-    the top coefficients of \code{poly} are not set to zero.
+    and that \code{rop} fits \code{len - n} elements.  Supports
+    aliasing between \code{rop} and \code{op}, although in this case
+    the top coefficients of \code{op} are not set to zero.
 
 void fq_poly_shift_right(fq_poly_t rop, const fq_poly_t op, slong n,
                          const fq_ctx_t ctx)
 
-    Sets \code{res} to \code{poly} shifted right by $n$ coefficients.
+    Sets \code{rop} to \code{op} shifted right by $n$ coefficients.
     If $n$ is equal to or greater than the current length of
-    \code{poly}, \code{res} is set to the zero polynomial.
+    \code{op}, \code{rop} is set to the zero polynomial.
 
 *******************************************************************************
 
@@ -1179,7 +1179,7 @@ fq_poly_inv_series(fq_poly_t Qinv, const fq_poly_t Q, slong n,
     Given \code{Q} find \code{Qinv} such that \code{Q * Qinv} is
     \code{1} modulo $x^n$. The constant coefficient of \code{Q} must
     be invertible modulo the modulus of \code{Q}. An exception is
-    raised if this is not the case or if \code{n = 0}. 
+    raised if this is not the case or if \code{n = 0}.
 
 void _fq_poly_div_series(fmpz * Q, const fmpz * A, slong Alen,
                              const fmpz * B, slong Blen, slong n, fq_ctx_t ctx)
@@ -1188,7 +1188,7 @@ void _fq_poly_div_series(fmpz * Q, const fmpz * A, slong Alen,
     \code{(B, Blen)} assuming \code{Alen, Blen <= n}. We assume the bottom
     coefficient of \code{B} is invertible.
 
-void fq_poly_div_series(fmpz_mod_poly_t Q, const fmpz_mod_poly_t A, 
+void fq_poly_div_series(fmpz_mod_poly_t Q, const fmpz_mod_poly_t A,
                                 const fmpz_mod_poly_t B, slong n, fq_ctx_t ctx)
 
     Set $Q$ to the quotient of the series $A$ by $B$, thinking of the series as
@@ -1450,13 +1450,13 @@ int fq_poly_divides(fq_poly_t Q, const fq_poly_t A, const fq_poly_t B,
 void _fq_poly_derivative(fq_struct *rop, const fq_struct *op, slong len,
                                          const fq_ctx_t ctx)
 
-    Sets \code{(rpoly, len - 1)} to the derivative of \code{(poly, len)}.
+    Sets \code{(rop, len - 1)} to the derivative of \code{(op, len)}.
     Also handles the cases where \code{len} is $0$ or $1$ correctly.
-    Supports aliasing of \code{rpoly} and \code{poly}.
+    Supports aliasing of \code{rop} and \code{op}.
 
 void fq_poly_derivative(fq_poly_t rop, const fq_poly_t op, const fq_ctx_t ctx)
 
-    Sets \code{res} to the derivative of \code{poly}.
+    Sets \code{rop} to the derivative of \code{op}.
 
 *******************************************************************************
 

--- a/fq_zech_poly/doc/fq_zech_poly.txt
+++ b/fq_zech_poly/doc/fq_zech_poly.txt
@@ -89,7 +89,7 @@ void fq_zech_poly_truncate(fq_zech_poly_t poly, slong newlen,
 
     Truncates the polynomial to length at most~$n$.
 
-void fq_zech_poly_set_trunc(fq_zech_poly_t poly1, fq_zech_poly_t poly2, 
+void fq_zech_poly_set_trunc(fq_zech_poly_t poly1, fq_zech_poly_t poly2,
                                            slong newlen, const fq_ctx_t ctx)
 
     Sets \code{poly1} to \code{poly2} truncated to length~$n$.
@@ -309,7 +309,7 @@ void fq_zech_poly_add(fq_zech_poly_t res, const fq_zech_poly_t poly1,
 
     Sets \code{res} to the sum of \code{poly1} and \code{poly2}.
 
-void fq_zech_poly_add_series(fq_poly_t res, const fq_poly_t poly1, 
+void fq_zech_poly_add_series(fq_poly_t res, const fq_poly_t poly1,
            const fq_poly_t poly2, slong n, const fq_ctx_t ctx)
 
     Notionally truncate \code{poly1} and \code{poly2} to length \code{n} and set
@@ -328,7 +328,7 @@ void fq_zech_poly_sub(fq_zech_poly_t res, const fq_zech_poly_t poly1,
 
     Sets \code{res} to the difference of \code{poly1} and \code{poly2}.
 
-void fq_zech_poly_sub_series(fq_poly_t res, const fq_poly_t poly1, 
+void fq_zech_poly_sub_series(fq_poly_t res, const fq_poly_t poly1,
            const fq_poly_t poly2, slong n, const fq_ctx_t ctx)
 
     Notionally truncate \code{poly1} and \code{poly2} to length \code{n} and set
@@ -337,7 +337,7 @@ void fq_zech_poly_sub_series(fq_poly_t res, const fq_poly_t poly1,
 void _fq_zech_poly_neg(fq_zech_struct *rop, const fq_zech_struct *op, slong len,
                   const fq_zech_ctx_t ctx)
 
-    Sets \code{res} to the additive inverse of \code{(poly,len)}.
+    Sets \code{rop} to the additive inverse of \code{(op,len)}.
 
 void fq_zech_poly_neg(fq_zech_poly_t res, const fq_zech_poly_t poly,
                       const fq_zech_ctx_t ctx)
@@ -497,8 +497,8 @@ void _fq_zech_poly_mullow_classical(fq_zech_struct *rop,
                                     const fq_zech_struct *op2, slong len2, slong n,
                                     const fq_zech_ctx_t ctx)
 
-    Sets \code{(res, n)} to the first $n$ coefficients of
-    \code{(poly1, len1)} multiplied by \code{(poly2, len2)}.
+    Sets \code{(rop, n)} to the first $n$ coefficients of
+    \code{(op1, len1)} multiplied by \code{(op2, len2)}.
 
     Assumes \code{0 < n <= len1 + len2 - 1}.  Assumes neither
     \code{len1} nor \code{len2} is zero.
@@ -506,7 +506,7 @@ void _fq_zech_poly_mullow_classical(fq_zech_struct *rop,
 void fq_zech_poly_mullow_classical(fq_zech_poly_t rop,
     const fq_zech_poly_t op1, const fq_zech_poly_t op2, slong n, const fq_zech_ctx_t ctx)
 
-    Sets \code{res} to the product of \code{poly1} and \code{poly2},
+    Sets \code{rop} to the product of \code{op1} and \code{op2},
     computed using the classical or schoolbook method.
 
 void _fq_zech_poly_mullow_KS(fq_zech_struct *rop,
@@ -514,27 +514,27 @@ void _fq_zech_poly_mullow_KS(fq_zech_struct *rop,
                              const fq_zech_struct *op2, slong len2, slong n,
                              const fq_zech_ctx_t ctx)
 
-    Sets \code{(res, n)} to the lowest $n$ coefficients of the product of
-    \code{(poly1, len1)} and \code{(poly2, len2)}.
+    Sets \code{(rop, n)} to the lowest $n$ coefficients of the product of
+    \code{(op1, len1)} and \code{(op2, len2)}.
 
     Assumes that \code{len1} and \code{len2} are positive, but does allow
     for the polynomials to be zero-padded.  The polynomials may be zero,
-    too.  Assumes $n$ is positive.  Supports aliasing between \code{res},
-    \code{poly1} and \code{poly2}.
+    too.  Assumes $n$ is positive.  Supports aliasing between \code{rop},
+    \code{op1} and \code{op2}.
 
 void fq_zech_poly_mullow_KS(fq_zech_poly_t rop,
                             const fq_zech_poly_t op1, const fq_zech_poly_t op2,
                             slong n, const fq_zech_ctx_t ctx)
 
-    Sets \code{res} to the product of \code{poly1} and \code{poly2}.
+    Sets \code{rop} to the product of \code{op1} and \code{op2}.
 
 void _fq_zech_poly_mullow(fq_zech_struct *rop,
                           const fq_zech_struct *op1, slong len1,
                           const fq_zech_struct *op2, slong len2, slong n,
                           const fq_zech_ctx_t ctx)
 
-    Sets \code{(res, n)} to the lowest $n$ coefficients of the product of
-    \code{(poly1, len1)} and \code{(poly2, len2)}.
+    Sets \code{(rop, n)} to the lowest $n$ coefficients of the product of
+    \code{(op1, len1)} and \code{(op2, len2)}.
 
     Assumes \code{0 < n <= len1 + len2 - 1}.  Allows for zero-padding in
     the inputs.  Does not support aliasing between the inputs and the output.
@@ -543,8 +543,8 @@ void fq_zech_poly_mullow(fq_zech_poly_t rop,
                          const fq_zech_poly_t op1, const fq_zech_poly_t op2, slong n,
                          const fq_zech_ctx_t ctx)
 
-    Sets \code{res} to the lowest $n$ coefficients of the product of
-    \code{poly1} and \code{poly2}.
+    Sets \code{rop} to the lowest $n$ coefficients of the product of
+    \code{op1} and \code{op2}.
 
 void _fq_zech_poly_mulhigh_classical(fq_zech_struct *res,
                                      const fq_zech_struct *poly1, slong len1,
@@ -701,14 +701,14 @@ void fq_zech_poly_sqr(fq_zech_poly_t rop, const fq_zech_poly_t op,
 void _fq_zech_poly_pow(fq_zech_struct *rop, const fq_zech_struct *op, slong len,
                        ulong e, const fq_zech_ctx_t ctx)
 
-    Sets \code{res = poly^e}, assuming that \code{e, len > 0} and that
+    Sets \code{rop = op^e}, assuming that \code{e, len > 0} and that
     \code{res} has space for \code{e*(len - 1) + 1} coefficients.  Does
     not support aliasing.
 
 void fq_zech_poly_pow(fq_zech_poly_t rop, const fq_zech_poly_t op, ulong e,
                       const fq_zech_ctx_t ctx)
 
-    Computes \code{res = poly^e}.  If $e$ is zero, returns one,
+    Computes \code{rop = op^e}.  If $e$ is zero, returns one,
     so that in particular \code{0^0 = 1}.
 
 void _fq_zech_poly_powmod_ui_binexp(fq_zech_struct* res,
@@ -875,37 +875,37 @@ fq_zech_poly_powmod_x_fmpz_preinv(fq_zech_poly_t res, const fmpz_t e,
 void _fq_zech_poly_shift_left(fq_zech_struct *rop, const fq_zech_struct *op,
                               slong len, slong n, const fq_zech_ctx_t ctx)
 
-    Sets \code{(res, len + n)} to \code{(poly, len)} shifted left by
+    Sets \code{(rop, len + n)} to \code{(op, len)} shifted left by
     $n$ coefficients.
 
     Inserts zero coefficients at the lower end.  Assumes that
-    \code{len} and $n$ are positive, and that \code{res} fits
-    \code{len + n} elements.  Supports aliasing between \code{res} and
-    \code{poly}.
+    \code{len} and $n$ are positive, and that \code{rop} fits
+    \code{len + n} elements.  Supports aliasing between \code{rop} and
+    \code{op}.
 
 void fq_zech_poly_shift_left(fq_zech_poly_t rop, const fq_zech_poly_t op, slong n,
                              const fq_zech_ctx_t ctx)
 
-    Sets \code{res} to \code{poly} shifted left by $n$ coeffs.  Zero
+    Sets \code{rop} to \code{op} shifted left by $n$ coeffs.  Zero
     coefficients are inserted.
 
 void _fq_zech_poly_shift_right(fq_zech_struct *rop, const fq_zech_struct *op,
                                slong len, slong n, const fq_zech_ctx_t ctx)
 
-    Sets \code{(res, len - n)} to \code{(poly, len)} shifted right by
+    Sets \code{(rop, len - n)} to \code{(op, len)} shifted right by
     $n$ coefficients.
 
     Assumes that \code{len} and $n$ are positive, that \code{len > n},
-    and that \code{res} fits \code{len - n} elements.  Supports
-    aliasing between \code{res} and \code{poly}, although in this case
-    the top coefficients of \code{poly} are not set to zero.
+    and that \code{rop} fits \code{len - n} elements.  Supports
+    aliasing between \code{rop} and \code{op}, although in this case
+    the top coefficients of \code{op} are not set to zero.
 
 void fq_zech_poly_shift_right(fq_zech_poly_t rop, const fq_zech_poly_t op,
                               slong n, const fq_zech_ctx_t ctx)
 
-    Sets \code{res} to \code{poly} shifted right by $n$ coefficients.
+    Sets \code{rop} to \code{op} shifted right by $n$ coefficients.
     If $n$ is equal to or greater than the current length of
-    \code{poly}, \code{res} is set to the zero polynomial.
+    \code{op}, \code{rop} is set to the zero polynomial.
 
 *******************************************************************************
 
@@ -1179,7 +1179,7 @@ void _fq_zech_poly_div_series(fmpz * Q, const fmpz * A, slong Alen,
     \code{(B, Blen)} assuming \code{Alen, Blen <= n}. We assume the bottom
     coefficient of \code{B} is invertible.
 
-void fq_zech_poly_div_series(fmpz_mod_poly_t Q, const fmpz_mod_poly_t A, 
+void fq_zech_poly_div_series(fmpz_mod_poly_t Q, const fmpz_mod_poly_t A,
                                 const fmpz_mod_poly_t B, slong n, fq_ctx_t ctx)
 
     Set $Q$ to the quotient of the series $A$ by $B$, thinking of the series as
@@ -1450,13 +1450,13 @@ int fq_zech_poly_divides(fq_zech_poly_t Q, const fq_zech_poly_t A, const fq_zech
 void _fq_zech_poly_derivative(fq_zech_struct *rop, const fq_zech_struct *op, slong len,
                                          const fq_zech_ctx_t ctx)
 
-    Sets \code{(rpoly, len - 1)} to the derivative of \code{(poly, len)}.
+    Sets \code{(rop, len - 1)} to the derivative of \code{(op, len)}.
     Also handles the cases where \code{len} is $0$ or $1$ correctly.
-    Supports aliasing of \code{rpoly} and \code{poly}.
+    Supports aliasing of \code{rop} and \code{op}.
 
 void fq_zech_poly_derivative(fq_zech_poly_t rop, const fq_zech_poly_t op, const fq_zech_ctx_t ctx)
 
-    Sets \code{res} to the derivative of \code{poly}.
+    Sets \code{rop} to the derivative of \code{op}.
 
 *******************************************************************************
 


### PR DESCRIPTION
There are a bunch of functions that seem to have been refactored; however the
documentation is still keeping the old argument names. This patch updates the documentation w.r.t. this refactoring.

Looking at the surrounding, it seems there's a lot of inconsistencies in argument naming, why this `res` vs `rop` discrepancy? Would it be of any use another patch to fit the GNU MP convention of `rop`?  

There's multipla trailing whitespaces fix in this patch. I'm not sure if they should be taken away, if you should fix your editor/git, or if a `git rebase --whitespace=fix` would be a viable solution.