### PR TITLE
Fix bug in nmod_poly_factor_equal_deg_prob

### DIFF
--- a/nmod_poly_factor/factor_equal_deg_prob.c
+++ b/nmod_poly_factor/factor_equal_deg_prob.c
@@ -79,7 +79,7 @@ nmod_poly_factor_equal_deg_prob(nmod_poly_t factor,
     }
     mpz_clear(exp);
 
-    b->coeffs[0] = n_submod(b->coeffs[0], 1, pol->mod.n);
+    nmod_poly_set_coeff_ui(b, 0, n_submod(b->coeffs[0], 1, pol->mod.n));
 
     nmod_poly_gcd(factor, b, pol);
 


### PR DESCRIPTION
Fixes the following bug reported by Carlo:
```julia
julia> using Nemo

julia> R = ResidueRing(FlintZZ, 11); Rx, x = R["x"];

julia> f = x^312+6*x^286+4*x^260+9*x^234+8*x^208+4*x^182+10*x^130+9*x^104+6*x^78+4*x^52+2*x^26+1; factor(f)
Flint exception (Impossible inverse):
    Cannot invert modulo 11*1
ERROR: Problem in the Flint-Subsystem
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] flint_abort() at /home/thofmann/.julia/dev/Nemo/src/Nemo.jl:99
 [3] _factor at /home/thofmann/.julia/dev/Nemo/src/flint/nmod_poly.jl:746 [inlined]
 [4] factor(::nmod_poly) at /home/thofmann/.julia/dev/Nemo/src/flint/nmod_poly.jl:739
 [5] top-level scope at none:0
```julia
