### PR TITLE
Add some functions for primitive polynomials/elements

### DIFF
--- a/fmpz_mod_poly.h
+++ b/fmpz_mod_poly.h
@@ -159,6 +159,9 @@ FLINT_DLL void fmpz_mod_poly_randtest_monic(fmpz_mod_poly_t f, flint_rand_t stat
 FLINT_DLL void fmpz_mod_poly_randtest_monic_irreducible(fmpz_mod_poly_t f,
                                          flint_rand_t state, slong len);
 
+FLINT_DLL void fmpz_mod_poly_randtest_monic_primitive(fmpz_mod_poly_t f,
+                                         flint_rand_t state, slong len);
+
 FLINT_DLL void fmpz_mod_poly_randtest_trinomial(fmpz_mod_poly_t f, flint_rand_t state, slong len);
 
 FLINT_DLL int fmpz_mod_poly_randtest_trinomial_irreducible(fmpz_mod_poly_t f,

--- a/fmpz_mod_poly/doc/fmpz_mod_poly.txt
+++ b/fmpz_mod_poly/doc/fmpz_mod_poly.txt
@@ -3,6 +3,7 @@
     Copyright (C) 2011 Sebastian Pancratz
     Copyright (C) 2011 Fredrik Johansson
     Copyright (C) 2013 Mike Hansen
+    Copyright (C) 2018 Luca De Feo
 
     This file is part of FLINT.
 
@@ -113,6 +114,13 @@ fmpz_mod_poly_randtest_monic_irreducible(fmpz_mod_poly_t poly,
                                          flint_rand_t state, slong len)
 
     Generates a random monic irreducible polynomial with length \code{len}.
+
+void
+fmpz_mod_poly_randtest_monic_primitive(fmpz_mod_poly_t poly,
+                                       flint_rand_t state, slong len)
+
+    Generates a random monic irreducible primitive polynomial with
+    length \code{len}.
 
 
 void

--- a/fmpz_mod_poly/randtest_monic_primitive.c
+++ b/fmpz_mod_poly/randtest_monic_primitive.c
@@ -1,0 +1,34 @@
+/*
+    Copyright (C) 2018 Luca De Feo
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+#include "fmpz_mod_poly.h"
+#include "fq.h"
+
+void
+fmpz_mod_poly_randtest_monic_primitive(fmpz_mod_poly_t f,
+                                       flint_rand_t state, slong len)
+{
+    fq_ctx_t ctx;
+    fq_t X;
+    int primitive = 0;
+    
+    while (!primitive)
+    {
+        fmpz_mod_poly_randtest_monic_irreducible(f, state, len);
+        fq_ctx_init_modulus(ctx, f, "X");
+        fq_init(X, ctx);
+        fq_gen(X, ctx);
+        primitive = fq_is_primitive(X, ctx);
+        fq_clear(X, ctx);
+        fq_ctx_clear(ctx);
+    }
+}

--- a/fmpz_mod_poly/test/t-randtest_monic_primitive.c
+++ b/fmpz_mod_poly/test/t-randtest_monic_primitive.c
@@ -1,0 +1,52 @@
+/*
+    Copyright (C) 2018 Luca De Feo
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <gmp.h>
+#include "flint.h"
+#include "fmpz.h"
+#include "fmpz_mod_poly.h"
+#include "ulong_extras.h"
+
+int
+main(void)
+{
+    int i;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("randtest_monic_primitive....");
+    fflush(stdout);
+
+    for (i = 0; i < 10 * flint_test_multiplier(); i++)
+    {
+        fmpz_t p;
+        fmpz_mod_poly_t poly;
+        slong d;
+        
+        fmpz_init(p);
+        fmpz_set_ui(p, n_randprime(state, 2 + n_randint(state, 
+                                   FLINT_MIN(FLINT_BITS - 1, 10)), 1));
+        d = n_randint(state, 5) + 3;
+
+        fmpz_mod_poly_init(poly, p);
+        fmpz_mod_poly_randtest_monic_primitive(poly, state, d);
+
+        fmpz_mod_poly_clear(poly);
+        fmpz_clear(p);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+    
+    flint_printf("PASS\n");
+    return 0;
+}
+

--- a/fq/doc/fq.txt
+++ b/fq/doc/fq.txt
@@ -2,7 +2,7 @@
     Copyright (C) 2011, 2012 Sebastian Pancratz
     Copyright (C) 2012, 2013 Andres Goens
     Copyright (C) 2013 Mike Hansen
-    Copyright (C) 2017 Luca De Feo
+    Copyright (C) 2017, 2018 Luca De Feo
 
     This file is part of FLINT.
 
@@ -455,6 +455,19 @@ void fq_frobenius(fq_t rop, const fq_t op, slong e, const fq_ctx_t ctx)
     $\mathbf{Z}/d\mathbf{Z}$, where
     $\sigma \in \Gal(\mathbf{F}_q/\mathbf{F}_p)$ is the Frobenius element
     $\sigma \colon x \mapsto x^p$.
+
+int fq_multiplicative_order(fmpz_t ord, const fq_t op, const fq_ctx_t ctx)
+
+    Computes the order of \code{op} as an element of the
+    multiplicative group of \code{ctx}.
+    
+    Returns 0 if \code{op} is 0, otherwise it returns 1 if \code{op}
+    is a generator of the multiplicative group, and -1 if it is not.
+
+int fq_is_primitive(const fq_t op, const fq_ctx_t ctx)
+
+    Returns whether \code{op} is primitive, i.e., whether it is a
+    generator of the multiplicative group of \code{ctx}.
 
 *******************************************************************************
 

--- a/fq/multiplicative_order.c
+++ b/fq/multiplicative_order.c
@@ -1,0 +1,22 @@
+/*
+    Copyright (C) 2018 Luca De Feo
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fq.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq
+#define CAP_T FQ
+#include "fq_templates/multiplicative_order.c"
+#undef CAP_T
+#undef T

--- a/fq/test/t-is_primitive.c
+++ b/fq/test/t-is_primitive.c
@@ -1,0 +1,22 @@
+/*
+    Copyright (C) 2018 Luca De Feo
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fq.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq
+#define CAP_T FQ
+#include "fq_templates/test/t-is_primitive.c"
+#undef CAP_T
+#undef T

--- a/fq/test/t-multiplicative_order.c
+++ b/fq/test/t-multiplicative_order.c
@@ -1,0 +1,22 @@
+/*
+    Copyright (C) 2018 Luca De Feo
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fq.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq
+#define CAP_T FQ
+#include "fq_templates/test/t-multiplicative_order.c"
+#undef CAP_T
+#undef T

--- a/fq_nmod/doc/fq_nmod.txt
+++ b/fq_nmod/doc/fq_nmod.txt
@@ -1,6 +1,6 @@
 /*
     Copyright (C) 2013 Mike Hansen
-    Copyright (C) 2017 Luca De Feo
+    Copyright (C) 2017, 2018 Luca De Feo
 
     This file is part of FLINT.
 
@@ -466,6 +466,19 @@ void fq_nmod_frobenius(fq_nmod_t rop, const fq_nmod_t op, slong e,
     $\mathbf{Z}/d\mathbf{Z}$, where
     $\sigma \in \Gal(\mathbf{F}_q/\mathbf{F}_p)$ is the Frobenius element
     $\sigma \colon x \mapsto x^p$.
+
+int fq_nmod_multiplicative_order(fmpz_t ord, const fq_nmod_t op, const fq_nmod_ctx_t ctx)
+
+    Computes the order of \code{op} as an element of the
+    multiplicative group of \code{ctx}.
+    
+    Returns 0 if \code{op} is 0, otherwise it returns 1 if \code{op}
+    is a generator of the multiplicative group, and -1 if it is not.
+
+int fq_nmod_is_primitive(const fq_nmod_t op, const fq_nmod_ctx_t ctx)
+
+    Returns whether \code{op} is primitive, i.e., whether it is a
+    generator of the multiplicative group of \code{ctx}.
 
 *******************************************************************************
 

--- a/fq_nmod/multiplicative_order.c
+++ b/fq_nmod/multiplicative_order.c
@@ -1,0 +1,22 @@
+/*
+    Copyright (C) 2018 Luca De Feo
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fq_nmod.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq_nmod
+#define CAP_T FQ_NMOD
+#include "fq_templates/multiplicative_order.c"
+#undef CAP_T
+#undef T

--- a/fq_nmod/test/t-is_primitive.c
+++ b/fq_nmod/test/t-is_primitive.c
@@ -1,0 +1,22 @@
+/*
+    Copyright (C) 2018 Luca De Feo
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fq_nmod.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq_nmod
+#define CAP_T FQ_NMOD
+#include "fq_templates/test/t-is_primitive.c"
+#undef CAP_T
+#undef T

--- a/fq_nmod/test/t-multiplicative_order.c
+++ b/fq_nmod/test/t-multiplicative_order.c
@@ -1,0 +1,22 @@
+/*
+    Copyright (C) 2018 Luca De Feo
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fq_nmod.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq_nmod
+#define CAP_T FQ_NMOD
+#include "fq_templates/test/t-multiplicative_order.c"
+#undef CAP_T
+#undef T

--- a/fq_templates.h
+++ b/fq_templates.h
@@ -26,4 +26,18 @@ FLINT_DLL int TEMPLATE(T, is_invertible_f)(TEMPLATE(T, t) rop, const TEMPLATE(T,
 FLINT_DLL void TEMPLATE(T, div)(TEMPLATE(T, t) rop, const TEMPLATE(T, t) op1,
                  const TEMPLATE(T, t) op2, const TEMPLATE(T, ctx_t) ctx);
 
+FLINT_DLL int TEMPLATE(T, multiplicative_order)(fmpz_t ord, const TEMPLATE(T, t) op,
+                             const TEMPLATE(T, ctx_t) ctx);
+
+FQ_TEMPLATES_INLINE
+int TEMPLATE(T, is_primitive)(const TEMPLATE(T, t) op, const TEMPLATE(T, ctx_t) ctx)
+{
+    fmpz_t tmp;
+    int ret;
+    fmpz_init(tmp);
+    ret = TEMPLATE(T, multiplicative_order)(tmp, op, ctx) == 1;
+    fmpz_clear(tmp);
+    return ret;
+}
+
 #endif

--- a/fq_templates/multiplicative_order.c
+++ b/fq_templates/multiplicative_order.c
@@ -1,0 +1,63 @@
+/*
+    Copyright (C) 2018 Luca De Feo
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef T
+
+#include "templates.h"
+
+int TEMPLATE(T, multiplicative_order)(fmpz_t ord, const TEMPLATE(T, t) op,
+                                      const TEMPLATE(T, ctx_t) ctx)
+{
+    fmpz_t tmp;
+    fmpz_factor_t ord_fact;
+    TEMPLATE(T, t) one;
+    slong i, j;
+    int is_primitive = 1;
+
+    if (TEMPLATE(T, is_zero)(op, ctx))
+    {
+        fmpz_set_ui(ord, 0);
+        return 0;
+    }
+
+    fmpz_init(tmp);
+    fmpz_factor_init(ord_fact);
+    TEMPLATE(T, init)(one, ctx);
+
+    TEMPLATE(T, ctx_order)(ord, ctx);
+    fmpz_sub_ui(ord, ord, 1);
+    fmpz_factor(ord_fact, ord);
+
+    for (i = 0; i < ord_fact->num; i++)
+    {
+        fmpz_set(tmp, ord);
+        for (j = ord_fact->exp[i]; j > 0; j--) 
+        {
+            fmpz_cdiv_q(tmp, tmp, ord_fact->p + i);
+            TEMPLATE(T, pow)(one, op, tmp, ctx);
+            if (!TEMPLATE(T, is_one)(one, ctx))
+                break;
+            is_primitive = -1;
+        }
+        if (j > 0) 
+            fmpz_mul(ord, tmp, ord_fact->p + i);
+        else 
+            fmpz_set(ord, tmp);
+    }
+    
+    fmpz_clear(tmp);
+    fmpz_factor_clear(ord_fact);
+    TEMPLATE(T, clear)(one, ctx);
+    
+    return is_primitive;
+}
+
+#endif

--- a/fq_templates/test/t-is_primitive.c
+++ b/fq_templates/test/t-is_primitive.c
@@ -1,0 +1,64 @@
+/*
+    Copyright (C) 2018 Luca De Feo
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef T
+
+#include "templates.h"
+
+int
+main(void)
+{
+    int i;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("is_primitive... ");
+    fflush(stdout);
+
+    for (i = 0; i < 10 * flint_test_multiplier(); i++)
+    {
+        TEMPLATE(T, ctx_t) ctx;
+        TEMPLATE(T, t) a;
+        fmpz_t ord, field_ord;
+
+        TEMPLATE(T, ctx_randtest)(ctx, state);
+
+        TEMPLATE(T, init)(a, ctx);
+        TEMPLATE(T, randtest)(a, state, ctx);
+
+        fmpz_init(ord);
+        fmpz_init(field_ord);
+        TEMPLATE(T, multiplicative_order)(ord, a, ctx);
+        TEMPLATE(T, ctx_order)(field_ord, ctx);
+        fmpz_sub(field_ord, field_ord, ord);
+
+        if (TEMPLATE(T, is_primitive)(a, ctx) != fmpz_is_one(field_ord))
+        {
+            flint_printf("FAIL:\n\n");
+            flint_printf("a = "), TEMPLATE(T, print_pretty)(a, ctx), flint_printf("\n");
+            TEMPLATE(T, ctx_print)(ctx);
+            abort();
+        }
+
+        fmpz_clear(ord);
+        fmpz_clear(field_ord);
+        TEMPLATE(T, clear)(a, ctx);
+
+        TEMPLATE(T, ctx_clear)(ctx);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+    flint_printf("PASS\n");
+    return EXIT_SUCCESS;
+}
+
+
+
+#endif

--- a/fq_templates/test/t-is_primitive.c
+++ b/fq_templates/test/t-is_primitive.c
@@ -22,6 +22,7 @@ main(void)
     flint_printf("is_primitive... ");
     fflush(stdout);
 
+    /* Test that is_primitive gives consistent answers with multiplicative_order */
     for (i = 0; i < 10 * flint_test_multiplier(); i++)
     {
         TEMPLATE(T, ctx_t) ctx;

--- a/fq_templates/test/t-multiplicative_order.c
+++ b/fq_templates/test/t-multiplicative_order.c
@@ -1,0 +1,64 @@
+/*
+    Copyright (C) 2018 Luca De Feo
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef T
+
+#include "templates.h"
+
+int
+main(void)
+{
+    int i, result;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("multiplicative_order... ");
+    fflush(stdout);
+
+    for (i = 0; i < flint_test_multiplier(); i++)
+    {
+        TEMPLATE(T, ctx_t) ctx;
+        TEMPLATE(T, t) a, tmp;
+        fmpz_t ord;
+
+        TEMPLATE(T, ctx_randtest)(ctx, state);
+
+        TEMPLATE(T, init)(a, ctx);
+        TEMPLATE(T, init)(tmp, ctx);
+        TEMPLATE(T, randtest)(a, state, ctx);
+
+        fmpz_init(ord);
+        result = TEMPLATE(T, multiplicative_order)(ord, a, ctx);
+        TEMPLATE(T, pow)(tmp, a, ord, ctx);
+
+        if (result && !TEMPLATE(T, is_one)(tmp, ctx))
+        {
+            flint_printf("FAIL:\n\n");
+            flint_printf("a = "), TEMPLATE(T, print_pretty)(a, ctx), flint_printf("\n");
+            flint_printf("ord = "), fmpz_print(ord), flint_printf("\n");
+            TEMPLATE(T, ctx_print)(ctx);
+            abort();
+        }
+
+        fmpz_clear(ord);
+        TEMPLATE(T, clear)(a, ctx);
+        TEMPLATE(T, clear)(tmp, ctx);
+
+        TEMPLATE(T, ctx_clear)(ctx);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+    flint_printf("PASS\n");
+    return EXIT_SUCCESS;
+}
+
+
+
+#endif

--- a/fq_templates/test/t-multiplicative_order.c
+++ b/fq_templates/test/t-multiplicative_order.c
@@ -22,7 +22,8 @@ main(void)
     flint_printf("multiplicative_order... ");
     fflush(stdout);
 
-    for (i = 0; i < flint_test_multiplier(); i++)
+    /* Test that the computed multiplicative order is a multiple of the real one */
+    for (i = 0; i < 10 * flint_test_multiplier(); i++)
     {
         TEMPLATE(T, ctx_t) ctx;
         TEMPLATE(T, t) a, tmp;
@@ -50,6 +51,51 @@ main(void)
         fmpz_clear(ord);
         TEMPLATE(T, clear)(a, ctx);
         TEMPLATE(T, clear)(tmp, ctx);
+
+        TEMPLATE(T, ctx_clear)(ctx);
+    }
+
+    /* Test that the computed multiplicative order is coherent with powering by p-1 */
+    for (i = 0; i < 10 * flint_test_multiplier(); i++)
+    {
+        TEMPLATE(T, ctx_t) ctx;
+        TEMPLATE(T, t) X, a;
+        fmpz_t ord, size, pm1;
+
+        TEMPLATE(T, ctx_randtest)(ctx, state);
+
+        TEMPLATE(T, init)(X, ctx);
+        TEMPLATE(T, init)(a, ctx);
+        fmpz_init(ord);
+        fmpz_init(size);
+        fmpz_init(pm1);
+        
+        TEMPLATE(T, gen)(X, ctx);
+        if (!TEMPLATE(T, is_primitive)(X, ctx))
+            continue;
+
+        fmpz_sub_ui(pm1, TEMPLATE(T, ctx_prime)(ctx), 1);
+        TEMPLATE(T, pow)(a, X, pm1, ctx);
+        result = TEMPLATE(T, multiplicative_order)(ord, a, ctx);
+        fmpz_mul(ord, ord, pm1);
+
+        TEMPLATE(T, ctx_order)(size, ctx);
+        fmpz_sub(size, size, ord);
+
+        if (result && !fmpz_is_one(size))
+        {
+            flint_printf("FAIL:\n\n");
+            flint_printf("a = "), TEMPLATE(T, print_pretty)(a, ctx), flint_printf("\n");
+            flint_printf("ord = "), fmpz_print(ord), flint_printf("\n");
+            TEMPLATE(T, ctx_print)(ctx);
+            abort();
+        }
+
+        fmpz_clear(pm1);
+        fmpz_clear(ord);
+        fmpz_clear(size);
+        TEMPLATE(T, clear)(a, ctx);
+        TEMPLATE(T, clear)(X, ctx);
 
         TEMPLATE(T, ctx_clear)(ctx);
     }

--- a/fq_zech.h
+++ b/fq_zech.h
@@ -61,6 +61,8 @@ FLINT_DLL int _fq_zech_ctx_init_conway(fq_zech_ctx_t ctx, const fmpz_t p, slong 
 
 FLINT_DLL void fq_zech_ctx_init_conway(fq_zech_ctx_t ctx, const fmpz_t p, slong d, const char *var);
 
+FLINT_DLL void fq_zech_ctx_init_random(fq_zech_ctx_t ctx, const fmpz_t p, slong d, const char *var);
+
 FLINT_DLL void fq_zech_ctx_init_modulus(fq_zech_ctx_t ctx,
                               const nmod_poly_t modulus,
                               const char *var);

--- a/fq_zech/ctx_init.c
+++ b/fq_zech/ctx_init.c
@@ -127,7 +127,8 @@ fq_zech_ctx_init_fq_nmod_ctx(fq_zech_ctx_t ctx,
 
     ctx->zech_log_table[ctx->qm1] = 0;
     ctx->prime_field_table[0] = ctx->qm1;
-    n_reverse_table[0] = ctx->qm1;
+    for (i = 0; i < q; i++)
+        n_reverse_table[i] = ctx->qm1;
     ctx->eval_table[ctx->qm1] = 0;
 
     fq_nmod_init(r, ctx->fq_nmod_ctx);
@@ -141,6 +142,10 @@ fq_zech_ctx_init_fq_nmod_ctx(fq_zech_ctx_t ctx,
     {
         nmod_poly_evaluate_fmpz(result, r, fq_nmod_ctx_prime(fq_nmod_ctx));
         result_ui = fmpz_get_ui(result);
+        if (n_reverse_table[result_ui] != ctx->qm1) {
+            flint_printf("Exception (fq_zech_ctx_init_nmod_ctx). Polynomial is not primitive.\n");
+            flint_abort();
+        }
         n_reverse_table[result_ui] = i;
         ctx->eval_table[i] = result_ui;
         if (r->length == 1)

--- a/fq_zech/ctx_init.c
+++ b/fq_zech/ctx_init.c
@@ -18,13 +18,8 @@
 void
 fq_zech_ctx_init(fq_zech_ctx_t ctx, const fmpz_t p, slong d, const char *var)
 {
-    fq_nmod_ctx_struct * fq_nmod_ctx;
-
-    fq_nmod_ctx = flint_malloc(sizeof(fq_nmod_ctx_struct));
-
-    fq_nmod_ctx_init(fq_nmod_ctx, p, d, var);
-    fq_zech_ctx_init_fq_nmod_ctx(ctx, fq_nmod_ctx);
-    ctx->owns_fq_nmod_ctx = 1;
+    if (!_fq_zech_ctx_init_conway(ctx, p, d, var))
+        fq_zech_ctx_init_random(ctx, p, d, var);
 }
 
 void
@@ -61,6 +56,29 @@ _fq_zech_ctx_init_conway(fq_zech_ctx_t ctx, const fmpz_t p, slong d,
     return result;
 }
 
+void
+fq_zech_ctx_init_random(fq_zech_ctx_t ctx, const fmpz_t p, slong d,
+                        const char *var)
+{
+    fq_nmod_ctx_struct * fq_nmod_ctx;
+    flint_rand_t state;
+    nmod_poly_t poly;
+
+    fq_nmod_ctx = flint_malloc(sizeof(fq_nmod_ctx_struct));
+
+    flint_randinit(state);
+
+    nmod_poly_init2(poly, fmpz_get_ui(p), d + 1);
+    nmod_poly_randtest_monic_primitive(poly, state, d + 1);
+
+    fq_nmod_ctx_init_modulus(fq_nmod_ctx, poly, var);
+
+    nmod_poly_clear(poly);
+    flint_randclear(state);
+
+    fq_zech_ctx_init_fq_nmod_ctx(ctx, fq_nmod_ctx);
+    ctx->owns_fq_nmod_ctx = 1;
+}
 
 void
 fq_zech_ctx_init_modulus(fq_zech_ctx_t ctx,

--- a/fq_zech/doc/fq_zech.txt
+++ b/fq_zech/doc/fq_zech.txt
@@ -1,6 +1,6 @@
 /*
     Copyright (C) 2013 Mike Hansen
-    Copyright (C) 2017 Luca De Feo
+    Copyright (C) 2017, 2018 Luca De Feo
 
     This file is part of FLINT.
 
@@ -22,9 +22,9 @@ void fq_zech_ctx_init(fq_zech_ctx_t ctx, const fmpz_t p,
     Initialises the context for prime~$p$ and extension degree~$d$,
     with name \code{var} for the generator.  By default, it will try
     use a Conway polynomial; if one is not available, a random
-    irreducible polynomial will be used.
+    primitive polynomial will be used.
 
-    Assumes that $p$ is a prime and $p^d < 2^{FLINT_BITS}$.
+    Assumes that $p$ is a prime and $p^d < 2^\texttt{FLINT\_BITS}$.
 
     Assumes that the string \code{var} is a null-terminated string
     of length at least one.
@@ -40,7 +40,7 @@ int _fq_zech_ctx_init_conway(fq_zech_ctx_t ctx, const fmpz_t p,
     given size and the initialization is successful; otherwise,
     returns $0$.
 
-    Assumes that $p$ is a prime and $p^d < 2^{FLINT_BITS}$.
+    Assumes that $p$ is a prime and $p^d < 2^\texttt{FLINT\_BITS}$.
 
     Assumes that the string \code{var} is a null-terminated string
     of length at least one.
@@ -52,7 +52,19 @@ void fq_zech_ctx_init_conway(fq_zech_ctx_t ctx, const fmpz_t p,
     with name \code{var} for the generator using a Conway polynomial
     for the modulus.
 
-    Assumes that $p$ is a prime and $p^d < 2^{FLINT_BITS}$.
+    Assumes that $p$ is a prime and $p^d < 2^\texttt{FLINT\_BITS}$.
+
+    Assumes that the string \code{var} is a null-terminated string
+    of length at least one.
+
+void fq_zech_ctx_init_random(fq_zech_ctx_t ctx, const fmpz_t p,
+                             slong d, const char *var)
+
+    Initialises the context for prime~$p$ and extension degree~$d$,
+    with name \code{var} for the generator using a random primitive
+    polynomial.
+
+    Assumes that $p$ is a prime and $p^d < 2^\texttt{FLINT\_BITS}$.
 
     Assumes that the string \code{var} is a null-terminated string
     of length at least one.
@@ -64,7 +76,7 @@ void fq_zech_ctx_init_modulus(fq_zech_ctx_t ctx
     Initialises the context for given \code{modulus} with name
     \code{var} for the generator.
 
-    Assumes that \code{modulus} is an irreducible polynomial over
+    Assumes that \code{modulus} is an primitive polynomial over
     $\mathbf{F}_{p}$.
 
     Assumes that the string \code{var} is a null-terminated string
@@ -473,6 +485,19 @@ void fq_zech_frobenius(fq_zech_t rop, const fq_zech_t op, slong e,
     $\mathbf{Z}/d\mathbf{Z}$, where
     $\sigma \in \Gal(\mathbf{F}_q/\mathbf{F}_p)$ is the Frobenius element
     $\sigma \colon x \mapsto x^p$.
+
+int fq_zech_multiplicative_order(fmpz_t ord, const fq_zech_t op, const fq_zech_ctx_t ctx)
+
+    Computes the order of \code{op} as an element of the
+    multiplicative group of \code{ctx}.
+    
+    Returns 0 if \code{op} is 0, otherwise it returns 1 if \code{op}
+    is a generator of the multiplicative group, and -1 if it is not.
+
+int fq_zech_is_primitive(const fq_zech_t op, const fq_zech_ctx_t ctx)
+
+    Returns whether \code{op} is primitive, i.e., whether it is a
+    generator of the multiplicative group of \code{ctx}.
 
 *******************************************************************************
 

--- a/fq_zech/multiplicative_order.c
+++ b/fq_zech/multiplicative_order.c
@@ -1,0 +1,22 @@
+/*
+    Copyright (C) 2018 Luca De Feo
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fq_zech.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq_zech
+#define CAP_T FQ_ZECH
+#include "fq_templates/multiplicative_order.c"
+#undef CAP_T
+#undef T

--- a/fq_zech/test/t-ctx_init.c
+++ b/fq_zech/test/t-ctx_init.c
@@ -21,10 +21,10 @@ main(void)
 {
     slong primes[10] = { 2, 3, 5, 7, 11, 13, 17, 19, 23, 29 };
     slong exponents[10] = { 16, 10, 6, 5, 4, 4, 3, 3, 3, 3 };
-    int i, j;
+    int i, j, random;
     slong d;
     fmpz_t p, e;
-    fq_nmod_ctx_t fq_nmod_ctx;
+    fq_nmod_ctx_struct *fq_nmod_ctx;
     fq_nmod_t lhs, rhs, one;
     fq_zech_ctx_t ctx;
     FLINT_TEST_INIT(state);
@@ -42,59 +42,64 @@ main(void)
 
         for (d = 2; d < exponents[i]; d++)
         {
-            fq_nmod_ctx_init_conway(fq_nmod_ctx, p, d, "a");
-            fq_zech_ctx_init_fq_nmod_ctx(ctx, fq_nmod_ctx);
-            fq_nmod_init(lhs, fq_nmod_ctx);
-            fq_nmod_init(rhs, fq_nmod_ctx);
-            fq_nmod_init(one, fq_nmod_ctx);
-
-            fq_nmod_one(one, fq_nmod_ctx);
-
-
-            for (j = 0; j < ctx->qm1; j++)
+            for (random = 0; random <= 1; random++)
             {
-                /* Skip the cases where a^j + 1 == 0 */
-                if (primes[i] == 2 && i == 0)
+                if (random)
+                    fq_zech_ctx_init_random(ctx, p, d, "a");
+                else
+                    fq_zech_ctx_init_conway(ctx, p, d, "a");
+                fq_nmod_ctx = ctx->fq_nmod_ctx;
+                fq_nmod_init(lhs, fq_nmod_ctx);
+                fq_nmod_init(rhs, fq_nmod_ctx);
+                fq_nmod_init(one, fq_nmod_ctx);
+
+                fq_nmod_one(one, fq_nmod_ctx);
+
+
+                for (j = 0; j < ctx->qm1; j++)
                 {
-                    continue;
-                }
-                if (j == ctx->qm1 / 2)
-                {
-                    continue;
+                    /* Skip the cases where a^j + 1 == 0 */
+                    if (primes[i] == 2 && i == 0)
+                    {
+                        continue;
+                    }
+                    if (j == ctx->qm1 / 2)
+                    {
+                        continue;
+                    }
+
+                    /* lhs = a^Z(j) */
+                    fmpz_set_ui(e, ctx->zech_log_table[j]);
+                    fq_nmod_gen(lhs, fq_nmod_ctx);
+                    fq_nmod_pow(lhs, lhs, e, fq_nmod_ctx);
+
+                    /* rhs = a^j + 1 */
+                    fmpz_set_ui(e, j);
+                    fq_nmod_gen(rhs, fq_nmod_ctx);
+                    fq_nmod_pow(rhs, rhs, e, fq_nmod_ctx);
+                    fq_nmod_add(rhs, rhs, one, fq_nmod_ctx);
+
+                    if (!fq_nmod_equal(lhs, rhs, fq_nmod_ctx))
+                    {
+                        flint_printf("FAIL:\n\n");
+                        flint_printf("K = GF(%wd^%wd)\n", primes[i], d);
+                        flint_printf("Z(%d) = %wd\n", j, ctx->zech_log_table[j]);
+                        flint_printf("LHS: ");
+                        fq_nmod_print_pretty(lhs, fq_nmod_ctx);
+                        flint_printf("\n");
+                        flint_printf("RHS: ");
+                        fq_nmod_print_pretty(rhs, fq_nmod_ctx);
+                        flint_printf("\n");
+                        abort();
+                    }
                 }
 
-                /* lhs = a^Z(j) */
-                fmpz_set_ui(e, ctx->zech_log_table[j]);
-                fq_nmod_gen(lhs, fq_nmod_ctx);
-                fq_nmod_pow(lhs, lhs, e, fq_nmod_ctx);
+                fq_nmod_clear(lhs, fq_nmod_ctx);
+                fq_nmod_clear(rhs, fq_nmod_ctx);
+                fq_nmod_clear(one, fq_nmod_ctx);
 
-                /* rhs = a^j + 1 */
-                fmpz_set_ui(e, j);
-                fq_nmod_gen(rhs, fq_nmod_ctx);
-                fq_nmod_pow(rhs, rhs, e, fq_nmod_ctx);
-                fq_nmod_add(rhs, rhs, one, fq_nmod_ctx);
-
-                if (!fq_nmod_equal(lhs, rhs, fq_nmod_ctx))
-                {
-                    flint_printf("FAIL:\n\n");
-                    flint_printf("K = GF(%wd^%wd)\n", primes[i], d);
-                    flint_printf("Z(%d) = %wd\n", j, ctx->zech_log_table[j]);
-                    flint_printf("LHS: ");
-                    fq_nmod_print_pretty(lhs, fq_nmod_ctx);
-                    flint_printf("\n");
-                    flint_printf("RHS: ");
-                    fq_nmod_print_pretty(rhs, fq_nmod_ctx);
-                    flint_printf("\n");
-                    abort();
-                }
+                fq_zech_ctx_clear(ctx);
             }
-
-            fq_nmod_clear(lhs, fq_nmod_ctx);
-            fq_nmod_clear(rhs, fq_nmod_ctx);
-            fq_nmod_clear(one, fq_nmod_ctx);
-
-            fq_zech_ctx_clear(ctx);
-            fq_nmod_ctx_clear(fq_nmod_ctx);
         }
     }
 

--- a/fq_zech/test/t-is_primitive.c
+++ b/fq_zech/test/t-is_primitive.c
@@ -1,0 +1,22 @@
+/*
+    Copyright (C) 2018 Luca De Feo
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fq_zech.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq_zech
+#define CAP_T FQ_ZECH
+#include "fq_templates/test/t-is_primitive.c"
+#undef CAP_T
+#undef T

--- a/fq_zech/test/t-multiplicative_order.c
+++ b/fq_zech/test/t-multiplicative_order.c
@@ -1,0 +1,22 @@
+/*
+    Copyright (C) 2018 Luca De Feo
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fq_zech.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq_zech
+#define CAP_T FQ_ZECH
+#include "fq_templates/test/t-multiplicative_order.c"
+#undef CAP_T
+#undef T

--- a/nmod_poly.h
+++ b/nmod_poly.h
@@ -329,6 +329,8 @@ FLINT_DLL void nmod_poly_randtest_monic(nmod_poly_t poly, flint_rand_t state, sl
 
 FLINT_DLL void nmod_poly_randtest_monic_irreducible(nmod_poly_t poly, flint_rand_t state, slong len);
 
+FLINT_DLL void nmod_poly_randtest_monic_primitive(nmod_poly_t poly, flint_rand_t state, slong len);
+
 FLINT_DLL void nmod_poly_randtest_trinomial(nmod_poly_t poly, flint_rand_t state, slong len);
 
 FLINT_DLL int nmod_poly_randtest_trinomial_irreducible(nmod_poly_t poly, flint_rand_t state,

--- a/nmod_poly/doc/nmod_poly.txt
+++ b/nmod_poly/doc/nmod_poly.txt
@@ -3,6 +3,7 @@
     Copyright (C) 2011 Fredrik Johansson
     Copyright (C) 2011 Sebastian Pancratz
     Copyright (C) 2014 Ashish Kedia
+    Copyright (C) 2018 Luca De Feo
 
     This file is part of FLINT.
 
@@ -172,6 +173,13 @@ nmod_poly_randtest_monic_irreducible(nmod_poly_t poly, flint_rand_t state,
                                      slong len)
 
     Generates a random monic irreducible polynomial with length \code{len}.
+
+void
+nmod_poly_randtest_monic_primitive(nmod_poly_t poly, flint_rand_t state,
+                                   slong len)
+
+    Generates a random monic irreducible primitive polynomial with
+    length \code{len}.
 
 
 void

--- a/nmod_poly/randtest_monic_primitive.c
+++ b/nmod_poly/randtest_monic_primitive.c
@@ -1,0 +1,32 @@
+/*
+    Copyright (C) 2018 Luca De Feo
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "nmod_poly.h"
+#include "fq_nmod.h"
+
+void
+nmod_poly_randtest_monic_primitive(nmod_poly_t poly, flint_rand_t state, slong len)
+{
+    fq_nmod_ctx_t ctx;
+    fq_nmod_t X;
+    int primitive = 0;
+    
+    while (!primitive)
+    {
+        nmod_poly_randtest_monic_irreducible(poly, state, len);
+        fq_nmod_ctx_init_modulus(ctx, poly, "X");
+        fq_nmod_init(X, ctx);
+        fq_nmod_gen(X, ctx);
+        primitive = fq_nmod_is_primitive(X, ctx);
+        fq_nmod_clear(X, ctx);
+        fq_nmod_ctx_clear(ctx);
+    }
+}


### PR DESCRIPTION
- Adds a check to fq_zech_ctx_init to abort in case in case
  the modulus is not primitive.
- Fixes bugs in fq_zech_ctx_init related to non-primitive
  polynomials.
- Adds functions to compute the multiplicative order of fq_t, 
  fq_nmod_t and fq_zech_t.
- Adds functions to compute random primitive polynomials.

Fixes #419.