### PR TITLE
Fix memory leaks

### DIFF
--- a/fmpq_poly/test/t-print_read.c
+++ b/fmpq_poly/test/t-print_read.c
@@ -97,6 +97,9 @@ int main(void)
             }
 
             fclose(out);
+            for (i = 0; i < n; ++i)
+                fmpq_poly_clear(a[i]);
+            flint_free(a);
             exit(0);
         }
         else  /* Parent process */

--- a/fmpz/test/t-out_inp_raw.c
+++ b/fmpz/test/t-out_inp_raw.c
@@ -96,6 +96,9 @@ int main(void)
             }
 
             fclose(out);
+            for (i = 0; i < n; ++i)
+                fmpz_clear(a + i);
+            flint_free(a);
             exit(0);
         }
         else  /* Parent process */

--- a/fmpz/test/t-print_read.c
+++ b/fmpz/test/t-print_read.c
@@ -92,6 +92,9 @@ int main(void)
             }
 
             fclose(out);
+            for (i = 0; i < n; ++i)
+                fmpz_clear(a + i);
+            flint_free(a);
             exit(0);
         }
         else  /* Parent process */

--- a/fmpz_mat/test/t-print_read.c
+++ b/fmpz_mat/test/t-print_read.c
@@ -98,6 +98,9 @@ int main(void)
             }
 
             fclose(out);
+            for (i = 0; i < k; ++i)
+                fmpz_mat_clear(M[i]);
+            flint_free(M);
             exit(0);
         }
         else  /* Parent process */

--- a/fmpz_poly/test/t-print_read.c
+++ b/fmpz_poly/test/t-print_read.c
@@ -96,6 +96,9 @@ int main(void)
             }
 
             fclose(out);
+            for (i = 0; i < n; ++i)
+                fmpz_poly_clear(a[i]);
+            flint_free(a);
             exit(0);
         }
         else  /* Parent process */

--- a/fmpz_poly/test/t-print_read_pretty.c
+++ b/fmpz_poly/test/t-print_read_pretty.c
@@ -98,6 +98,9 @@ int main(void)
             }
 
             fclose(out);
+            for (i = 0; i < n; ++i)
+                fmpz_poly_clear(a[i]);
+            flint_free(a);
             exit(0);
         }
         else  /* Parent process */

--- a/fq_poly_factor_templates/factor_berlekamp.c
+++ b/fq_poly_factor_templates/factor_berlekamp.c
@@ -263,6 +263,7 @@ __TEMPLATE(T, poly_factor_berlekamp) (TEMPLATE(T, poly_factor_t) factors,
     TEMPLATE(T, clear) (mul, ctx);
     fmpz_clear(pow);
     fmpz_clear(p);
+    fmpz_clear(q);
     fmpz_clear(s);
 }
 

--- a/fq_poly_factor_templates/is_irreducible_ben_or.c
+++ b/fq_poly_factor_templates/is_irreducible_ben_or.c
@@ -82,6 +82,8 @@ TEMPLATE(T, poly_is_irreducible_ben_or) (const TEMPLATE(T, poly_t) f,
         }
     }
 
+    TEMPLATE(T, poly_clear) (g, ctx);
+    TEMPLATE(T, poly_clear) (x, ctx);
     TEMPLATE(T, poly_clear) (xq, ctx);
     TEMPLATE(T, poly_clear) (xqimx, ctx);
     TEMPLATE(T, poly_clear) (v, ctx);

--- a/fq_poly_templates/div_newton_n_preinv.c
+++ b/fq_poly_templates/div_newton_n_preinv.c
@@ -79,7 +79,7 @@ TEMPLATE(T, poly_div_newton_n_preinv) (TEMPLATE(T, poly_t) Q,
 
     if (Q == A || Q == B || Q == Binv)
     {
-        flint_free(Q->coeffs);
+        TEMPLATE(T, poly_clear) (Q, ctx);
         Q->coeffs = q;
         Q->alloc = lenQ;
     }

--- a/fq_poly_templates/divrem_newton_n_preinv.c
+++ b/fq_poly_templates/divrem_newton_n_preinv.c
@@ -96,13 +96,13 @@ TEMPLATE(T, poly_divrem_newton_n_preinv) (TEMPLATE(T, poly_t) Q,
 
     if (Q == A || Q == B || Q == Binv)
     {
-        _TEMPLATE(T, vec_clear) (Q->coeffs, lenA - lenB + 1, ctx);
+        _TEMPLATE(T, vec_clear) (Q->coeffs, Q->alloc, ctx);
         Q->coeffs = q;
         Q->alloc = lenA - lenB + 1;
     }
     if (R == A || R == B || R == Binv)
     {
-        _TEMPLATE(T, vec_clear) (R->coeffs, lenB - 1, ctx);
+        _TEMPLATE(T, vec_clear) (R->coeffs, R->alloc, ctx);
         R->coeffs = r;
         R->alloc = lenB - 1;
     }

--- a/fq_poly_templates/evaluate_fq_vec_fast.c
+++ b/fq_poly_templates/evaluate_fq_vec_fast.c
@@ -45,6 +45,7 @@ _TEMPLATE4(T, poly_evaluate, T, vec_fast_precomp)
                 TEMPLATE(T, set)(vs + i, poly, ctx);
         
         TEMPLATE(T, clear)(temp, ctx);
+        TEMPLATE(T, clear)(inv, ctx);
         return;
     }
 

--- a/fq_poly_templates/gcd_hgcd.c
+++ b/fq_poly_templates/gcd_hgcd.c
@@ -158,6 +158,8 @@ void TEMPLATE(T, poly_gcd_hgcd) (TEMPLATE(T, poly_t) G,
                 TEMPLATE(T, one) (G->coeffs, ctx);
             else
                 TEMPLATE(T, poly_make_monic) (G, G, ctx);
+
+            TEMPLATE(T, clear) (invB, ctx);
         }
     }
 }

--- a/fq_poly_templates/test/t-evaluate_fq_vec_fast.c
+++ b/fq_poly_templates/test/t-evaluate_fq_vec_fast.c
@@ -71,6 +71,8 @@ main(void)
         _TEMPLATE(T, vec_clear)(x, npoints, ctx);
         _TEMPLATE(T, vec_clear)(y, npoints, ctx);
         _TEMPLATE(T, vec_clear)(z, npoints, ctx);
+
+        TEMPLATE(T, ctx_clear)(ctx);
     }
 
     FLINT_TEST_CLEANUP(state);

--- a/fq_poly_templates/test/t-gcd.c
+++ b/fq_poly_templates/test/t-gcd.c
@@ -62,6 +62,8 @@ main(void)
         TEMPLATE(T, poly_clear) (a, ctx);
         TEMPLATE(T, poly_clear) (b, ctx);
         TEMPLATE(T, poly_clear) (g, ctx);
+
+        TEMPLATE(T, ctx_clear) (ctx);
     }
 
 

--- a/fq_poly_templates/test/t-gcd_euclidean.c
+++ b/fq_poly_templates/test/t-gcd_euclidean.c
@@ -62,6 +62,8 @@ main(void)
         TEMPLATE(T, poly_clear) (a, ctx);
         TEMPLATE(T, poly_clear) (b, ctx);
         TEMPLATE(T, poly_clear) (g, ctx);
+
+        TEMPLATE(T, ctx_clear) (ctx);
     }
 
 

--- a/fq_poly_templates/test/t-make_monic.c
+++ b/fq_poly_templates/test/t-make_monic.c
@@ -54,6 +54,7 @@ main(void)
         }
 
         TEMPLATE(T, poly_clear) (a, ctx);
+        TEMPLATE(T, poly_clear) (b, ctx);
         TEMPLATE(T, ctx_clear) (ctx);
     }
 

--- a/fq_templates/test/t-is_invertible_f.c
+++ b/fq_templates/test/t-is_invertible_f.c
@@ -34,7 +34,6 @@ main(void)
         TEMPLATE(T, t) a, ainv, f, g;
 
         TEMPLATE(T, ctx_randtest_reducible)(ctx, state);
-        TEMPLATE(T, init)(f, ctx);
 
         TEMPLATE(T, init)(a, ctx);
         TEMPLATE(T, init)(f, ctx);

--- a/nmod_matxx.h
+++ b/nmod_matxx.h
@@ -415,8 +415,15 @@ private:
             nmod_mat_init_set(data[i], o.data[i]);
     }
 
+    void clear(void)
+    {
+        for(std::size_t i = 0;i < size_;++i)
+            nmod_mat_clear(data[i]);
+        delete[] data;
+    }
+
 public:
-    ~nmod_mat_vector() {delete[] data;}
+    ~nmod_mat_vector() {clear();}
     nmod_mat_vector(slong rows, slong cols, const std::vector<mp_limb_t>& primes)
     {
         size_ = primes.size();
@@ -432,7 +439,7 @@ public:
 
     nmod_mat_vector& operator=(const nmod_mat_vector& o)
     {
-        delete[] data;
+        clear();
         init(o);
         return *this;
     }


### PR DESCRIPTION
I recently built flint 2.5.2 with -fsanitize=address to track down a build failure on ppc64le in Fedora Rawhide.  This change plugs all of the easily plugged memory leaks found while doing so.  I will have a few more patches for you to fix other problems found during this exercise.