### PR TITLE
fix OMP threadprivate for TLS variables

### DIFF
--- a/flint.h
+++ b/flint.h
@@ -146,10 +146,14 @@ FLINT_DLL void flint_set_abort(void (*func)(void));
 #define mp_bitcnt_t ulong
 
 #if HAVE_TLS
-#ifdef _MSC_VER
+#if __STDC_VERSION__ >= 201112L
+#define FLINT_TLS_PREFIX _Thread_local
+#elif defined(_MSC_VER)
 #define FLINT_TLS_PREFIX __declspec(thread)
-#else
+#elif defined(__GNUC__)
 #define FLINT_TLS_PREFIX __thread
+#else
+#error "thread local prefix defined in C11 or later"
 #endif
 #else
 #define FLINT_TLS_PREFIX

--- a/ulong_extras.h
+++ b/ulong_extras.h
@@ -119,7 +119,7 @@ FLINT_DLL extern const unsigned int flint_primes_small[];
 extern FLINT_TLS_PREFIX ulong * _flint_primes[FLINT_BITS];
 extern FLINT_TLS_PREFIX double * _flint_prime_inverses[FLINT_BITS];
 extern FLINT_TLS_PREFIX int _flint_primes_used;
-#if defined(_OPENMP)
+#if defined(_OPENMP) && !defined(HAVE_TLS)
 #pragma omp threadprivate(_flint_primes, _flint_prime_inverses, _flint_primes_used)
 #endif
 


### PR DESCRIPTION
This allows compilation with clang; the OpenMP 4.5 standard does not seem to prohibit thread_local threadprivate, but semantically it does not make particular sense.