### PR TITLE
change fq_nmod typedef

### DIFF
--- a/fmpz_mat/hadamard.c
+++ b/fmpz_mat/hadamard.c
@@ -19,7 +19,7 @@ _fq_nmod_rank(const fq_nmod_t x, const fq_nmod_ctx_t ctx)
     ulong t = 0;
 
     for (i = x->length - 1; i >= 0; i--)
-        t = t * ctx->mod.n + x->coeffs[i];
+        t = t * ctx->fpctx->mod.n + x->coeffs[i];
 
     return t;
 }
@@ -29,14 +29,14 @@ _fq_nmod_unrank(fq_nmod_t x, ulong r, const fq_nmod_ctx_t ctx)
 {
     slong i;
 
-    nmod_poly_zero(x);
-    nmod_poly_fit_length(x, fq_nmod_ctx_degree(ctx));
+    nmod_polydr_zero(x, ctx->fpctx);
+    nmod_polydr_fit_length(x, fq_nmod_ctx_degree(ctx), ctx->fpctx);
 
     for (i = 0; r != 0; i++)
     {
-        x->coeffs[i] = r % ctx->mod.n;
+        x->coeffs[i] = r % ctx->fpctx->mod.n;
         x->length = i + 1;
-        r = r / ctx->mod.n;
+        r = r / ctx->fpctx->mod.n;
     }
 }
 

--- a/fmpz_mpoly/gcd_brown.c
+++ b/fmpz_mpoly/gcd_brown.c
@@ -545,7 +545,7 @@ void fmpz_mpoly_convert_from_fmpz_mpolyd(
 
 int fmpz_mpolyd_CRT_nmod(fmpz_mpolyd_t A,
                                  const fmpz_mpolyd_t B, const fmpz_t Bm,
-                                 const nmod_mpolyd_t C, const nmodf_ctx_t fctx)
+                                 const nmod_mpolyd_t C, const nmod_ctx_t fctx)
 {
     int Bok, Cok;
     slong carry;
@@ -756,7 +756,7 @@ void fmpz_mpolyd_content(fmpz_t c, const fmpz_mpolyd_t A)
     _fmpz_vec_content(c, A->coeffs, degb_prod);
 }
 
-void fmpz_mpolyd_to_nmod_mpolyd(nmod_mpolyd_t Ap, fmpz_mpolyd_t A, const nmodf_ctx_t fctx)
+void fmpz_mpolyd_to_nmod_mpolyd(nmod_mpolyd_t Ap, fmpz_mpolyd_t A, const nmod_ctx_t fctx)
 {
     slong j;
     slong degb_prod;
@@ -774,7 +774,7 @@ void fmpz_mpolyd_to_nmod_mpolyd(nmod_mpolyd_t Ap, fmpz_mpolyd_t A, const nmodf_c
     _fmpz_vec_get_nmod_vec(Ap->coeffs, A->coeffs, degb_prod, fctx->mod);
 }
 
-void fmpz_mpolyd_set_nmod_mpolyd(fmpz_mpolyd_t A, nmod_mpolyd_t Ap, const nmodf_ctx_t fctx)
+void fmpz_mpolyd_set_nmod_mpolyd(fmpz_mpolyd_t A, nmod_mpolyd_t Ap, const nmod_ctx_t fctx)
 {
     slong j;
     slong degb_prod;
@@ -883,12 +883,12 @@ int fmpz_mpolyd_gcd_brown(fmpz_mpolyd_t G,
     fmpz_t gnm, gns, anm, ans, bnm, bns;
     fmpz_t lA, lB, cA, cB, cG, bound, temp, pp;
     nmod_mpolyd_t Gp, Apbar, Bpbar, Ap, Bp;
-    nmodf_ctx_t fctx;
+    nmod_ctx_t fctx;
     TMP_INIT;
 
     TMP_START;
 
-    nmodf_ctx_init(fctx, 2);
+    nmod_ctx_init(fctx, 2);
     nvars = A->nvars;
 
     nmod_mpolyd_init(Gp, nvars);
@@ -953,7 +953,7 @@ choose_next_prime:
     if (fmpz_divisible(lA, pp) || fmpz_divisible(lB, pp))
         goto choose_next_prime;
 
-    nmodf_ctx_reset(fctx, p);
+    nmod_ctx_reset(fctx, p);
     fmpz_mpolyd_to_nmod_mpolyd(Ap, A, fctx);
     fmpz_mpolyd_to_nmod_mpolyd(Bp, B, fctx);
     success = nmod_mpolyd_gcd_brown_smprime(Gp, Apbar, Bpbar, Ap, Bp, fctx);
@@ -1067,7 +1067,7 @@ done:
     nmod_mpolyd_clear(Ap);
     nmod_mpolyd_clear(Bp);
 
-    nmodf_ctx_clear(fctx);
+    nmod_ctx_clear(fctx);
 
     TMP_END;
     return success;

--- a/fmpz_mpoly/gcd_zippel.c
+++ b/fmpz_mpoly/gcd_zippel.c
@@ -12,13 +12,6 @@
 #include "nmod_mpoly.h"
 #include "fmpz_mpoly.h"
 
-
-void nmod_mpoly_ctx_change_modulus(nmod_mpoly_ctx_t ctx, mp_limb_t modulus)
-{
-    nmodf_ctx_clear(ctx->ffinfo);
-    nmodf_ctx_init(ctx->ffinfo, modulus);
-}
-
 /*
     Find a bound on the bits of the coefficients of gcd(A,B).
     If this overflows a mp_bitcnt_t, the max mp_bitcnt_t is returned.
@@ -156,7 +149,7 @@ choose_prime_outer:
     if (gammap == UWORD(0))
         goto choose_prime_outer;
 
-    nmod_mpoly_ctx_change_modulus(ctxp, p);
+    nmod_ctx_reset(ctxp->ffinfo, p);
 
     /* make sure mod p reduction does not kill either A or B */
     fmpz_mpolyu_to_nmod_mpolyu(Ap, ctxp, A, ctx);
@@ -205,7 +198,7 @@ choose_prime_inner:
     if (gammap == UWORD(0))
         goto choose_prime_inner;
 
-    nmod_mpoly_ctx_change_modulus(ctxp, p);
+    nmod_ctx_reset(ctxp->ffinfo, p);
 
     /* make sure mod p reduction does not kill either A or B */
     fmpz_mpolyu_to_nmod_mpolyu(Ap, ctxp, A, ctx);

--- a/fq_nmod.h
+++ b/fq_nmod.h
@@ -44,7 +44,7 @@ typedef struct
     slong *j;
     slong len;
 
-    nmod_polydr_t modulus;
+    nmod_poly_t modulus;
     nmod_polydr_t inv;
 
     char *var;
@@ -66,17 +66,19 @@ FLINT_DLL void fq_nmod_ctx_init_modulus(fq_nmod_ctx_t ctx,
                               const nmod_poly_t modulus,
                               const char *var);
 
-FLINT_DLL void fq_nmod_ctx_init_modulusdr(fq_nmod_ctx_t ctx,
-                              const nmod_polydr_t modulus, mp_limb_t p,
-                              const char *var);
-
 FLINT_DLL void fq_nmod_ctx_randtest(fq_nmod_ctx_t ctx, flint_rand_t state);
 
 FLINT_DLL void fq_nmod_ctx_randtest_reducible(fq_nmod_ctx_t ctx, flint_rand_t state);
 
 FLINT_DLL void fq_nmod_ctx_clear(fq_nmod_ctx_t ctx);
 
-FQ_NMOD_INLINE const nmod_polydr_struct* fq_nmod_ctx_modulus(const fq_nmod_ctx_t ctx)
+FQ_NMOD_INLINE const nmod_polydr_struct* fq_nmod_ctx_modulusdr(const fq_nmod_ctx_t ctx)
+{
+/*    return (nmod_polydr_struct*)(ctx->modulus);*/
+    return nmod_poly_polydr(ctx->modulus);
+}
+
+FQ_NMOD_INLINE const nmod_poly_struct* fq_nmod_ctx_modulus(const fq_nmod_ctx_t ctx)
 {
     return ctx->modulus;
 }

--- a/fq_nmod/add.c
+++ b/fq_nmod/add.c
@@ -17,12 +17,12 @@ void fq_nmod_add(fq_nmod_t rop, const fq_nmod_t op1, const fq_nmod_t op2, const 
 {
     slong max = FLINT_MAX(op1->length, op2->length);
 
-    nmod_poly_fit_length(rop, max);
+    nmod_polydr_fit_length(rop, max, ctx->fpctx);
 
     _nmod_poly_add(rop->coeffs, 
                    op1->coeffs, op1->length, op2->coeffs, op2->length, 
-                   rop->mod);
+                   ctx->fpctx->mod);
 
-    _nmod_poly_set_length(rop, max);
-    _nmod_poly_normalise(rop);
+    _nmod_polydr_set_length(rop, max);
+    _nmod_polydr_normalise(rop);
 }

--- a/fq_nmod/bit_pack.c
+++ b/fq_nmod/bit_pack.c
@@ -15,6 +15,6 @@ void
 fq_nmod_bit_pack(fmpz_t f, const fq_nmod_t op, mp_bitcnt_t bit_size,
                  const fq_nmod_ctx_t ctx)
 {
-    nmod_poly_bit_pack(f, op, bit_size);
+    nmod_polydr_bit_pack(f, op, bit_size, ctx->fpctx);
 }
 

--- a/fq_nmod/bit_unpack.c
+++ b/fq_nmod/bit_unpack.c
@@ -15,6 +15,6 @@ void
 fq_nmod_bit_unpack(fq_nmod_t rop, const fmpz_t f, mp_bitcnt_t bit_size,
                    const fq_nmod_ctx_t ctx)
 {
-    nmod_poly_bit_unpack(rop, f, bit_size);
+    nmod_polydr_bit_unpack(rop, f, bit_size, ctx->fpctx);
     fq_nmod_reduce(rop, ctx);
 }

--- a/fq_nmod/ctx_clear.c
+++ b/fq_nmod/ctx_clear.c
@@ -15,7 +15,7 @@
 
 void fq_nmod_ctx_clear(fq_nmod_ctx_t ctx)
 {
-    nmod_polydr_clear(ctx->modulus, ctx->fpctx);
+    nmod_poly_clear(ctx->modulus);
     nmod_polydr_clear(ctx->inv, ctx->fpctx);
     fmpz_clear(fq_nmod_ctx_prime(ctx));
     _nmod_vec_clear(ctx->a);

--- a/fq_nmod/ctx_clear.c
+++ b/fq_nmod/ctx_clear.c
@@ -15,10 +15,11 @@
 
 void fq_nmod_ctx_clear(fq_nmod_ctx_t ctx)
 {
-    nmod_poly_clear(ctx->modulus);
-    nmod_poly_clear(ctx->inv);
+    nmod_polydr_clear(ctx->modulus, ctx->fpctx);
+    nmod_polydr_clear(ctx->inv, ctx->fpctx);
     fmpz_clear(fq_nmod_ctx_prime(ctx));
     _nmod_vec_clear(ctx->a);
     flint_free(ctx->j);
     flint_free(ctx->var);
+    nmod_ctx_clear(ctx->fpctx);
 }

--- a/fq_nmod/ctx_init_modulus.c
+++ b/fq_nmod/ctx_init_modulus.c
@@ -14,7 +14,7 @@
 
 #include "fq_nmod.h"
 
-
+/*
 void fq_nmod_ctx_init_modulusdr(fq_nmod_ctx_t ctx, const nmod_polydr_t modulus, mp_limb_t p,
                          const char *var)
 {
@@ -31,7 +31,7 @@ void fq_nmod_ctx_init_modulusdr(fq_nmod_ctx_t ctx, const nmod_polydr_t modulus, 
 
     nmod_ctx_clear(fpctx);
 }
-
+*/
 void
 fq_nmod_ctx_init_modulus(fq_nmod_ctx_t ctx, const nmod_poly_t modulus,
                          const char *var)
@@ -81,8 +81,8 @@ fq_nmod_ctx_init_modulus(fq_nmod_ctx_t ctx, const nmod_poly_t modulus,
     strcpy(ctx->var, var);
 
     /* Set the modulus */
-    nmod_polydr_init(ctx->modulus, ctx->fpctx);
-    nmod_polydr_set_nmod_poly(ctx->modulus, modulus, ctx->fpctx);
+    nmod_poly_init(ctx->modulus, modulus->mod.n);
+    nmod_poly_set(ctx->modulus, modulus);
 
     /* Precompute the inverse of the modulus */
     nmod_polydr_init(ctx->inv, ctx->fpctx);

--- a/fq_nmod/ctx_randtest.c
+++ b/fq_nmod/ctx_randtest.c
@@ -16,7 +16,7 @@
 void
 fq_nmod_ctx_randtest(fq_nmod_ctx_t ctx, flint_rand_t state)
 {
-    nmod_polydr_t modulus;
+    nmod_poly_t modulus;
     mp_limb_t x;
     fmpz_t p;
     slong d;
@@ -30,13 +30,12 @@ fq_nmod_ctx_randtest(fq_nmod_ctx_t ctx, flint_rand_t state)
     /* Test non-monic modulus */
     if (n_randint(state, 2))
     {
-        mp_limb_t pp = ctx->fpctx->mod.n;
-        nmod_polydr_init(modulus, ctx->fpctx);
-        nmod_polydr_set(modulus, ctx->modulus, ctx->fpctx);
+        nmod_poly_init(modulus, ctx->fpctx->mod.n);
+        nmod_poly_set(modulus, ctx->modulus);
         x = n_randint(state, ctx->fpctx->mod.n - 1) + 1;
-        nmod_polydr_scalar_mul_nmod(modulus, modulus, x, ctx->fpctx);
+        nmod_poly_scalar_mul_nmod(modulus, modulus, x);
         fq_nmod_ctx_clear(ctx);
-        fq_nmod_ctx_init_modulusdr(ctx, modulus, pp, "a");
-        nmod_polydr_clear(modulus, ctx->fpctx);
+        fq_nmod_ctx_init_modulus(ctx, modulus, "a");
+        nmod_poly_clear(modulus);
     }
 }

--- a/fq_nmod/ctx_randtest.c
+++ b/fq_nmod/ctx_randtest.c
@@ -16,7 +16,7 @@
 void
 fq_nmod_ctx_randtest(fq_nmod_ctx_t ctx, flint_rand_t state)
 {
-    nmod_poly_t modulus;
+    nmod_polydr_t modulus;
     mp_limb_t x;
     fmpz_t p;
     slong d;
@@ -30,12 +30,13 @@ fq_nmod_ctx_randtest(fq_nmod_ctx_t ctx, flint_rand_t state)
     /* Test non-monic modulus */
     if (n_randint(state, 2))
     {
-        nmod_poly_init(modulus, ctx->mod.n);
-        nmod_poly_set(modulus, ctx->modulus);
-        x = n_randint(state, ctx->mod.n - 1) + 1;
-        nmod_poly_scalar_mul_nmod(modulus, modulus, x);
+        mp_limb_t pp = ctx->fpctx->mod.n;
+        nmod_polydr_init(modulus, ctx->fpctx);
+        nmod_polydr_set(modulus, ctx->modulus, ctx->fpctx);
+        x = n_randint(state, ctx->fpctx->mod.n - 1) + 1;
+        nmod_polydr_scalar_mul_nmod(modulus, modulus, x, ctx->fpctx);
         fq_nmod_ctx_clear(ctx);
-        fq_nmod_ctx_init_modulus(ctx, modulus, "a");
-        nmod_poly_clear(modulus);
+        fq_nmod_ctx_init_modulusdr(ctx, modulus, pp, "a");
+        nmod_polydr_clear(modulus, ctx->fpctx);
     }
 }

--- a/fq_nmod/frobenius.c
+++ b/fq_nmod/frobenius.c
@@ -65,7 +65,7 @@ void fq_nmod_frobenius(fq_nmod_t rop, const fq_nmod_t op, slong e, const fq_nmod
         }
         else
         {
-            nmod_poly_fit_length(rop, 2 * d - 1);
+            nmod_polydr_fit_length(rop, 2 * d - 1, ctx->fpctx);
             t = rop->coeffs;
         }
 
@@ -80,9 +80,9 @@ void fq_nmod_frobenius(fq_nmod_t rop, const fq_nmod_t op, slong e, const fq_nmod
         }
         else
         {
-            _nmod_poly_set_length(rop, d);
+            _nmod_polydr_set_length(rop, d);
         }
-        _nmod_poly_normalise(rop);
+        _nmod_polydr_normalise(rop);
     }
 }
 

--- a/fq_nmod/gcdinv.c
+++ b/fq_nmod/gcdinv.c
@@ -15,5 +15,5 @@ void
 fq_nmod_gcdinv(fq_nmod_t rop, fq_nmod_t inv, const fq_nmod_t op,
                const fq_nmod_ctx_t ctx)
 {
-    nmod_polydr_gcdinv(rop, inv, op, ctx->modulus, ctx->fpctx);
+    nmod_polydr_gcdinv(rop, inv, op, fq_nmod_ctx_modulusdr(ctx), ctx->fpctx);
 }

--- a/fq_nmod/gcdinv.c
+++ b/fq_nmod/gcdinv.c
@@ -15,5 +15,5 @@ void
 fq_nmod_gcdinv(fq_nmod_t rop, fq_nmod_t inv, const fq_nmod_t op,
                const fq_nmod_ctx_t ctx)
 {
-    nmod_poly_gcdinv(rop, inv, op, ctx->modulus);
+    nmod_polydr_gcdinv(rop, inv, op, ctx->modulus, ctx->fpctx);
 }

--- a/fq_nmod/get_str.c
+++ b/fq_nmod/get_str.c
@@ -14,5 +14,5 @@
 char *
 fq_nmod_get_str(const fq_nmod_t op, const fq_nmod_ctx_t ctx)
 {
-    return nmod_poly_get_str(op);
+    return nmod_polydr_get_str(op, ctx->fpctx);
 }

--- a/fq_nmod/get_str_pretty.c
+++ b/fq_nmod/get_str_pretty.c
@@ -14,5 +14,5 @@
 char *
 fq_nmod_get_str_pretty(const fq_nmod_t op, const fq_nmod_ctx_t ctx)
 {
-    return nmod_poly_get_str_pretty(op, ctx->var);
+    return nmod_polydr_get_str_pretty(op, ctx->var, ctx->fpctx);
 }

--- a/fq_nmod/inv.c
+++ b/fq_nmod/inv.c
@@ -20,12 +20,12 @@ void _fq_nmod_inv(mp_limb_t *rop, const mp_limb_t *op, slong len,
 
     if (len == 1)
     {
-        rop[0] = n_invmod(op[0], ctx->mod.n);
+        rop[0] = n_invmod(op[0], ctx->fpctx->mod.n);
         _nmod_vec_zero(rop + 1, d - 1);
     }
     else
     {
-        _nmod_poly_invmod(rop, op, len, ctx->modulus->coeffs, d + 1, ctx->mod);
+        _nmod_poly_invmod(rop, op, len, ctx->modulus->coeffs, d + 1, ctx->fpctx->mod);
     }
 }
 
@@ -47,7 +47,7 @@ void fq_nmod_inv(fq_nmod_t rop, const fq_nmod_t op, const fq_nmod_ctx_t ctx)
         }
         else
         {
-            nmod_poly_fit_length(rop, d);
+            nmod_polydr_fit_length(rop, d, ctx->fpctx);
             t = rop->coeffs;
         }
 
@@ -62,8 +62,8 @@ void fq_nmod_inv(fq_nmod_t rop, const fq_nmod_t op, const fq_nmod_ctx_t ctx)
         }
         else
         {
-            _nmod_poly_set_length(rop, d);
+            _nmod_polydr_set_length(rop, d);
         }
-        _nmod_poly_normalise(rop);
+        _nmod_polydr_normalise(rop);
     }
 }

--- a/fq_nmod/mul.c
+++ b/fq_nmod/mul.c
@@ -15,7 +15,7 @@
 
 void fq_nmod_mul(fq_nmod_t rop, const fq_nmod_t op1, const fq_nmod_t op2, const fq_nmod_ctx_t ctx)
 {
-    nmod_poly_mul(rop, op1, op2);
+    nmod_polydr_mul(rop, op1, op2, ctx->fpctx);
 
     fq_nmod_reduce(rop, ctx);
 }

--- a/fq_nmod/mul_fmpz.c
+++ b/fq_nmod/mul_fmpz.c
@@ -14,11 +14,5 @@
 
 void fq_nmod_mul_fmpz(fq_nmod_t rop, const fq_nmod_t op, const fmpz_t x, const fq_nmod_ctx_t ctx)
 {
-    fmpz_t rx;
-    fmpz_init(rx);
-
-    fmpz_mod(rx, x, fq_nmod_ctx_prime(ctx));
-    nmod_poly_scalar_mul_nmod(rop, op, fmpz_get_ui(rx));
-
-    fmpz_clear(rx);
+    nmod_polydr_scalar_mul_nmod(rop, op, fmpz_fdiv_ui(x, ctx->fpctx->mod.n), ctx->fpctx);
 }

--- a/fq_nmod/mul_si.c
+++ b/fq_nmod/mul_si.c
@@ -14,9 +14,9 @@
 void fq_nmod_mul_si(fq_nmod_t rop, const fq_nmod_t op, slong x, const fq_nmod_ctx_t ctx)
 {
     mp_limb_t rx = x < 0 ? -x : x;
-    
-    nmod_poly_scalar_mul_nmod(rop, op, rx);
+    NMOD_RED(rx, rx, ctx->fpctx->mod);
+    nmod_polydr_scalar_mul_nmod(rop, op, rx, ctx->fpctx);
     
     if (x < 0)
-        nmod_poly_neg(rop, rop);
+        nmod_polydr_neg(rop, rop, ctx->fpctx);
 }

--- a/fq_nmod/mul_ui.c
+++ b/fq_nmod/mul_ui.c
@@ -13,5 +13,5 @@
 
 void fq_nmod_mul_ui(fq_nmod_t rop, const fq_nmod_t op, ulong x, const fq_nmod_ctx_t ctx)
 {
-   nmod_poly_scalar_mul_nmod(rop, op, n_mod2_preinv(x, ctx->mod.n, ctx->mod.ninv));
+   nmod_polydr_scalar_mul_nmod(rop, op, n_mod2_preinv(x, ctx->fpctx->mod.n, ctx->fpctx->mod.ninv), ctx->fpctx);
 }

--- a/fq_nmod/neg.c
+++ b/fq_nmod/neg.c
@@ -15,8 +15,8 @@ void fq_nmod_neg(fq_nmod_t rop, const fq_nmod_t op, const fq_nmod_ctx_t ctx)
 {
     slong len = op->length;
 
-    nmod_poly_fit_length(rop, len);
-    _nmod_poly_set_length(rop, len);
+    nmod_polydr_fit_length(rop, len, ctx->fpctx);
+    _nmod_polydr_set_length(rop, len);
 
-    nmod_poly_neg(rop, op);
+    nmod_polydr_neg(rop, op, ctx->fpctx);
 }

--- a/fq_nmod/norm.c
+++ b/fq_nmod/norm.c
@@ -32,12 +32,12 @@ void _fq_nmod_norm(fmpz_t rop2, const mp_limb_t *op, slong len,
     } 
     else if (len == 1) /* element scalar */
     {
-        rop = n_powmod2_ui_preinv(op[0], d, ctx->mod.n, ctx->mod.ninv);
+        rop = n_powmod2_ui_preinv(op[0], d, ctx->fpctx->mod.n, ctx->fpctx->mod.ninv);
     }
     else 
     {
         rop = _nmod_poly_resultant(ctx->modulus->coeffs, ctx->modulus->length,
-            op, len, ctx->mod);
+            op, len, ctx->fpctx->mod);
 
         /*
             XXX:  This part of the code is currently untested as the Conway 
@@ -49,14 +49,13 @@ void _fq_nmod_norm(fmpz_t rop2, const mp_limb_t *op, slong len,
         if (ctx->modulus->coeffs[d] != WORD(1))
         {
             mp_limb_t f;
-            f = n_powmod2_ui_preinv(ctx->modulus->coeffs[d], len - 1, ctx->mod.n, ctx->mod.ninv);
-            f = n_invmod(f, ctx->mod.n);
-            rop = n_mulmod2_preinv(f, rop, ctx->mod.n, ctx->mod.ninv);
+            f = n_powmod2_ui_preinv(ctx->modulus->coeffs[d], len - 1, ctx->fpctx->mod.n, ctx->fpctx->mod.ninv);
+            f = n_invmod(f, ctx->fpctx->mod.n);
+            rop = n_mulmod2_preinv(f, rop, ctx->fpctx->mod.n, ctx->fpctx->mod.ninv);
         }
     }
 
     fmpz_set_ui(rop2, rop);
-
 }
 
 void fq_nmod_norm(fmpz_t rop, const fq_nmod_t op, const fq_nmod_ctx_t ctx)

--- a/fq_nmod/pow.c
+++ b/fq_nmod/pow.c
@@ -72,12 +72,12 @@ void _fq_nmod_pow(mp_limb_t *rop, const mp_limb_t *op, slong len, const fmpz_t e
            We unroll the first step of the loop, referring to {op, len}
          */
 
-        _nmod_poly_mul(R, op, len, op, len, ctx->mod);
+        _nmod_poly_mul(R, op, len, op, len, ctx->fpctx->mod);
         _fq_nmod_reduce(R, 2 * len - 1, ctx);
 
         if (fmpz_tstbit(e, bit))
         {
-            _nmod_poly_mul(S, R, d, op, len, ctx->mod);
+            _nmod_poly_mul(S, R, d, op, len, ctx->fpctx->mod);
             _fq_nmod_reduce(S, d + len - 1, ctx);
             T = R;
             R = S;
@@ -88,14 +88,14 @@ void _fq_nmod_pow(mp_limb_t *rop, const mp_limb_t *op, slong len, const fmpz_t e
         {
             if (fmpz_tstbit(e, bit))
             {
-                _nmod_poly_mul(S, R, d, R, d, ctx->mod);
+                _nmod_poly_mul(S, R, d, R, d, ctx->fpctx->mod);
                 _fq_nmod_reduce(S, 2 * d - 1, ctx);
-                _nmod_poly_mul(R, S, d, op, len, ctx->mod);
+                _nmod_poly_mul(R, S, d, op, len, ctx->fpctx->mod);
                 _fq_nmod_reduce(R, d + len - 1, ctx);
             }
             else
             {
-                _nmod_poly_mul(S, R, d, R, d, ctx->mod);
+                _nmod_poly_mul(S, R, d, R, d, ctx->fpctx->mod);
                 _fq_nmod_reduce(S, 2 * d - 1, ctx);
                 T = R;
                 R = S;
@@ -138,7 +138,7 @@ void fq_nmod_pow(fq_nmod_t rop, const fq_nmod_t op, const fmpz_t e, const fq_nmo
         }
         else
         {
-            nmod_poly_fit_length(rop, 2 * d - 1);
+            nmod_polydr_fit_length(rop, 2 * d - 1, ctx->fpctx);
             t = rop->coeffs;
         }
 
@@ -153,9 +153,9 @@ void fq_nmod_pow(fq_nmod_t rop, const fq_nmod_t op, const fmpz_t e, const fq_nmo
         }
         else
         {
-            _nmod_poly_set_length(rop, d);
+            _nmod_polydr_set_length(rop, d);
         }
-        _nmod_poly_normalise(rop);
+        _nmod_polydr_normalise(rop);
     }
 }
 

--- a/fq_nmod/randtest.c
+++ b/fq_nmod/randtest.c
@@ -18,12 +18,12 @@ void fq_nmod_randtest(fq_nmod_t rop, flint_rand_t state, const fq_nmod_ctx_t ctx
     const slong d = fq_nmod_ctx_degree(ctx);
     slong i, sparse;
 
-    nmod_poly_fit_length(rop, d);
+    nmod_polydr_fit_length(rop, d, ctx->fpctx);
 
     if (n_randint(state, 2))
     {
         for (i = 0; i < d; i++)
-            rop->coeffs[i] = n_randint(state, ctx->mod.n);
+            rop->coeffs[i] = n_randint(state, ctx->fpctx->mod.n);
     }
     else
     {
@@ -33,11 +33,11 @@ void fq_nmod_randtest(fq_nmod_t rop, flint_rand_t state, const fq_nmod_ctx_t ctx
             if (n_randint(state, sparse))
                 rop->coeffs[i] = WORD(0);
             else
-                rop->coeffs[i] = n_randint(state, ctx->mod.n);
+                rop->coeffs[i] = n_randint(state, ctx->fpctx->mod.n);
     }
 
-    _nmod_poly_set_length(rop, d);
-    _nmod_poly_normalise(rop);
+    _nmod_polydr_set_length(rop, d);
+    _nmod_polydr_normalise(rop);
 }
 
 void fq_nmod_randtest_dense(fq_nmod_t rop, flint_rand_t state, const fq_nmod_ctx_t ctx)
@@ -45,15 +45,15 @@ void fq_nmod_randtest_dense(fq_nmod_t rop, flint_rand_t state, const fq_nmod_ctx
     const slong d = fq_nmod_ctx_degree(ctx);
     slong i;
 
-    nmod_poly_fit_length(rop, d);
+    nmod_polydr_fit_length(rop, d, ctx->fpctx);
 
     for (i = 0; i < d - 1; i++)
-        rop->coeffs[i] = n_randint(state, ctx->mod.n);
+        rop->coeffs[i] = n_randint(state, ctx->fpctx->mod.n);
 
     rop->coeffs[d - 1] = 1;
 
-    _nmod_poly_set_length(rop, d);
-    _nmod_poly_normalise(rop);
+    _nmod_polydr_set_length(rop, d);
+    _nmod_polydr_normalise(rop);
 }
 
 void fq_nmod_randtest_not_zero(fq_nmod_t rop, flint_rand_t state, const fq_nmod_ctx_t ctx)

--- a/fq_nmod/sqr.c
+++ b/fq_nmod/sqr.c
@@ -13,7 +13,7 @@
 
 void fq_nmod_sqr(fq_nmod_t rop, const fq_nmod_t op, const fq_nmod_ctx_t ctx)
 {
-    nmod_poly_mul(rop, op, op);
+    nmod_polydr_mul(rop, op, op, ctx->fpctx);
 
     fq_nmod_reduce(rop, ctx);
 }

--- a/fq_nmod/sub.c
+++ b/fq_nmod/sub.c
@@ -17,12 +17,12 @@ void fq_nmod_sub(fq_nmod_t rop, const fq_nmod_t op1, const fq_nmod_t op2, const 
 {
     slong max = FLINT_MAX(op1->length, op2->length);
 
-    nmod_poly_fit_length(rop, max);
+    nmod_polydr_fit_length(rop, max, ctx->fpctx);
 
     _nmod_poly_sub(rop->coeffs, 
                    op1->coeffs, op1->length, op2->coeffs, op2->length, 
-                   ctx->mod);
+                   ctx->fpctx->mod);
 
-    _nmod_poly_set_length(rop, max);
-    _nmod_poly_normalise(rop);
+    _nmod_polydr_set_length(rop, max);
+    _nmod_polydr_normalise(rop);
 }

--- a/fq_nmod/test/t-mul_fmpz.c
+++ b/fq_nmod/test/t-mul_fmpz.c
@@ -42,7 +42,7 @@ main(void)
 
         fq_nmod_init(a, ctx);
         fq_nmod_init(b, ctx);
-	fmpz_init(x);
+	    fmpz_init(x);
 
         fq_nmod_randtest(a, state, ctx);
         fmpz_randtest_mod_signed(x,state,fq_nmod_ctx_prime(ctx));
@@ -61,7 +61,7 @@ main(void)
 
         fq_nmod_clear(a, ctx);
         fq_nmod_clear(b, ctx);
-	fmpz_clear(x);
+	    fmpz_clear(x);
         fmpz_clear(p);
         fq_nmod_ctx_clear(ctx);
     }
@@ -74,7 +74,7 @@ main(void)
         fq_nmod_ctx_t ctx;
         fmpz_t x;
         fq_nmod_t a, c;
-	nmod_poly_t b;
+	    nmod_polydr_t b;
 
         fmpz_init(p);
         fmpz_set_ui(p, n_randprime(state, 2 + n_randint(state, 3), 1));
@@ -83,8 +83,8 @@ main(void)
 
         fq_nmod_init(a, ctx);
         fq_nmod_init(c, ctx);
-	fmpz_init(x);
-	nmod_poly_init(b, fmpz_get_ui(p));
+	    fmpz_init(x);
+	    nmod_polydr_init(b, ctx->fpctx);
 
         fq_nmod_randtest(a, state, ctx);
         fmpz_randtest_mod_signed(x, state, fq_nmod_ctx_prime(ctx));
@@ -92,12 +92,12 @@ main(void)
 
         if (fmpz_cmp_ui(x, 0) < 0)
         {
-            nmod_poly_scalar_mul_nmod(b,a,-fmpz_get_si(x));
-            nmod_poly_neg(b, b);
+            nmod_polydr_scalar_mul_nmod(b, a, -fmpz_get_si(x), ctx->fpctx);
+            nmod_polydr_neg(b, b, ctx->fpctx);
         }
         else
         {
-            nmod_poly_scalar_mul_nmod(b,a,fmpz_get_ui(x));
+            nmod_polydr_scalar_mul_nmod(b, a, fmpz_get_ui(x), ctx->fpctx);
         }
 
         result = (fq_nmod_equal(c, b, ctx));
@@ -107,15 +107,15 @@ main(void)
             flint_printf("a = "), fq_nmod_print_pretty(a, ctx), flint_printf("\n");
             flint_printf("b = "), fq_nmod_print_pretty(b, ctx), flint_printf("\n");
             flint_printf("c = "), fq_nmod_print_pretty(b, ctx), flint_printf("\n");
-	    flint_printf("x = "), fmpz_print(x), flint_printf("\n");
+	        flint_printf("x = "), fmpz_print(x), flint_printf("\n");
             abort();
         }
 
         fq_nmod_clear(a, ctx);
         fq_nmod_clear(c, ctx);
-        nmod_poly_clear(b);
+        nmod_polydr_clear(b, ctx->fpctx);
         fmpz_clear(p);
-	fmpz_clear(x);
+	    fmpz_clear(x);
         fq_nmod_ctx_clear(ctx);
     }
 

--- a/fq_nmod/test/t-mul_si.c
+++ b/fq_nmod/test/t-mul_si.c
@@ -49,7 +49,7 @@ main(void)
             flint_printf("FAIL:\n\n");
             flint_printf("a = "), fq_nmod_print_pretty(a, ctx), flint_printf("\n");
             flint_printf("b = "), fq_nmod_print_pretty(b, ctx), flint_printf("\n");
-	    flint_printf("x = %wd\n",x);
+	        flint_printf("x = %wd\n",x);
             abort();
         }
 
@@ -65,25 +65,25 @@ main(void)
         fq_nmod_ctx_t ctx;
         slong x;
         fq_nmod_t a, c;
-	nmod_poly_t b;
+	    nmod_polydr_t b;
 
         fq_nmod_ctx_randtest(ctx, state);
 
         fq_nmod_init(a, ctx);
         fq_nmod_init(c, ctx);
-	nmod_poly_init(b, ctx->mod.n);
+	    nmod_polydr_init(b, ctx->fpctx);
 
         fq_nmod_randtest(a, state, ctx);
         x = z_randtest(state);
         fq_nmod_mul_si(c, a, x, ctx);
         if (x < 0) 
         {
-            nmod_poly_scalar_mul_nmod(b, a, -x);
-            nmod_poly_neg(b, b);
+            nmod_polydr_scalar_mul_nmod(b, a, (ulong)(-x)%ctx->fpctx->mod.n, ctx->fpctx);
+            nmod_polydr_neg(b, b, ctx->fpctx);
         }
         else
         {
-            nmod_poly_scalar_mul_nmod(b, a, x);
+            nmod_polydr_scalar_mul_nmod(b, a, (ulong)(x)%ctx->fpctx->mod.n, ctx->fpctx);
         }
 
         result = (fq_nmod_equal(c, b, ctx));
@@ -92,13 +92,13 @@ main(void)
             flint_printf("FAIL:\n\n");
             flint_printf("a = "), fq_nmod_print_pretty(a, ctx), flint_printf("\n");
             flint_printf("b = "), fq_nmod_print_pretty(b, ctx), flint_printf("\n");
-	    flint_printf("x = %wd\n",x);
+	        flint_printf("x = %wd\n",x);
             abort();
         }
 
         fq_nmod_clear(a, ctx);
         fq_nmod_clear(c, ctx);
-        nmod_poly_clear(b);
+        nmod_polydr_clear(b, ctx->fpctx);
         fq_nmod_ctx_clear(ctx);
     }
 

--- a/fq_nmod/test/t-mul_ui.c
+++ b/fq_nmod/test/t-mul_ui.c
@@ -49,7 +49,7 @@ main(void)
             flint_printf("FAIL 1:\n\n");
             flint_printf("a = "), fq_nmod_print_pretty(a, ctx), flint_printf("\n");
             flint_printf("b = "), fq_nmod_print_pretty(b, ctx), flint_printf("\n");
-	    flint_printf("x = %wu\n",x);
+	        flint_printf("x = %wu\n",x);
             abort();
         }
 
@@ -65,18 +65,18 @@ main(void)
         fq_nmod_ctx_t ctx;
         ulong x;
         fq_nmod_t a, c;
-	nmod_poly_t b;
+	    nmod_polydr_t b;
 
         fq_nmod_ctx_randtest(ctx, state);
         
         fq_nmod_init(a, ctx);
         fq_nmod_init(c, ctx);
-	nmod_poly_init(b, ctx->mod.n);
+	    nmod_polydr_init(b, ctx->fpctx);
 
         fq_nmod_randtest(a, state, ctx);
-        x = n_randint(state, ctx->mod.n);
+        x = n_randint(state, ctx->fpctx->mod.n);
         fq_nmod_mul_ui(c, a, x, ctx);
-        nmod_poly_scalar_mul_nmod(b,a,x);
+        nmod_polydr_scalar_mul_nmod(b, a, x, ctx->fpctx);
 
         result = (fq_nmod_equal(c, b, ctx));
         if (!result)
@@ -85,13 +85,13 @@ main(void)
             flint_printf("a = "), fq_nmod_print_pretty(a, ctx), flint_printf("\n");
             flint_printf("b = "), fq_nmod_print_pretty(b, ctx), flint_printf("\n");
             flint_printf("c = "), fq_nmod_print_pretty(c, ctx), flint_printf("\n");
-	    flint_printf("x = %wu\n",x);
+	        flint_printf("x = %wu\n",x);
             abort();
         }
 
         fq_nmod_clear(a, ctx);
         fq_nmod_clear(c, ctx);
-        nmod_poly_clear(b);
+        nmod_polydr_clear(b, ctx->fpctx);
         fq_nmod_ctx_clear(ctx);
     }
 

--- a/fq_nmod/trace.c
+++ b/fq_nmod/trace.c
@@ -23,25 +23,25 @@ void _fq_nmod_trace(fmpz_t rop2, const mp_limb_t *op, slong len,
     t = _nmod_vec_init(d);
     _nmod_vec_zero(t, d);
 
-    t[0] = n_mod2_preinv(d, ctx->mod.n, ctx->mod.ninv);
+    t[0] = n_mod2_preinv(d, ctx->fpctx->mod.n, ctx->fpctx->mod.ninv);
 
     for (i = 1; i < d; i++)
     {
         for (l = ctx->len - 2; l >= 0 && ctx->j[l] >= d - (i - 1); l--)
         {
             t[i] = n_addmod(t[i],
-                            n_mulmod2_preinv(t[ctx->j[l] + i - d], ctx->a[l], ctx->mod.n, ctx->mod.ninv), 
-                            ctx->mod.n);
+                            n_mulmod2_preinv(t[ctx->j[l] + i - d], ctx->a[l], ctx->fpctx->mod.n, ctx->fpctx->mod.ninv), 
+                            ctx->fpctx->mod.n);
         }
 
         if (l >= 0 && ctx->j[l] == d - i)
         {
             t[i] = n_addmod(t[i],
-                            n_mulmod2_preinv(ctx->a[l], i, ctx->mod.n, ctx->mod.ninv),
-                            ctx->mod.n);
+                            n_mulmod2_preinv(ctx->a[l], i, ctx->fpctx->mod.n, ctx->fpctx->mod.ninv),
+                            ctx->fpctx->mod.n);
         }
 
-        t[i] = n_negmod(t[i], ctx->mod.n);
+        t[i] = n_negmod(t[i], ctx->fpctx->mod.n);
     }
 
     
@@ -49,8 +49,8 @@ void _fq_nmod_trace(fmpz_t rop2, const mp_limb_t *op, slong len,
     for (i = 0; i < len; i++)
     {
         rop = n_addmod(rop,
-                       n_mulmod2_preinv(op[i], t[i], ctx->mod.n, ctx->mod.ninv),
-                       ctx->mod.n);
+                       n_mulmod2_preinv(op[i], t[i], ctx->fpctx->mod.n, ctx->fpctx->mod.ninv),
+                       ctx->fpctx->mod.n);
     }
 
     _nmod_vec_clear(t);

--- a/fq_nmod_mat/reduce_row.c
+++ b/fq_nmod_mat/reduce_row.c
@@ -91,12 +91,12 @@ slong fq_nmod_mat_reduce_row(fq_nmod_mat_t A, slong * P, slong * L,
                                          slong m, const fq_nmod_ctx_t ctx)
 {
    slong n = A->c, i, j, r;
-   nmod_poly_t h;
+   nmod_polydr_t h;
 
    if (m > 10 && fq_nmod_ctx_degree(ctx) > 6)
       return fq_nmod_mat_reduce_row_KS(A, P, L, m, ctx);
 
-   nmod_poly_init(h, ctx->p);
+   nmod_polydr_init(h, ctx->fpctx);
 
    for (i = 0; i < n; i++)
    {
@@ -110,8 +110,8 @@ slong fq_nmod_mat_reduce_row(fq_nmod_mat_t A, slong * P, slong * L,
          {
             for (j = i + 1; j < L[r]; j++)
             {
-               nmod_poly_mul(h, fq_nmod_mat_entry(A, r, j), fq_nmod_mat_entry(A, m, i));
-               nmod_poly_sub(fq_nmod_mat_entry(A, m, j), fq_nmod_mat_entry(A, m, j), h);
+               nmod_polydr_mul(h, fq_nmod_mat_entry(A, r, j), fq_nmod_mat_entry(A, m, i), ctx->fpctx);
+               nmod_polydr_sub(fq_nmod_mat_entry(A, m, j), fq_nmod_mat_entry(A, m, j), h, ctx->fpctx);
             }
  
             fq_nmod_zero(fq_nmod_mat_entry(A, m, i), ctx);
@@ -129,7 +129,7 @@ slong fq_nmod_mat_reduce_row(fq_nmod_mat_t A, slong * P, slong * L,
 
             P[i] = m;
 
-            nmod_poly_clear(h);
+            nmod_polydr_clear(h, ctx->fpctx);
        
             return i;
          }
@@ -139,7 +139,7 @@ slong fq_nmod_mat_reduce_row(fq_nmod_mat_t A, slong * P, slong * L,
    for (j = i + 1; j < L[m]; j++)
       fq_nmod_reduce(fq_nmod_mat_entry(A, m, j), ctx);
 
-   nmod_poly_clear(h);
+   nmod_polydr_clear(h, ctx->fpctx);
    
    return -WORD(1);
 }

--- a/fq_nmod_mpoly.h
+++ b/fq_nmod_mpoly.h
@@ -928,14 +928,14 @@ FLINT_DLL int fq_nmod_mpolyu_gcdm_zippel(fq_nmod_mpolyu_t G, fq_nmod_mpolyu_t A,
 
 FLINT_DLL int nmod_mpolyun_CRT_fq_nmod_mpolyu(slong * lastdeg,
                              nmod_mpolyun_t H, const nmod_mpoly_ctx_t ctx,
-            nmod_poly_t m, fq_nmod_mpolyu_t A, const fq_nmod_mpoly_ctx_t ctxp);
+            nmod_polydr_t m, fq_nmod_mpolyu_t A, const fq_nmod_mpoly_ctx_t ctxp);
 
 FLINT_DLL void nmod_mpolyun_redto_fq_nmod_mpolyu(fq_nmod_mpolyu_t A, nmod_mpolyun_t B,
                   const fq_nmod_mpoly_ctx_t ffctx, const nmod_mpoly_ctx_t ctx);
 
 FLINT_DLL int nmod_mpolyun_addinterp_fq_nmod_mpolyu(slong * lastdeg,
                                 nmod_mpolyun_t F, nmod_mpolyun_t T,
-                             nmod_poly_t m, const nmod_mpoly_ctx_t ctx,
+                             nmod_polydr_t m, const nmod_mpoly_ctx_t ctx,
                           fq_nmod_mpolyu_t A, const fq_nmod_mpoly_ctx_t ffctx);
 /*
     fq_nmod_mpolyn_t

--- a/fq_nmod_mpoly/ctx_change_modulus.c
+++ b/fq_nmod_mpoly/ctx_change_modulus.c
@@ -14,7 +14,7 @@
 void fq_nmod_mpoly_ctx_change_modulus(fq_nmod_mpoly_ctx_t ctx, slong deg)
 {
     fmpz_t P;
-    fmpz_init_set_ui(P, ctx->fqctx->mod.n);
+    fmpz_init_set_ui(P, ctx->fqctx->fpctx->mod.n);
     fq_nmod_ctx_clear(ctx->fqctx);
     fq_nmod_ctx_init(ctx->fqctx, P, deg, "#");
     fmpz_clear(P);

--- a/fq_nmod_mpoly/ctx_init.c
+++ b/fq_nmod_mpoly/ctx_init.c
@@ -25,5 +25,5 @@ void fq_nmod_mpoly_ctx_init(fq_nmod_mpoly_ctx_t ctx, slong nvars,
                                const ordering_t ord, const fq_nmod_ctx_t fqctx)
 {
     mpoly_ctx_init(ctx->minfo, nvars, ord);
-    fq_nmod_ctx_init_modulusdr(ctx->fqctx, fqctx->modulus, fqctx->fpctx->mod.n, fqctx->var);
+    fq_nmod_ctx_init_modulus(ctx->fqctx, fqctx->modulus, fqctx->var);
 }

--- a/fq_nmod_mpoly/ctx_init.c
+++ b/fq_nmod_mpoly/ctx_init.c
@@ -25,5 +25,5 @@ void fq_nmod_mpoly_ctx_init(fq_nmod_mpoly_ctx_t ctx, slong nvars,
                                const ordering_t ord, const fq_nmod_ctx_t fqctx)
 {
     mpoly_ctx_init(ctx->minfo, nvars, ord);
-    fq_nmod_ctx_init_modulus(ctx->fqctx, fqctx->modulus, fqctx->var);
+    fq_nmod_ctx_init_modulusdr(ctx->fqctx, fqctx->modulus, fqctx->fpctx->mod.n, fqctx->var);
 }

--- a/fq_nmod_mpoly/derivative.c
+++ b/fq_nmod_mpoly/derivative.c
@@ -27,7 +27,7 @@ slong _fq_nmod_mpoly_derivative(fq_nmod_struct * Acoeff,       ulong * Aexp,
         ulong c = (Bexp[N*i + offset] >> shift) & mask;
         if (c == 0)
             continue;
-        NMOD_RED(cr, c, fqctx->modulus->mod);
+        NMOD_RED(cr, c, fqctx->fpctx->mod);
         if (cr == 0)
             continue;
         fq_nmod_mul_ui(Acoeff + Alen, Bcoeff + i, cr, fqctx);
@@ -56,7 +56,7 @@ slong _fq_nmod_mpoly_derivative_mp(fq_nmod_struct * Acoeff,       ulong * Aexp,
         fmpz_set_ui_array(c, Bexp + N*i + offset, bits/FLINT_BITS);
         if (fmpz_is_zero(c))
             continue;
-        cr = fmpz_fdiv_ui(c, fqctx->modulus->mod.n);
+        cr = fmpz_fdiv_ui(c, fqctx->fpctx->mod.n);
         if (cr == 0)
             continue;
         fq_nmod_mul_ui(Acoeff + Alen, Bcoeff + i, cr, fqctx);

--- a/fq_nmod_mpoly/fq_nmod_embed.c
+++ b/fq_nmod_mpoly/fq_nmod_embed.c
@@ -107,10 +107,10 @@ void _fq_nmod_embed_array_init(_fq_nmod_embed_struct * emb,
     mp_limb_t lc_inv;
     slong nullity;
     mp_limb_t p = smallctx->fpctx->mod.n;
-    slong n, m = nmod_polydr_degree(smallctx->modulus, smallctx->fpctx);
+    slong n, m = nmod_polydr_degree(fq_nmod_ctx_modulusdr(smallctx), smallctx->fpctx);
 
     /* n is the degree of the extension */
-    n = nmod_polydr_degree(bigctx->modulus, bigctx->fpctx);
+    n = nmod_polydr_degree(fq_nmod_ctx_modulusdr(bigctx), bigctx->fpctx);
     FLINT_ASSERT((n%m) == 0);
     n = n/m;
 
@@ -123,8 +123,8 @@ void _fq_nmod_embed_array_init(_fq_nmod_embed_struct * emb,
         cur->lgctx = bigctx;
 
         fq_nmod_init(cur->theta_lg, bigctx);
-        FLINT_ASSERT(1 == nmod_polydr_get_coeff_ui(cur->smctx->modulus, 1, cur->smctx->fpctx));
-        fq_nmod_set_ui(cur->theta_lg, nmod_polydr_get_coeff_ui(cur->smctx->modulus, 0, cur->smctx->fpctx), bigctx);
+        FLINT_ASSERT(1 == nmod_polydr_get_coeff_ui(fq_nmod_ctx_modulusdr(cur->smctx), 1, cur->smctx->fpctx));
+        fq_nmod_set_ui(cur->theta_lg, nmod_polydr_get_coeff_ui(fq_nmod_ctx_modulusdr(cur->smctx), 0, cur->smctx->fpctx), bigctx);
         fq_nmod_neg(cur->theta_lg, cur->theta_lg, bigctx);
         
         fq_nmod_init(cur->x_lg, bigctx);
@@ -135,9 +135,9 @@ void _fq_nmod_embed_array_init(_fq_nmod_embed_struct * emb,
 
         fq_nmod_poly_init(cur->h, smallctx);
         fq_nmod_init(t, smallctx);
-        for (i = 0; i < nmod_polydr_length(bigctx->modulus, bigctx->fpctx); i++)
+        for (i = 0; i < nmod_polydr_length(fq_nmod_ctx_modulusdr(bigctx), bigctx->fpctx); i++)
         {
-            fq_nmod_set_ui(t, nmod_polydr_get_coeff_ui(bigctx->modulus, i, bigctx->fpctx), smallctx);
+            fq_nmod_set_ui(t, nmod_polydr_get_coeff_ui(fq_nmod_ctx_modulusdr(bigctx), i, bigctx->fpctx), smallctx);
             fq_nmod_poly_set_coeff(cur->h, i, t, smallctx);
         }
 /*
@@ -151,9 +151,9 @@ flint_printf("**** emb[0]:\n"); _embed_print(emb + 0);
     /* poly will be bigctx->modulus as a polynomial over smallctx */
     fq_nmod_poly_init(poly, smallctx);
     fq_nmod_init(t, smallctx);
-    for (i = 0; i < nmod_polydr_length(bigctx->modulus, bigctx->fpctx); i++)
+    for (i = 0; i < nmod_polydr_length(fq_nmod_ctx_modulusdr(bigctx), bigctx->fpctx); i++)
     {
-        fq_nmod_set_ui(t, nmod_polydr_get_coeff_ui(bigctx->modulus, i, bigctx->fpctx), smallctx);
+        fq_nmod_set_ui(t, nmod_polydr_get_coeff_ui(fq_nmod_ctx_modulusdr(bigctx), i, bigctx->fpctx), smallctx);
         fq_nmod_poly_set_coeff(poly, i, t, smallctx);
     }
 
@@ -161,9 +161,9 @@ flint_printf("**** emb[0]:\n"); _embed_print(emb + 0);
     fq_nmod_poly_init(poly2, bigctx);
     fq_nmod_init(t2, bigctx);
     fq_nmod_init(t3, bigctx);
-    for (i = 0; i < nmod_polydr_length(smallctx->modulus, smallctx->fpctx); i++)
+    for (i = 0; i < nmod_polydr_length(fq_nmod_ctx_modulusdr(smallctx), smallctx->fpctx); i++)
     {
-        fq_nmod_set_ui(t2, nmod_polydr_get_coeff_ui(smallctx->modulus, i, smallctx->fpctx), bigctx);
+        fq_nmod_set_ui(t2, nmod_polydr_get_coeff_ui(fq_nmod_ctx_modulusdr(smallctx), i, smallctx->fpctx), bigctx);
         fq_nmod_poly_set_coeff(poly2, i, t2, bigctx);
     }
 
@@ -347,7 +347,7 @@ _fq_nmod_mpoly_embed_chooser_init(_fq_nmod_mpoly_embed_chooser_t embc,
     nmod_poly_t ext_modulus;
     fq_nmod_ctx_t ext_fqctx;
     mp_limb_t p = ctx->fqctx->fpctx->mod.n;
-    slong m = nmod_polydr_degree(ctx->fqctx->modulus, ctx->fqctx->fpctx);
+    slong m = nmod_polydr_degree(fq_nmod_ctx_modulusdr(ctx->fqctx), ctx->fqctx->fpctx);
     slong n;
 
     n = WORD(20)/(m*FLINT_BIT_COUNT(p));

--- a/fq_nmod_mpoly/mpolyd.c
+++ b/fq_nmod_mpoly/mpolyd.c
@@ -42,7 +42,7 @@ void fq_nmod_mpolyd_ctx_init_modulus(fq_nmod_mpolyd_ctx_t dctx, slong nvars,
         dctx->perm[i] = i;
     }
 
-    fq_nmod_ctx_init_modulusdr(dctx->fqctx, fqctx->modulus, fqctx->fpctx->mod.n, "#");
+    fq_nmod_ctx_init_modulus(dctx->fqctx, fq_nmod_ctx_modulus(fqctx), "#");
 }
 
 void fq_nmod_mpolyd_ctx_init2(fq_nmod_mpolyd_ctx_t dctx, slong nvars,
@@ -57,7 +57,7 @@ void fq_nmod_mpolyd_ctx_init2(fq_nmod_mpolyd_ctx_t dctx, slong nvars,
         dctx->perm[i] = i;
     }
 
-    fq_nmod_ctx_init_modulusdr(dctx->fqctx, fqctx->modulus, fqctx->fpctx->mod.n, fqctx->var);
+    fq_nmod_ctx_init_modulus(dctx->fqctx, fq_nmod_ctx_modulus(fqctx), fqctx->var);
 }
 
 void fq_nmod_mpolyd_ctx_clear(fq_nmod_mpolyd_ctx_t dctx)

--- a/fq_nmod_mpoly/mpolyd.c
+++ b/fq_nmod_mpoly/mpolyd.c
@@ -42,7 +42,7 @@ void fq_nmod_mpolyd_ctx_init_modulus(fq_nmod_mpolyd_ctx_t dctx, slong nvars,
         dctx->perm[i] = i;
     }
 
-    fq_nmod_ctx_init_modulus(dctx->fqctx, fqctx->modulus, "#");
+    fq_nmod_ctx_init_modulusdr(dctx->fqctx, fqctx->modulus, fqctx->fpctx->mod.n, "#");
 }
 
 void fq_nmod_mpolyd_ctx_init2(fq_nmod_mpolyd_ctx_t dctx, slong nvars,
@@ -57,7 +57,7 @@ void fq_nmod_mpolyd_ctx_init2(fq_nmod_mpolyd_ctx_t dctx, slong nvars,
         dctx->perm[i] = i;
     }
 
-    fq_nmod_ctx_init_modulus(dctx->fqctx, fqctx->modulus, fqctx->var);
+    fq_nmod_ctx_init_modulusdr(dctx->fqctx, fqctx->modulus, fqctx->fpctx->mod.n, fqctx->var);
 }
 
 void fq_nmod_mpolyd_ctx_clear(fq_nmod_mpolyd_ctx_t dctx)

--- a/fq_nmod_mpoly/mpolyd_gcd_brown_lgprime.c
+++ b/fq_nmod_mpoly/mpolyd_gcd_brown_lgprime.c
@@ -269,7 +269,7 @@ int fq_nmod_mpolyd_gcd_brown_lgprime(fq_nmod_mpolyd_t G,
     flint_rand_t state;
     _fq_nmod_embed_struct * embed;
     mp_limb_t p = dctx->fqctx->fpctx->mod.n;
-    slong m = nmod_polydr_degree(dctx->fqctx->modulus, dctx->fqctx->fpctx);
+    slong m = nmod_polydr_degree(fq_nmod_ctx_modulusdr(dctx->fqctx), dctx->fqctx->fpctx);
     slong n;
 
     FLINT_ASSERT(G != A);

--- a/fq_nmod_mpoly/mpolyd_gcd_brown_lgprime.c
+++ b/fq_nmod_mpoly/mpolyd_gcd_brown_lgprime.c
@@ -268,8 +268,8 @@ int fq_nmod_mpolyd_gcd_brown_lgprime(fq_nmod_mpolyd_t G,
     slong deggamma, degGs, degA, degB, degAbars, degBbars;
     flint_rand_t state;
     _fq_nmod_embed_struct * embed;
-    mp_limb_t p = dctx->fqctx->modulus->mod.n;
-    slong m = nmod_poly_degree(dctx->fqctx->modulus);
+    mp_limb_t p = dctx->fqctx->fpctx->mod.n;
+    slong m = nmod_polydr_degree(dctx->fqctx->modulus, dctx->fqctx->fpctx);
     slong n;
 
     FLINT_ASSERT(G != A);

--- a/fq_nmod_mpoly/mpolyd_gcd_brown_smprime.c
+++ b/fq_nmod_mpoly/mpolyd_gcd_brown_smprime.c
@@ -632,14 +632,16 @@ int fq_nmod_next(fq_nmod_t alpha, const fq_nmod_ctx_t fqctx)
     slong i;
     slong deg = fqctx->modulus->length - 1;
 
-    for (i = 0; i < deg; i++) {
-        ulong c = nmod_poly_get_coeff_ui(alpha, i);
+    for (i = 0; i < deg; i++)
+    {
+        ulong c = nmod_polydr_get_coeff_ui(alpha, i, fqctx->fpctx);
         c += UWORD(1);
-        if (c < fqctx->mod.n) {
-            nmod_poly_set_coeff_ui(alpha, i, c);
+        if (c < fqctx->fpctx->mod.n)
+        {
+            nmod_polydr_set_coeff_ui(alpha, i, c, fqctx->fpctx);
             return 1;
         }
-        nmod_poly_set_coeff_ui(alpha, i, UWORD(0));
+        nmod_polydr_set_coeff_ui(alpha, i, UWORD(0), fqctx->fpctx);
     }
 
     return 0;

--- a/fq_nmod_mpoly/mpolyu_gcdp_zippel.c
+++ b/fq_nmod_mpoly/mpolyu_gcdp_zippel.c
@@ -17,18 +17,20 @@ void fq_nmod_next_not_zero(fq_nmod_t alpha, const fq_nmod_ctx_t fqctx)
     slong i;
     slong deg = fqctx->modulus->length - 1;
 
-    for (i = 0; i < deg; i++) {
-        ulong c = nmod_poly_get_coeff_ui(alpha, i);
+    for (i = 0; i < deg; i++)
+    {
+        ulong c = nmod_polydr_get_coeff_ui(alpha, i, fqctx->fpctx);
         c += UWORD(1);
-        if (c < fqctx->mod.n) {
-            nmod_poly_set_coeff_ui(alpha, i, c);
+        if (c < fqctx->fpctx->mod.n)
+        {
+            nmod_polydr_set_coeff_ui(alpha, i, c, fqctx->fpctx);
             return;
         }
-        nmod_poly_set_coeff_ui(alpha, i, UWORD(0));
+        nmod_polydr_set_coeff_ui(alpha, i, UWORD(0), fqctx->fpctx);
     }
 
     /* we hit zero, so skip to 1 */
-    nmod_poly_set_coeff_ui(alpha, 0, UWORD(1));
+    nmod_polydr_set_coeff_ui(alpha, 0, UWORD(1), fqctx->fpctx);
 }
 
 
@@ -1077,7 +1079,7 @@ int fq_nmod_mpolyu_gcdp_zippel(fq_nmod_mpolyu_t G,
     }
 
     /* we don't expect this function to work over F_p */
-    if (nmod_poly_degree(ctx->fqctx->modulus) < WORD(2))
+    if (nmod_polydr_degree(ctx->fqctx->modulus, ctx->fqctx->fpctx) < WORD(2))
     {
         success = 0;
         goto finished;

--- a/fq_nmod_mpoly/mpolyu_gcdp_zippel.c
+++ b/fq_nmod_mpoly/mpolyu_gcdp_zippel.c
@@ -1079,7 +1079,7 @@ int fq_nmod_mpolyu_gcdp_zippel(fq_nmod_mpolyu_t G,
     }
 
     /* we don't expect this function to work over F_p */
-    if (nmod_polydr_degree(ctx->fqctx->modulus, ctx->fqctx->fpctx) < WORD(2))
+    if (nmod_polydr_degree(fq_nmod_ctx_modulusdr(ctx->fqctx), ctx->fqctx->fpctx) < WORD(2))
     {
         success = 0;
         goto finished;

--- a/fq_nmod_mpoly/set_str_pretty.c
+++ b/fq_nmod_mpoly/set_str_pretty.c
@@ -161,8 +161,8 @@ int _fq_nmod_mpoly_parse_pretty(fq_nmod_mpoly_t A, const char * s, slong sn,
                 goto failed;
             _fq_nmod_mpoly_parse_pretty_fit_estack(&estack, ei, &ealloc);
             fq_nmod_mpoly_geobucket_init(estack[ei], ctx);
-            fmpz_mod_ui(c, c, ctx->fqctx->modulus->mod.n);
-            fq_nmod_mpoly_geobucket_set_ui(estack[ei++], fmpz_get_ui(c), ctx);
+            fq_nmod_mpoly_geobucket_set_ui(estack[ei++],
+                               fmpz_fdiv_ui(c, ctx->fqctx->fpctx->mod.n), ctx);
             expecting = 2;
         }
         else if (*s == '^')

--- a/fq_nmod_mpoly/set_ui.c
+++ b/fq_nmod_mpoly/set_ui.c
@@ -18,9 +18,9 @@ void fq_nmod_mpoly_set_ui(fq_nmod_mpoly_t A, ulong c,
 
     N = mpoly_words_per_exp(A->bits, ctx->minfo);
 
-    if (c >= ctx->fqctx->modulus->mod.n)
+    if (c >= ctx->fqctx->fpctx->mod.n)
     {
-        NMOD_RED(c, c, ctx->fqctx->modulus->mod);
+        NMOD_RED(c, c, ctx->fqctx->fpctx->mod);
     }
 
     if (c == UWORD(0))

--- a/fq_nmod_poly/mul_univariate.c
+++ b/fq_nmod_poly/mul_univariate.c
@@ -19,7 +19,7 @@ _fq_nmod_poly_mul_univariate (fq_nmod_struct * rop,
 {
     const slong fqlen = ctx->modulus->length - 1;
     const slong pfqlen = 2*fqlen - 1;
-    const nmod_t mod = ctx->mod;
+    const nmod_t mod = ctx->fpctx->mod;
     const slong rlen = len1 + len2 - 1;
     const slong llen1 = (op1 + (len1 - 1))->length;
     const slong llen2 = (op2 + (len2 - 1))->length;
@@ -70,7 +70,7 @@ _fq_nmod_poly_mul_univariate (fq_nmod_struct * rop,
         _fq_nmod_reduce(crop + pfqlen*i, pfqlen, ctx);
         len = fqlen;
         while (len && (*(crop + pfqlen*i + len - 1) == UWORD(0))) len--;
-        nmod_poly_fit_length(rop + i, len);
+        nmod_polydr_fit_length(rop + i, len, ctx->fpctx);
         (rop + i)->length = len;
         flint_mpn_copyi((rop + i)->coeffs, crop + pfqlen*i, len);
     }
@@ -82,7 +82,7 @@ _fq_nmod_poly_mul_univariate (fq_nmod_struct * rop,
             len = fqlen;
             while (len && (*(crop + pfqlen*i + len - 1) == UWORD(0))) len--;
         }
-        nmod_poly_fit_length(rop + i, len);
+        nmod_polydr_fit_length(rop + i, len, ctx->fpctx);
         (rop + i)->length = len;
         flint_mpn_copyi((rop + i)->coeffs, crop + pfqlen*i, len);
     }

--- a/fq_nmod_poly/mullow_univariate.c
+++ b/fq_nmod_poly/mullow_univariate.c
@@ -19,7 +19,7 @@ _fq_nmod_poly_mullow_univariate (fq_nmod_struct * rop,
 {
     const slong fqlen = ctx->modulus->length - 1;
     const slong pfqlen = 2*fqlen - 1;
-    const nmod_t mod = ctx->mod;
+    const nmod_t mod = ctx->fpctx->mod;
     const slong rlen = len1 + len2 - 1;
     const slong m = FLINT_MIN(n, rlen);
     const slong cmlen = pfqlen*m;
@@ -68,7 +68,7 @@ _fq_nmod_poly_mullow_univariate (fq_nmod_struct * rop,
         _fq_nmod_reduce(crop + pfqlen*i, pfqlen, ctx);
         len = fqlen;
         while (len && (*(crop + pfqlen*i + len - 1) == UWORD(0))) len--;
-        nmod_poly_fit_length(rop + i, len);
+        nmod_polydr_fit_length(rop + i, len, ctx->fpctx);
         (rop + i)->length = len;
         flint_mpn_copyi((rop + i)->coeffs, crop + pfqlen*i, len);
     }

--- a/fq_nmod_vec/dot.c
+++ b/fq_nmod_vec/dot.c
@@ -15,7 +15,7 @@ void _fq_nmod_vec_dot(fq_nmod_t res, const fq_nmod_struct * vec1,
          const fq_nmod_struct * vec2, slong len2, const fq_nmod_ctx_t ctx)
 {
    slong i;
-   nmod_poly_t t;
+   nmod_polydr_t t;
 
    if (len2 == 0)
    {
@@ -24,19 +24,18 @@ void _fq_nmod_vec_dot(fq_nmod_t res, const fq_nmod_struct * vec1,
       return;
    }
 
-   nmod_poly_init(t, ctx->p);
+   nmod_polydr_init(t, ctx->fpctx);
 
-   nmod_poly_mul(res, vec1 + 0, vec2 + 0);
+   nmod_polydr_mul(res, vec1 + 0, vec2 + 0, ctx->fpctx);
 
    for (i = 1; i < len2; i++)
    {
-      nmod_poly_mul(t, vec1 + i, vec2 + i);
-
-      nmod_poly_add(res, res, t);
+      nmod_polydr_mul(t, vec1 + i, vec2 + i, ctx->fpctx);
+      nmod_polydr_add(res, res, t, ctx->fpctx);
    }
 
    fq_nmod_reduce(res, ctx);
 
-   nmod_poly_clear(t);
+   nmod_polydr_clear(t, ctx->fpctx);
 }
 

--- a/fq_templates/test/t-ctx_init.c
+++ b/fq_templates/test/t-ctx_init.c
@@ -55,8 +55,7 @@ main(void)
         fmpz_set_ui(p, n_randprime(state, 2 + n_randint(state, 3), 1));
         d = n_randint(state, 10) + 1;
         TEMPLATE(T, ctx_init_conway)(ctx_conway, p, d, "a");
-        TEMPLATE(T, ctx_init_modulusdr)(ctx_mod, ctx_conway->modulus, fmpz_get_ui(p), "a");
-
+        TEMPLATE(T, ctx_init_modulus)(ctx_mod, ctx_conway->modulus, "a");
         TEMPLATE(T, init)(a, ctx_conway);
         TEMPLATE(T, init)(b, ctx_mod);
         TEMPLATE(T, init)(lhs, ctx_conway);

--- a/fq_templates/test/t-ctx_init.c
+++ b/fq_templates/test/t-ctx_init.c
@@ -55,8 +55,7 @@ main(void)
         fmpz_set_ui(p, n_randprime(state, 2 + n_randint(state, 3), 1));
         d = n_randint(state, 10) + 1;
         TEMPLATE(T, ctx_init_conway)(ctx_conway, p, d, "a");
-
-        TEMPLATE(T, ctx_init_modulus)(ctx_mod, ctx_conway->modulus, "a");
+        TEMPLATE(T, ctx_init_modulusdr)(ctx_mod, ctx_conway->modulus, fmpz_get_ui(p), "a");
 
         TEMPLATE(T, init)(a, ctx_conway);
         TEMPLATE(T, init)(b, ctx_mod);
@@ -93,6 +92,7 @@ main(void)
         TEMPLATE(T, ctx_clear)(ctx_conway);
         TEMPLATE(T, ctx_clear)(ctx_mod);
 
+/*        nmod_poly_clear(ctx_conway_modulus);*/
     }
 
     FLINT_TEST_CLEANUP(state);

--- a/fq_zech.h
+++ b/fq_zech.h
@@ -73,7 +73,7 @@ FLINT_DLL void fq_zech_ctx_randtest_reducible(fq_zech_ctx_t ctx, flint_rand_t st
 
 FLINT_DLL void fq_zech_ctx_clear(fq_zech_ctx_t ctx);
 
-FQ_ZECH_INLINE const nmod_polydr_struct* fq_zech_ctx_modulus(const fq_zech_ctx_t ctx)
+FQ_ZECH_INLINE const nmod_poly_struct* fq_zech_ctx_modulus(const fq_zech_ctx_t ctx)
 {
     return fq_nmod_ctx_modulus(ctx->fq_nmod_ctx);
 }

--- a/fq_zech.h
+++ b/fq_zech.h
@@ -73,7 +73,7 @@ FLINT_DLL void fq_zech_ctx_randtest_reducible(fq_zech_ctx_t ctx, flint_rand_t st
 
 FLINT_DLL void fq_zech_ctx_clear(fq_zech_ctx_t ctx);
 
-FQ_ZECH_INLINE const nmod_poly_struct* fq_zech_ctx_modulus(const fq_zech_ctx_t ctx)
+FQ_ZECH_INLINE const nmod_polydr_struct* fq_zech_ctx_modulus(const fq_zech_ctx_t ctx)
 {
     return fq_nmod_ctx_modulus(ctx->fq_nmod_ctx);
 }

--- a/fq_zech/ctx_init.c
+++ b/fq_zech/ctx_init.c
@@ -158,7 +158,7 @@ fq_zech_ctx_init_fq_nmod_ctx(fq_zech_ctx_t ctx,
 
     for (i = 0; i < ctx->qm1; i++)
     {
-        nmod_poly_evaluate_fmpz(result, r, fq_nmod_ctx_prime(fq_nmod_ctx));
+        nmod_polydr_evaluate_fmpz(result, r, fq_nmod_ctx_prime(fq_nmod_ctx));
         result_ui = fmpz_get_ui(result);
         if (n_reverse_table[result_ui] != ctx->qm1) {
             flint_printf("Exception (fq_zech_ctx_init_nmod_ctx). Polynomial is not primitive.\n");

--- a/fq_zech/get_fq_nmod.c
+++ b/fq_zech/get_fq_nmod.c
@@ -17,16 +17,16 @@ fq_zech_get_fq_nmod(fq_nmod_t rop, const fq_zech_t op, const fq_zech_ctx_t ctx)
     slong i;
     mp_limb_t q, r;
     
-    nmod_poly_fit_length(rop, fq_zech_ctx_degree(ctx));
+    nmod_polydr_fit_length(rop, fq_zech_ctx_degree(ctx), ctx->fq_nmod_ctx->fpctx);
 
     q = ctx->eval_table[op->value];
     i = 0;
     while (q >= ctx->p)
     {
         r = n_divrem2_precomp(&q, q, ctx->p, ctx->ppre);
-        nmod_poly_set_coeff_ui(rop, i, r);
+        nmod_polydr_set_coeff_ui(rop, i, r, ctx->fq_nmod_ctx->fpctx);
         i ++;
     }
-    nmod_poly_set_coeff_ui(rop, i, q);
+    nmod_polydr_set_coeff_ui(rop, i, q, ctx->fq_nmod_ctx->fpctx);
 
 }

--- a/nmod_mpoly/add.c
+++ b/nmod_mpoly/add.c
@@ -14,7 +14,7 @@
 slong _nmod_mpoly_add1(mp_limb_t * coeff1,       ulong * exp1,
                  const mp_limb_t * coeff2, const ulong * exp2, slong len2,
                  const mp_limb_t * coeff3, const ulong * exp3, slong len3,
-                                          ulong maskhi, const nmodf_ctx_t fctx)
+                                          ulong maskhi, const nmod_ctx_t fctx)
 {
     slong i = 0, j = 0, k = 0;
 
@@ -63,7 +63,7 @@ slong _nmod_mpoly_add1(mp_limb_t * coeff1,       ulong * exp1,
 slong _nmod_mpoly_add(mp_limb_t * coeff1,       ulong * exp1,
                 const mp_limb_t * coeff2, const ulong * exp2, slong len2,
                 const mp_limb_t * coeff3, const ulong * exp3, slong len3,
-                   slong N, const ulong * cmpmask, const nmodf_ctx_t fctx)
+                   slong N, const ulong * cmpmask, const nmod_ctx_t fctx)
 {
     slong i = 0, j = 0, k = 0;
 

--- a/nmod_mpoly/add_ui.c
+++ b/nmod_mpoly/add_ui.c
@@ -16,7 +16,7 @@ void nmod_mpoly_add_ui(nmod_mpoly_t A, const nmod_mpoly_t B,
 {
     slong i, N;
     slong Blen = B->length;
-    const nmodf_ctx_struct * fctx = ctx->ffinfo;
+    const nmod_ctx_struct * fctx = ctx->ffinfo;
 
     if (Blen == 0)
     {

--- a/nmod_mpoly/ctx_clear.c
+++ b/nmod_mpoly/ctx_clear.c
@@ -14,5 +14,5 @@
 void nmod_mpoly_ctx_clear(nmod_mpoly_ctx_t ctx)
 {
     mpoly_ctx_clear(ctx->minfo);
-    nmodf_ctx_clear(ctx->ffinfo);
+    nmod_ctx_clear(ctx->ffinfo);
 }

--- a/nmod_mpoly/ctx_init.c
+++ b/nmod_mpoly/ctx_init.c
@@ -15,5 +15,5 @@ void nmod_mpoly_ctx_init(nmod_mpoly_ctx_t ctx, slong nvars,
                                        const ordering_t ord, mp_limb_t modulus)
 {
     mpoly_ctx_init(ctx->minfo, nvars, ord);
-    nmodf_ctx_init(ctx->ffinfo, modulus);
+    nmod_ctx_init(ctx->ffinfo, modulus);
 }

--- a/nmod_mpoly/ctx_init_rand.c
+++ b/nmod_mpoly/ctx_init_rand.c
@@ -15,5 +15,5 @@ void nmod_mpoly_ctx_init_rand(nmod_mpoly_ctx_t ctx, flint_rand_t state,
                                             slong max_nvars, mp_limb_t modulus)
 {
     mpoly_ctx_init_rand(ctx->minfo, state, max_nvars);
-    nmodf_ctx_init(ctx->ffinfo, modulus);
+    nmod_ctx_init(ctx->ffinfo, modulus);
 }

--- a/nmod_mpoly/derivative.c
+++ b/nmod_mpoly/derivative.c
@@ -11,11 +11,10 @@
 
 #include "nmod_mpoly.h"
 
-
 slong _nmod_mpoly_derivative(mp_limb_t * coeff1,       ulong * exp1,
                        const mp_limb_t * coeff2, const ulong * exp2, slong len2,
           mp_bitcnt_t bits, slong N, slong offset, slong shift, ulong * oneexp,
-                                                        const nmodf_ctx_t fctx)
+                                                        const nmod_ctx_t fctx)
 {
     slong i, len1;
 
@@ -43,7 +42,7 @@ slong _nmod_mpoly_derivative(mp_limb_t * coeff1,       ulong * exp1,
 slong _nmod_mpoly_derivative_mp(mp_limb_t * coeff1,       ulong * exp1,
                           const mp_limb_t * coeff2, const ulong * exp2, slong len2,
           mp_bitcnt_t bits, slong N, slong offset,              ulong * oneexp,
-                                                        const nmodf_ctx_t fctx)
+                                                        const nmod_ctx_t fctx)
 {
     slong i, len1;
     fmpz_t c;

--- a/nmod_mpoly/div_monagan_pearce.c
+++ b/nmod_mpoly/div_monagan_pearce.c
@@ -15,7 +15,7 @@ slong _nmod_mpoly_div_monagan_pearce1(
         mp_limb_t ** polyq, ulong ** expq, slong * allocq,
         const mp_limb_t * coeff2, const ulong * exp2, slong len2,
         const mp_limb_t * coeff3, const ulong * exp3, slong len3,
-                              slong bits, ulong maskhi, const nmodf_ctx_t fctx)
+                              slong bits, ulong maskhi, const nmod_ctx_t fctx)
 {
     slong i, j, q_len, s;
     slong next_loc, heap_len = 2;
@@ -199,7 +199,7 @@ slong _nmod_mpoly_div_monagan_pearce(
                   mp_limb_t ** polyq,      ulong ** expq, slong * allocq,
             const mp_limb_t * coeff2, const ulong * exp2, slong len2,
             const mp_limb_t * coeff3, const ulong * exp3, slong len3,
-       slong bits, slong N, const ulong * cmpmask, const nmodf_ctx_t fctx)
+       slong bits, slong N, const ulong * cmpmask, const nmod_ctx_t fctx)
 {
     slong i, j, q_len, s;
     slong next_loc;

--- a/nmod_mpoly/divides_monagan_pearce.c
+++ b/nmod_mpoly/divides_monagan_pearce.c
@@ -15,7 +15,7 @@ slong _nmod_mpoly_divides_monagan_pearce1(
                      mp_limb_t ** coeff1,      ulong ** exp1, slong * alloc,
                 const mp_limb_t * coeff2, const ulong * exp2, slong len2,
                 const mp_limb_t * coeff3, const ulong * exp3, slong len3,
-                              slong bits, ulong maskhi, const nmodf_ctx_t fctx)
+                              slong bits, ulong maskhi, const nmod_ctx_t fctx)
 {
     int lt_divides;
     slong i, j, q_len, s;
@@ -199,7 +199,7 @@ slong _nmod_mpoly_divides_monagan_pearce(
                      mp_limb_t ** coeff1,      ulong ** exp1, slong * alloc,
                 const mp_limb_t * coeff2, const ulong * exp2, slong len2,
                 const mp_limb_t * coeff3, const ulong * exp3, slong len3,
-     mp_bitcnt_t bits, slong N, const ulong * cmpmask, const nmodf_ctx_t fctx)
+     mp_bitcnt_t bits, slong N, const ulong * cmpmask, const nmod_ctx_t fctx)
 {
     int lt_divides;
     slong i, j, q_len, s;

--- a/nmod_mpoly/divrem_monagan_pearce.c
+++ b/nmod_mpoly/divrem_monagan_pearce.c
@@ -16,7 +16,7 @@ slong _nmod_mpoly_divrem_monagan_pearce1(slong * lenr,
         mp_limb_t ** polyr, ulong ** expr, slong * allocr,
         const mp_limb_t * coeff2, const ulong * exp2, slong len2,
         const mp_limb_t * coeff3, const ulong * exp3, slong len3,
-                              slong bits, ulong maskhi, const nmodf_ctx_t fctx)
+                              slong bits, ulong maskhi, const nmod_ctx_t fctx)
 {
     slong i, j, q_len, r_len, s;
     slong next_loc, heap_len = 2;
@@ -216,7 +216,7 @@ slong _nmod_mpoly_divrem_monagan_pearce(slong * lenr,
                   mp_limb_t ** polyr,      ulong ** expr, slong * allocr,
             const mp_limb_t * coeff2, const ulong * exp2, slong len2,
             const mp_limb_t * coeff3, const ulong * exp3, slong len3,
-       slong bits, slong N, const ulong * cmpmask, const nmodf_ctx_t fctx)
+       slong bits, slong N, const ulong * cmpmask, const nmod_ctx_t fctx)
 {
     slong i, j, q_len, r_len, s;
     slong next_loc;

--- a/nmod_mpoly/fprint_pretty.c
+++ b/nmod_mpoly/fprint_pretty.c
@@ -19,7 +19,7 @@
 int
 _nmod_mpoly_fprint_pretty(FILE * file, const mp_limb_t * coeff, const ulong * exp,
                         slong len, const char ** x_in,  slong bits,
-                                const mpoly_ctx_t mctx, const nmodf_ctx_t fctx)
+                                const mpoly_ctx_t mctx, const nmod_ctx_t fctx)
 {
     slong i, j, N;
     fmpz * exponents;

--- a/nmod_mpoly/gcd.c
+++ b/nmod_mpoly/gcd.c
@@ -614,7 +614,7 @@ int _nmod_mpoly_gcd(nmod_mpoly_t G, mp_bitcnt_t Gbits,
             Calculate gcd using univariates
         */
         ulong * Gshift;
-        nmod_poly_t a, b, g;
+        nmod_polydr_t a, b, g;
 
         Gshift = (ulong *) TMP_ALLOC(nvars*sizeof(ulong));
         for (j = 0; j < nvars; j++)
@@ -625,17 +625,17 @@ int _nmod_mpoly_gcd(nmod_mpoly_t G, mp_bitcnt_t Gbits,
                   A->exps, A->bits, A->length, Amax_exp, Amin_exp,
                   B->exps, B->bits, B->length, Bmax_exp, Bmin_exp, ctx->minfo);
 
-        nmod_poly_init_preinv(a, ctx->ffinfo->mod.n, ctx->ffinfo->mod.ninv);
-        nmod_poly_init_preinv(b, ctx->ffinfo->mod.n, ctx->ffinfo->mod.ninv);
-        nmod_poly_init_preinv(g, ctx->ffinfo->mod.n, ctx->ffinfo->mod.ninv);
-        _nmod_mpoly_to_nmod_poly_deflate(a, A, v_in_both, Amin_exp, Gstride, ctx);
-        _nmod_mpoly_to_nmod_poly_deflate(b, B, v_in_both, Bmin_exp, Gstride, ctx);
-        nmod_poly_gcd(g, a, b);
-        _nmod_mpoly_from_nmod_poly_inflate(G, Gbits, g, v_in_both,
+        nmod_polydr_init(a, ctx->ffinfo);
+        nmod_polydr_init(b, ctx->ffinfo);
+        nmod_polydr_init(g, ctx->ffinfo);
+        _nmod_mpoly_to_nmod_polydr_deflate(a, A, v_in_both, Amin_exp, Gstride, ctx);
+        _nmod_mpoly_to_nmod_polydr_deflate(b, B, v_in_both, Bmin_exp, Gstride, ctx);
+        nmod_polydr_gcd(g, a, b, ctx->ffinfo);
+        _nmod_mpoly_from_nmod_polydr_inflate(G, Gbits, g, v_in_both,
                                                           Gshift, Gstride, ctx);
-        nmod_poly_clear(a);
-        nmod_poly_clear(b);
-        nmod_poly_clear(g);
+        nmod_polydr_clear(a, ctx->ffinfo);
+        nmod_polydr_clear(b, ctx->ffinfo);
+        nmod_polydr_clear(g, ctx->ffinfo);
 
         success = 1;
         goto cleanup;

--- a/nmod_mpoly/gcd_zippel.c
+++ b/nmod_mpoly/gcd_zippel.c
@@ -113,7 +113,7 @@ int nmod_mpolyu_gcdm_zippel_bivar(
         fq_nmod_init(t, ffctx->fqctx);
 
         /* make sure reduction does not kill both lc(A) and lc(B) */
-        nmod_polydr_rem(geval, g, ffctx->fqctx->modulus, ctx->ffinfo);
+        nmod_polydr_rem(geval, g, fq_nmod_ctx_modulusdr(ffctx->fqctx), ctx->ffinfo);
         if (fq_nmod_is_zero(geval, ffctx->fqctx))
             goto outer_continue;
 
@@ -157,7 +157,7 @@ int nmod_mpolyu_gcdm_zippel_bivar(
         {
             changed = nmod_mpolyun_addinterp_fq_nmod_mpolyu(&lastdeg, H, Ht,
                                                    modulus, ctx, Geval, ffctx);
-            nmod_polydr_mul(modulus, modulus, ffctx->fqctx->modulus, ctx->ffinfo);
+            nmod_polydr_mul(modulus, modulus, fq_nmod_ctx_modulusdr(ffctx->fqctx), ctx->ffinfo);
 
             have_enough = nmod_polydr_degree(modulus, ctx->ffinfo) >= bound;
 
@@ -189,7 +189,7 @@ int nmod_mpolyu_gcdm_zippel_bivar(
         else
         {
             nmod_mpolyun_set_fq_nmod_mpolyu(H, ctx, Geval, ffctx);
-            nmod_polydr_set(modulus, ffctx->fqctx->modulus, ctx->ffinfo);
+            nmod_polydr_set(modulus, fq_nmod_ctx_modulusdr(ffctx->fqctx), ctx->ffinfo);
         }
 
 outer_continue:
@@ -330,7 +330,7 @@ choose_prime_outer:
     fq_nmod_init(t, ffctx->fqctx);
 
     /* make sure reduction does not kill both lc(A) and lc(B) */
-    nmod_polydr_rem(gammaff, gamma, ffctx->fqctx->modulus, ctx->ffinfo);
+    nmod_polydr_rem(gammaff, gamma, fq_nmod_ctx_modulusdr(ffctx->fqctx), ctx->ffinfo);
     if (fq_nmod_is_zero(gammaff, ffctx->fqctx))
         goto choose_prime_outer;
 
@@ -363,7 +363,7 @@ choose_prime_outer:
     fq_nmod_mpolyu_setform(Gform, Gff, ffctx);
     nmod_mpolyun_set_fq_nmod_mpolyu(Hn, ctx, Gff, ffctx);
 
-    nmod_polydr_set(modulus, ffctx->fqctx->modulus, ctx->ffinfo);
+    nmod_polydr_set(modulus, fq_nmod_ctx_modulusdr(ffctx->fqctx), ctx->ffinfo);
 
 choose_prime_inner:
 
@@ -390,7 +390,7 @@ choose_prime_inner:
     fq_nmod_init(t, ffctx->fqctx);
 
     /* make sure reduction does not kill both lc(A) and lc(B) */
-    nmod_polydr_rem(gammaff, gamma, ffctx->fqctx->modulus, ctx->ffinfo);
+    nmod_polydr_rem(gammaff, gamma, fq_nmod_ctx_modulusdr(ffctx->fqctx), ctx->ffinfo);
     if (fq_nmod_is_zero(gammaff, ffctx->fqctx))
         goto choose_prime_inner;
 
@@ -425,7 +425,7 @@ choose_prime_inner:
     fq_nmod_mpolyu_scalar_mul_fq_nmod(Gff, t, ffctx);
 
     changed = nmod_mpolyun_CRT_fq_nmod_mpolyu(&lastdeg, Hn, ctx, modulus, Gff, ffctx);
-    nmod_polydr_mul(modulus, modulus, ffctx->fqctx->modulus, ctx->ffinfo);
+    nmod_polydr_mul(modulus, modulus, fq_nmod_ctx_modulusdr(ffctx->fqctx), ctx->ffinfo);
 
     have_enough = nmod_polydr_degree(modulus, ctx->ffinfo) >= bound;
 

--- a/nmod_mpoly/get_str_pretty.c
+++ b/nmod_mpoly/get_str_pretty.c
@@ -16,7 +16,7 @@
 char *
 _nmod_mpoly_get_str_pretty(const mp_limb_t * coeff, const ulong * exp, slong len,
                              const char ** x_in, slong bits,
-                                const mpoly_ctx_t mctx, const nmodf_ctx_t fctx)
+                                const mpoly_ctx_t mctx, const nmod_ctx_t fctx)
 {
     char * str, ** x = (char **) x_in;
     slong i, j, N, bound, off;

--- a/nmod_mpoly/mpolyd.c
+++ b/nmod_mpoly/mpolyd.c
@@ -606,7 +606,7 @@ slong nmod_mpolyd_length(const nmod_mpolyd_t A)
     return i;
 }
 
-slong nmod_mpolyd_last_degree(const nmod_mpolyd_t A, const nmodf_ctx_t fctx)
+slong nmod_mpolyd_last_degree(const nmod_mpolyd_t A, const nmod_ctx_t fctx)
 {
     slong i, j, Plen, degree;
     slong degb_prod, degb_last=0;

--- a/nmod_mpoly/mpolyd_gcd_brown_lgprime.c
+++ b/nmod_mpoly/mpolyd_gcd_brown_lgprime.c
@@ -45,7 +45,7 @@ void nmod_mpolyd_lgprime_eval_last(fq_nmod_mpolyd_t E, const fq_nmod_mpolyd_ctx_
             k--;
         P->coeffs = A->coeffs + i;
         P->length = k;
-        nmod_polydr_rem(E->coeffs + j, P, efctx->fqctx->modulus, fctx);
+        nmod_polydr_rem(E->coeffs + j, P, fq_nmod_ctx_modulusdr(efctx->fqctx), fctx);
         j++;
     }
 
@@ -69,7 +69,7 @@ void nmod_mpolyd_lgprime_startinterp(nmod_mpolyd_t A, const nmod_ctx_t fctx,
         A->deg_bounds[j] = E->deg_bounds[j];
         degb_prod *= E->deg_bounds[j];
     }
-    degb_last = nmod_polydr_degree(efctx->fqctx->modulus, fctx);
+    degb_last = nmod_polydr_degree(fq_nmod_ctx_modulusdr(efctx->fqctx), fctx);
     A->deg_bounds[E->nvars] = degb_last;
     degb_prod *= degb_last;
 
@@ -125,7 +125,7 @@ void nmod_mpolyd_lgprime_addinterp(nmod_mpolyd_t F, nmod_mpolyd_t T,
     }
         T->deg_bounds[j] = FLINT_MAX(1 + nmod_mpolyd_last_degree(F, fctx),
                                        modulus->length
-                                       + nmod_polydr_degree(efctx->fqctx->modulus, fctx)
+                                       + nmod_polydr_degree(fq_nmod_ctx_modulusdr(efctx->fqctx), fctx)
                                     );
     
     nmod_mpolyd_fit_length(T, degb_prod*T->deg_bounds[nvars-1]);
@@ -167,7 +167,7 @@ void nmod_mpolyd_lgprime_addinterp(nmod_mpolyd_t F, nmod_mpolyd_t T,
                 k--;
             P->coeffs = F->coeffs + Find;
             P->length = k;
-            nmod_polydr_rem(v, P, efctx->fqctx->modulus, fctx);
+            nmod_polydr_rem(v, P, fq_nmod_ctx_modulusdr(efctx->fqctx), fctx);
             fq_nmod_sub(Nvalue, Nvalue, v, efctx->fqctx);
         }
 
@@ -319,7 +319,7 @@ int nmod_mpolyd_gcd_brown_lgprime(nmod_mpolyd_t G,
         fq_nmod_mpolyd_init(bbars, nvars - 1, efctx->fqctx);
         fq_nmod_init(gamma_eval, efctx->fqctx);
 
-        nmod_polydr_rem(gamma_eval, gamma, efctx->fqctx->modulus, fctx);
+        nmod_polydr_rem(gamma_eval, gamma, fq_nmod_ctx_modulusdr(efctx->fqctx), fctx);
         if (fq_nmod_is_zero(gamma_eval, efctx->fqctx))
             goto break_continue;
 
@@ -368,7 +368,7 @@ int nmod_mpolyd_gcd_brown_lgprime(nmod_mpolyd_t G,
 
         if (nmod_polydr_degree(modulus, fctx) > 0)
         {
-            nmod_polydr_rem(modulus_eval, modulus, efctx->fqctx->modulus, fctx);
+            nmod_polydr_rem(modulus_eval, modulus, fq_nmod_ctx_modulusdr(efctx->fqctx), fctx);
             FLINT_ASSERT(!fq_nmod_is_zero(modulus_eval, efctx->fqctx));
             fq_nmod_inv(modulus_eval, modulus_eval, efctx->fqctx);
 
@@ -384,7 +384,7 @@ int nmod_mpolyd_gcd_brown_lgprime(nmod_mpolyd_t G,
             nmod_mpolyd_lgprime_startinterp(Bbars, fctx, bbars, efctx);
         }
 
-        nmod_polydr_mul(modulus, modulus, efctx->fqctx->modulus, fctx);
+        nmod_polydr_mul(modulus, modulus, fq_nmod_ctx_modulusdr(efctx->fqctx), fctx);
 
         if (nmod_polydr_degree(modulus, fctx) < bound)
             goto break_continue;

--- a/nmod_mpoly/mpolyd_gcd_brown_smprime.c
+++ b/nmod_mpoly/mpolyd_gcd_brown_smprime.c
@@ -80,7 +80,7 @@ cleanup:
 void nmod_mpolyd_gcd_brown_univar(nmod_mpolyd_t G,
                                  nmod_mpolyd_t Abar,       nmod_mpolyd_t Bbar,
                            const nmod_mpolyd_t A   , const nmod_mpolyd_t B,
-                                                        const nmodf_ctx_t fctx)
+                                                        const nmod_ctx_t fctx)
 {
     slong Alen, Blen;
 
@@ -169,8 +169,8 @@ void nmod_mpolyd_gcd_brown_univar(nmod_mpolyd_t G,
 /*
     Set cont to the content of A in the last (innermost) variable only
 */
-void nmod_mpolyd_last_content(nmod_poly_t cont, const nmod_mpolyd_t A,
-                                                        const nmodf_ctx_t fctx) 
+void nmod_mpolyd_last_content(nmod_polydr_t cont, const nmod_mpolyd_t A,
+                                                        const nmod_ctx_t fctx) 
 {
     mp_limb_t * temp;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
     slong i, j, Plen;
@@ -184,8 +184,8 @@ void nmod_mpolyd_last_content(nmod_poly_t cont, const nmod_mpolyd_t A,
     }
 
     TMP_START;
-    nmod_poly_zero(cont);
-    nmod_poly_fit_length(cont, degb_last);
+    nmod_polydr_zero(cont, fctx);
+    nmod_polydr_fit_length(cont, degb_last, fctx);
     temp = (mp_limb_t *) TMP_ALLOC(degb_last*sizeof(mp_limb_t));
 
     for (i = 0; i < degb_prod; i += degb_last)
@@ -232,8 +232,8 @@ void nmod_mpolyd_last_content(nmod_poly_t cont, const nmod_mpolyd_t A,
 /*
     Divide A by b in the last (innermost) variable only
 */
-void nmod_mpolyd_div_last_poly(nmod_mpolyd_t A, nmod_poly_t b,
-                                                        const nmodf_ctx_t fctx)
+void nmod_mpolyd_div_last_poly(nmod_mpolyd_t A, nmod_polydr_t b,
+                                                        const nmod_ctx_t fctx)
 {
     slong i, j, k;
     slong degb_prod, degb_last=0, new_degb_last;
@@ -292,7 +292,7 @@ void nmod_mpolyd_div_last_poly(nmod_mpolyd_t A, nmod_poly_t b,
 */
 
 void nmod_mpolyd_mul_last_poly(nmod_mpolyd_t M,
-                   nmod_mpolyd_t A, nmod_poly_t b, const nmodf_ctx_t fctx)
+                   nmod_mpolyd_t A, nmod_polydr_t b, const nmod_ctx_t fctx)
 {
     slong i, j, k;
     slong degb_prod, degb_last, new_degb_last;
@@ -349,7 +349,7 @@ void nmod_mpolyd_mul_last_poly(nmod_mpolyd_t M,
 }
 
 
-void nmod_mpolyd_mul_scalar(nmod_mpolyd_t A, mp_limb_t b, const nmodf_ctx_t fctx)
+void nmod_mpolyd_mul_scalar(nmod_mpolyd_t A, mp_limb_t b, const nmod_ctx_t fctx)
 {
     slong j, degb_prod;
 
@@ -365,8 +365,8 @@ void nmod_mpolyd_mul_scalar(nmod_mpolyd_t A, mp_limb_t b, const nmodf_ctx_t fctx
     Set lc to the leading coefficient of A when considered as a polynomial
     in all but the last variable
 */
-void nmod_mpolyd_last_lc(nmod_poly_t lc, const nmod_mpolyd_t A,
-                                                        const nmodf_ctx_t fctx)
+void nmod_mpolyd_last_lc(nmod_polydr_t lc, const nmod_mpolyd_t A,
+                                                        const nmod_ctx_t fctx)
 {
     slong i, j, lc_len;
     slong degb_prod, degb_last=0;
@@ -377,7 +377,7 @@ void nmod_mpolyd_last_lc(nmod_poly_t lc, const nmod_mpolyd_t A,
         degb_prod *= degb_last;
     }
 
-    nmod_poly_zero(lc);
+    nmod_polydr_zero(lc, fctx);
 
     for (i = degb_prod - degb_last; i >= 0; i -= degb_last)
     {
@@ -386,7 +386,7 @@ void nmod_mpolyd_last_lc(nmod_poly_t lc, const nmod_mpolyd_t A,
         {
             if (A->coeffs[i+lc_len-1] != 0)
             {
-                nmod_poly_fit_length(lc, lc_len);
+                nmod_polydr_fit_length(lc, lc_len, fctx);
                 flint_mpn_copyi(lc->coeffs, A->coeffs + i, lc_len);
                 lc->length = lc_len;
                 return;
@@ -402,7 +402,7 @@ void nmod_mpolyd_last_lc(nmod_poly_t lc, const nmod_mpolyd_t A,
     set v = P(alpha) given precomputed powers of alpha
 */
 void _nmod_mpolyd_eval_uni(mp_limb_t * v, mp_limb_t * Pcoeffs, slong Plen,
-                              mp_limb_t * alpha_powers, const nmodf_ctx_t fctx)
+                              mp_limb_t * alpha_powers, const nmod_ctx_t fctx)
 {
     mp_limb_t pp1, pp0, ac0, ac1, ac2;
     slong k;
@@ -425,7 +425,7 @@ void _nmod_mpolyd_eval_uni(mp_limb_t * v, mp_limb_t * Pcoeffs, slong Plen,
 */
 void _nmod_mpolyd_eval2_uni(mp_limb_t * vp, mp_limb_t * vm,
                                       mp_limb_t * Pcoeffs, slong Plen,
-                              mp_limb_t * alpha_powers, const nmodf_ctx_t fctx)
+                              mp_limb_t * alpha_powers, const nmod_ctx_t fctx)
 {
     mp_limb_t p1, p0, a0, a1, a2, q1, q0, b0, b1, b2;
     slong k;
@@ -462,7 +462,7 @@ void _nmod_mpolyd_eval2_uni(mp_limb_t * vp, mp_limb_t * vm,
     Set E to A evaluated at last_var = alpha. E will have one fewer variable.
 */
 void nmod_mpolyd_eval_last(nmod_mpolyd_t E, const nmod_mpolyd_t A,
-                              mp_limb_t * alpha_powers, const nmodf_ctx_t fctx)
+                              mp_limb_t * alpha_powers, const nmod_ctx_t fctx)
 {
 
     slong i, j, k;
@@ -507,7 +507,7 @@ void nmod_mpolyd_eval_last(nmod_mpolyd_t E, const nmod_mpolyd_t A,
 */
 void nmod_mpolyd_eval2_last(nmod_mpolyd_t Ep, nmod_mpolyd_t Em,
                            const nmod_mpolyd_t A,  mp_limb_t * alpha_powers,
-                                                        const nmodf_ctx_t fctx)
+                                                        const nmod_ctx_t fctx)
 {
     slong i, j;
     slong degb_prod, degb_last=0, degb_prod_last=0;
@@ -613,8 +613,8 @@ void nmod_mpolyd_set(nmod_mpolyd_t A, const nmod_mpolyd_t B)
     F = F + modulus*(N - F(alpha))
 */
 void nmod_mpolyd_addinterp(nmod_mpolyd_t F, nmod_mpolyd_t T,
-             nmod_mpolyd_t N, nmod_poly_t modulus, mp_limb_t * alpha_powers,
-                                                        const nmodf_ctx_t fctx)
+             nmod_mpolyd_t N, nmod_polydr_t modulus, mp_limb_t * alpha_powers,
+                                                        const nmod_ctx_t fctx)
 {
     slong i, j, k, degb_prod;
     slong nvars = F->nvars;
@@ -739,9 +739,9 @@ void nmod_mpolyd_addinterp(nmod_mpolyd_t F, nmod_mpolyd_t T,
 
 
 int nmod_mpolyd_addinterp2(nmod_mpolyd_t F, nmod_mpolyd_t T,
-             nmod_mpolyd_t P, nmod_mpolyd_t M, nmod_poly_t modulus,
+             nmod_mpolyd_t P, nmod_mpolyd_t M, nmod_polydr_t modulus,
                                  mp_limb_t alpha, mp_limb_t * alpha_powers,
-                                                        const nmodf_ctx_t fctx)
+                                                        const nmod_ctx_t fctx)
 {
     slong i, j, k, degb_prod;
     slong nvars = F->nvars;
@@ -906,7 +906,7 @@ void nmod_mpolyd_startinterp(nmod_mpolyd_t fxn,
 
 void nmod_mpolyd_startinterp2(nmod_mpolyd_t F, const nmod_mpolyd_t P,
                                  const nmod_mpolyd_t M, mp_limb_t alpha,
-                                                        const nmodf_ctx_t fctx)
+                                                        const nmod_ctx_t fctx)
 {
     int Pok, Mok, carry;
     slong Pind, Mind;
@@ -994,24 +994,21 @@ void nmod_mpolyd_startinterp2(nmod_mpolyd_t F, const nmod_mpolyd_t P,
     the degree and leading coeff of D
 */
 int nmod_mpolyd_divides_univar(nmod_mpolyd_t Q, nmod_mpolyd_t A, nmod_mpolyd_t D,
-                 slong expected_deg, mp_limb_t expected_lc, const nmodf_ctx_t fctx)
+                 slong expected_deg, mp_limb_t expected_lc, const nmod_ctx_t fctx)
 {
     int success = 0;
     slong i;
-    nmod_poly_t q, r;
-    nmod_poly_t a, d;
+    nmod_polydr_t q, r;
+    nmod_polydr_t a, d;
 
-    nmod_poly_init(q, fctx->mod.n);
-    nmod_poly_init(r, fctx->mod.n);
+    nmod_polydr_init(q, fctx);
+    nmod_polydr_init(r, fctx);
 
     FLINT_ASSERT(A->nvars == WORD(1));
 
     a->coeffs = A->coeffs;
     a->length = A->deg_bounds[0];
     a->alloc = A->deg_bounds[0];
-    a->mod.n = fctx->mod.n;
-    a->mod.ninv = fctx->mod.ninv;
-    a->mod.norm = fctx->mod.norm;
     while ((a->length > 0) && (a->coeffs[a->length - 1] == 0))
         a->length--;
 
@@ -1019,9 +1016,6 @@ int nmod_mpolyd_divides_univar(nmod_mpolyd_t Q, nmod_mpolyd_t A, nmod_mpolyd_t D
     d->coeffs = D->coeffs;
     d->length = D->deg_bounds[0];
     d->alloc = D->deg_bounds[0];
-    d->mod.n = fctx->mod.n;
-    d->mod.ninv = fctx->mod.ninv;
-    d->mod.norm = fctx->mod.norm;
     while ((d->length > 0) && (d->coeffs[d->length - 1] == 0))
         d->length--;
 
@@ -1032,7 +1026,7 @@ int nmod_mpolyd_divides_univar(nmod_mpolyd_t Q, nmod_mpolyd_t A, nmod_mpolyd_t D
         goto clean_up;
     }
 
-    nmod_poly_divrem_basecase(q, r, a, d);
+    nmod_polydr_divrem_basecase(q, r, a, d, fctx);
 
     if (r->length != 0)
     {
@@ -1051,8 +1045,8 @@ int nmod_mpolyd_divides_univar(nmod_mpolyd_t Q, nmod_mpolyd_t A, nmod_mpolyd_t D
 
 clean_up:
 
-    nmod_poly_clear(q);
-    nmod_poly_clear(r);
+    nmod_polydr_clear(q, fctx);
+    nmod_polydr_clear(r, fctx);
 
     return success;
 }
@@ -1060,14 +1054,14 @@ clean_up:
 
 int nmod_mpolyd_gcd_brown_smprime_bivar(nmod_mpolyd_t G,
              nmod_mpolyd_t Abar, nmod_mpolyd_t Bbar,
-                   nmod_mpolyd_t A, nmod_mpolyd_t B, const nmodf_ctx_t fctx)
+                   nmod_mpolyd_t A, nmod_mpolyd_t B, const nmod_ctx_t fctx)
 {
     int success;
     slong j, bound;
     slong nvars = A->nvars;
     mp_limb_t alpha, gamma_eval, gammam_eval;
-    nmod_poly_t cA, cB, cG, cAbar, cBbar, lcA, lcB, gamma;
-    nmod_poly_t cGs, cAbars, cBbars, modulus, modulus2;
+    nmod_polydr_t cA, cB, cG, cAbar, cBbar, lcA, lcB, gamma;
+    nmod_polydr_t cGs, cAbars, cBbars, modulus, modulus2;
     nmod_mpolyd_t T, Gs, Abars, Bbars, phiA, phiB, phiAm, phiBm,
                                          gs, abars, bbars, gsm, abarsm, bbarsm;
     slong leadmon_gs_idx, leadmon_gsm_idx;
@@ -1091,31 +1085,31 @@ int nmod_mpolyd_gcd_brown_smprime_bivar(nmod_mpolyd_t G,
     alpha_powers = (mp_limb_t *) flint_malloc(ABlenmax*sizeof(mp_limb_t));
     alpham_powers = (mp_limb_t *) flint_malloc(ABlenmax*sizeof(mp_limb_t));
 
-    nmod_poly_init(cA, fctx->mod.n);
-    nmod_poly_init(cB, fctx->mod.n);
+    nmod_polydr_init(cA, fctx);
+    nmod_polydr_init(cB, fctx);
     nmod_mpolyd_last_content(cA, A, fctx);
     nmod_mpolyd_last_content(cB, B, fctx);
 
     nmod_mpolyd_div_last_poly(A, cA, fctx);
     nmod_mpolyd_div_last_poly(B, cB, fctx);
 
-    nmod_poly_init(cG, fctx->mod.n);
-    nmod_poly_gcd_euclidean(cG, cA, cB);
+    nmod_polydr_init(cG, fctx);
+    nmod_polydr_gcd_euclidean(cG, cA, cB, fctx);
 
-    nmod_poly_init(cAbar, fctx->mod.n);
-    nmod_poly_init(cBbar, fctx->mod.n);
-    nmod_poly_div(cAbar, cA, cG);
-    nmod_poly_div(cBbar, cB, cG);
+    nmod_polydr_init(cAbar, fctx);
+    nmod_polydr_init(cBbar, fctx);
+    nmod_polydr_div(cAbar, cA, cG, fctx);
+    nmod_polydr_div(cBbar, cB, cG, fctx);
 
-    nmod_poly_init(lcA, fctx->mod.n);
-    nmod_poly_init(lcB, fctx->mod.n);
+    nmod_polydr_init(lcA, fctx);
+    nmod_polydr_init(lcB, fctx);
     nmod_mpolyd_last_lc(lcA, A, fctx);
     nmod_mpolyd_last_lc(lcB, B, fctx);
 
-    nmod_poly_init(gamma, fctx->mod.n);
-    nmod_poly_gcd_euclidean(gamma, lcA, lcB);
+    nmod_polydr_init(gamma, fctx);
+    nmod_polydr_gcd_euclidean(gamma, lcA, lcB, fctx);
 
-    bound = 1 + nmod_poly_degree(gamma)
+    bound = 1 + nmod_polydr_degree(gamma, fctx)
                + FLINT_MAX(nmod_mpolyd_last_degree(A, fctx),
                            nmod_mpolyd_last_degree(B, fctx));
 
@@ -1137,8 +1131,8 @@ int nmod_mpolyd_gcd_brown_smprime_bivar(nmod_mpolyd_t G,
     nmod_mpolyd_init(abarsm, nvars - 1);
     nmod_mpolyd_init(bbarsm, nvars - 1);
 
-    nmod_poly_init(modulus, fctx->mod.n);
-    nmod_poly_init(modulus2, fctx->mod.n);
+    nmod_polydr_init(modulus, fctx);
+    nmod_polydr_init(modulus2, fctx);
 
     if ((fctx->mod.n & UWORD(1)) == UWORD(0))
     {
@@ -1149,7 +1143,7 @@ int nmod_mpolyd_gcd_brown_smprime_bivar(nmod_mpolyd_t G,
     use_stab = 1;
     gstab = bstab = astab = 0;
 
-    nmod_poly_one(modulus);
+    nmod_polydr_one(modulus, fctx);
 
     for (alpha = (fctx->mod.n - UWORD(1))/UWORD(2); alpha != UWORD(0); alpha--)
     {
@@ -1165,8 +1159,8 @@ int nmod_mpolyd_gcd_brown_smprime_bivar(nmod_mpolyd_t G,
                                        : alpha_powers[j];
         }
 
-        gamma_eval = nmod_poly_evaluate_nmod(gamma, alpha);
-        gammam_eval = nmod_poly_evaluate_nmod(gamma, fctx->mod.n - alpha);
+        gamma_eval = nmod_polydr_evaluate_nmod(gamma, alpha, fctx);
+        gammam_eval = nmod_polydr_evaluate_nmod(gamma, fctx->mod.n - alpha, fctx);
         if (gamma_eval == WORD(0) || gammam_eval == WORD(0))
             goto break_continue;
 
@@ -1196,7 +1190,7 @@ int nmod_mpolyd_gcd_brown_smprime_bivar(nmod_mpolyd_t G,
                     6*x1^10 == 13 for the values x1 = +-12, +-13
                 */
                 use_stab = 0;
-                nmod_poly_one(modulus);
+                nmod_polydr_one(modulus, fctx);
                 alpha = (fctx->mod.n - UWORD(1))/UWORD(2);
                 goto break_continue;
             }   
@@ -1242,7 +1236,7 @@ int nmod_mpolyd_gcd_brown_smprime_bivar(nmod_mpolyd_t G,
         }
 
 
-        if (nmod_poly_degree(modulus) > 0)
+        if (nmod_polydr_degree(modulus, fctx) > 0)
         {
             nmod_mpolyd_leadmon(leadmon_Gs, Gs);
             for (j = 0; j < nvars - 1; j++)
@@ -1258,7 +1252,7 @@ int nmod_mpolyd_gcd_brown_smprime_bivar(nmod_mpolyd_t G,
                     nmod_mpolyd_zero(Gs);
                     nmod_mpolyd_zero(Abars);
                     nmod_mpolyd_zero(Bbars);
-                    nmod_poly_one(modulus);
+                    nmod_polydr_one(modulus, fctx);
                 }
             }
         }
@@ -1266,15 +1260,15 @@ int nmod_mpolyd_gcd_brown_smprime_bivar(nmod_mpolyd_t G,
         nmod_mpolyd_mul_scalar(gs, gamma_eval, fctx);
         nmod_mpolyd_mul_scalar(gsm, gammam_eval, fctx);
 
-        if (nmod_poly_degree(modulus) > 0)
+        if (nmod_polydr_degree(modulus, fctx) > 0)
         {
-            temp = nmod_poly_evaluate_nmod(modulus, alpha);
+            temp = nmod_polydr_evaluate_nmod(modulus, alpha, fctx);
             FLINT_ASSERT(temp ==
-                        nmod_poly_evaluate_nmod(modulus, fctx->mod.n - alpha));
+                        nmod_polydr_evaluate_nmod(modulus, fctx->mod.n - alpha, fctx));
             temp = nmod_mul(temp, alpha, fctx->mod);
             temp = nmod_add(temp, temp, fctx->mod);
-            nmod_poly_scalar_mul_nmod(modulus, modulus,
-                                                  n_invmod(temp, fctx->mod.n));
+            nmod_polydr_scalar_mul_nmod(modulus, modulus,
+                                            n_invmod(temp, fctx->mod.n), fctx);
 
             if (!gstab)
             {
@@ -1285,27 +1279,27 @@ int nmod_mpolyd_gcd_brown_smprime_bivar(nmod_mpolyd_t G,
                                                            alpha_powers, fctx);
             nmod_mpolyd_addinterp2(Bbars, T, bbars, bbarsm, modulus, alpha,
                                                            alpha_powers, fctx);            
-            nmod_poly_scalar_mul_nmod(modulus2, modulus, alpha2);
-            nmod_poly_shift_left(modulus, modulus, 2);
-            nmod_poly_sub(modulus, modulus, modulus2);
+            nmod_polydr_scalar_mul_nmod(modulus2, modulus, alpha2, fctx);
+            nmod_polydr_shift_left(modulus, modulus, 2, fctx);
+            nmod_polydr_sub(modulus, modulus, modulus2, fctx);
 
         } else
         {
-            nmod_poly_one(modulus);
+            nmod_polydr_one(modulus, fctx);
             nmod_mpolyd_startinterp2(Gs, gs, gsm, alpha, fctx);
             nmod_mpolyd_startinterp2(Abars, abars, abarsm, alpha, fctx);
             nmod_mpolyd_startinterp2(Bbars, bbars, bbarsm, alpha, fctx);
-            nmod_poly_scalar_mul_nmod(modulus2, modulus, alpha2);
-            nmod_poly_shift_left(modulus, modulus, 2);
-            nmod_poly_sub(modulus, modulus, modulus2);
+            nmod_polydr_scalar_mul_nmod(modulus2, modulus, alpha2, fctx);
+            nmod_polydr_shift_left(modulus, modulus, 2, fctx);
+            nmod_polydr_sub(modulus, modulus, modulus2, fctx);
 
             gstab = astab = bstab = 0;
         }
 
-        if (nmod_poly_degree(modulus) < bound)
+        if (nmod_polydr_degree(modulus, fctx) < bound)
             continue;
 
-        deggamma = nmod_poly_degree(gamma);
+        deggamma = nmod_polydr_degree(gamma, fctx);
         degGs = nmod_mpolyd_last_degree(Gs, fctx);
         degA = nmod_mpolyd_last_degree(A, fctx);
         degB = nmod_mpolyd_last_degree(B, fctx);
@@ -1322,7 +1316,7 @@ int nmod_mpolyd_gcd_brown_smprime_bivar(nmod_mpolyd_t G,
             nmod_mpolyd_zero(Gs);
             nmod_mpolyd_zero(Abars);
             nmod_mpolyd_zero(Bbars);
-            nmod_poly_one(modulus);
+            nmod_polydr_one(modulus, fctx);
             continue;
         }
 
@@ -1340,17 +1334,17 @@ cleanup:
     flint_free(alpha_powers);
     flint_free(alpham_powers);
 
-    nmod_poly_clear(cA);
-    nmod_poly_clear(cB);
-    nmod_poly_clear(cG);
+    nmod_polydr_clear(cA, fctx);
+    nmod_polydr_clear(cB, fctx);
+    nmod_polydr_clear(cG, fctx);
 
-    nmod_poly_clear(cAbar);
-    nmod_poly_clear(cBbar);
+    nmod_polydr_clear(cAbar, fctx);
+    nmod_polydr_clear(cBbar, fctx);
 
-    nmod_poly_clear(lcA);
-    nmod_poly_clear(lcB);
+    nmod_polydr_clear(lcA, fctx);
+    nmod_polydr_clear(lcB, fctx);
 
-    nmod_poly_clear(gamma);
+    nmod_polydr_clear(gamma, fctx);
 
     nmod_mpolyd_clear(T);
     nmod_mpolyd_clear(Gs);
@@ -1369,16 +1363,16 @@ cleanup:
     nmod_mpolyd_clear(abarsm);
     nmod_mpolyd_clear(bbarsm);
 
-    nmod_poly_clear(modulus);
-    nmod_poly_clear(modulus2);
+    nmod_polydr_clear(modulus, fctx);
+    nmod_polydr_clear(modulus2, fctx);
 
     return success;
 
 successful:
 
-    nmod_poly_init(cGs, fctx->mod.n);
-    nmod_poly_init(cAbars, fctx->mod.n);
-    nmod_poly_init(cBbars, fctx->mod.n);
+    nmod_polydr_init(cGs, fctx);
+    nmod_polydr_init(cAbars, fctx);
+    nmod_polydr_init(cBbars, fctx);
     nmod_mpolyd_last_content(cGs, Gs, fctx);
     nmod_mpolyd_last_content(cAbars, Abars, fctx);
     nmod_mpolyd_last_content(cBbars, Bbars, fctx);
@@ -1391,9 +1385,9 @@ successful:
     nmod_mpolyd_mul_last_poly(Abar, Abars, cAbar, fctx);
     nmod_mpolyd_mul_last_poly(Bbar, Bbars, cBbar, fctx);
 
-    nmod_poly_clear(cGs);
-    nmod_poly_clear(cAbars);
-    nmod_poly_clear(cBbars);
+    nmod_polydr_clear(cGs, fctx);
+    nmod_polydr_clear(cAbars, fctx);
+    nmod_polydr_clear(cBbars, fctx);
 
     success = 1;
     goto cleanup;
@@ -1401,14 +1395,14 @@ successful:
 
 int nmod_mpolyd_gcd_brown_smprime(nmod_mpolyd_t G,
                 nmod_mpolyd_t Abar, nmod_mpolyd_t Bbar,
-                     nmod_mpolyd_t A, nmod_mpolyd_t B,  const nmodf_ctx_t fctx)
+                     nmod_mpolyd_t A, nmod_mpolyd_t B,  const nmod_ctx_t fctx)
 {
     int success;
     slong j, bound;
     slong nvars = A->nvars;
     mp_limb_t alpha, gamma_eval, gammam_eval;
-    nmod_poly_t cA, cB, cG, cAbar, cBbar, lcA, lcB, gamma;
-    nmod_poly_t cGs, cAbars, cBbars, modulus, modulus2;
+    nmod_polydr_t cA, cB, cG, cAbar, cBbar, lcA, lcB, gamma;
+    nmod_polydr_t cGs, cAbars, cBbars, modulus, modulus2;
     nmod_mpolyd_t T, Gs, Abars, Bbars, phiA, phiB, phiAm, phiBm,
                                          gs, abars, bbars, gsm, abarsm, bbarsm;
     slong leadmon_gs_idx, leadmon_gsm_idx;
@@ -1438,31 +1432,31 @@ int nmod_mpolyd_gcd_brown_smprime(nmod_mpolyd_t G,
     alpha_powers = (mp_limb_t *) flint_malloc(ABlenmax*sizeof(mp_limb_t));
     alpham_powers = (mp_limb_t *) flint_malloc(ABlenmax*sizeof(mp_limb_t));
 
-    nmod_poly_init(cA, fctx->mod.n);
-    nmod_poly_init(cB, fctx->mod.n);
+    nmod_polydr_init(cA, fctx);
+    nmod_polydr_init(cB, fctx);
     nmod_mpolyd_last_content(cA, A, fctx);
     nmod_mpolyd_last_content(cB, B, fctx);
 
     nmod_mpolyd_div_last_poly(A, cA, fctx);
     nmod_mpolyd_div_last_poly(B, cB, fctx);
 
-    nmod_poly_init(cG, fctx->mod.n);
-    nmod_poly_gcd_euclidean(cG, cA, cB);
+    nmod_polydr_init(cG, fctx);
+    nmod_polydr_gcd_euclidean(cG, cA, cB, fctx);
 
-    nmod_poly_init(cAbar, fctx->mod.n);
-    nmod_poly_init(cBbar, fctx->mod.n);
-    nmod_poly_div(cAbar, cA, cG);
-    nmod_poly_div(cBbar, cB, cG);
+    nmod_polydr_init(cAbar, fctx);
+    nmod_polydr_init(cBbar, fctx);
+    nmod_polydr_div(cAbar, cA, cG, fctx);
+    nmod_polydr_div(cBbar, cB, cG, fctx);
 
-    nmod_poly_init(lcA, fctx->mod.n);
-    nmod_poly_init(lcB, fctx->mod.n);
+    nmod_polydr_init(lcA, fctx);
+    nmod_polydr_init(lcB, fctx);
     nmod_mpolyd_last_lc(lcA, A, fctx);
     nmod_mpolyd_last_lc(lcB, B, fctx);
 
-    nmod_poly_init(gamma, fctx->mod.n);
-    nmod_poly_gcd_euclidean(gamma, lcA, lcB);
+    nmod_polydr_init(gamma, fctx);
+    nmod_polydr_gcd_euclidean(gamma, lcA, lcB, fctx);
 
-    bound = 1 + nmod_poly_degree(gamma)
+    bound = 1 + nmod_polydr_degree(gamma, fctx)
                + FLINT_MAX(nmod_mpolyd_last_degree(A, fctx),
                            nmod_mpolyd_last_degree(B, fctx));
 
@@ -1484,10 +1478,10 @@ int nmod_mpolyd_gcd_brown_smprime(nmod_mpolyd_t G,
     nmod_mpolyd_init(abarsm, nvars - 1);
     nmod_mpolyd_init(bbarsm, nvars - 1);
 
-    nmod_poly_init(modulus, fctx->mod.n);
-    nmod_poly_init(modulus2, fctx->mod.n);
+    nmod_polydr_init(modulus, fctx);
+    nmod_polydr_init(modulus2, fctx);
 
-    nmod_poly_one(modulus);
+    nmod_polydr_one(modulus, fctx);
 
     if ((fctx->mod.n & UWORD(1)) == UWORD(0))
     {
@@ -1509,8 +1503,8 @@ int nmod_mpolyd_gcd_brown_smprime(nmod_mpolyd_t G,
                                        : alpha_powers[j];
         }
 
-        gamma_eval = nmod_poly_evaluate_nmod(gamma, alpha);
-        gammam_eval = nmod_poly_evaluate_nmod(gamma, fctx->mod.n - alpha);
+        gamma_eval = nmod_polydr_evaluate_nmod(gamma, alpha, fctx);
+        gammam_eval = nmod_polydr_evaluate_nmod(gamma, fctx->mod.n - alpha, fctx);
         if (gamma_eval == WORD(0) || gammam_eval == WORD(0))
             goto break_continue;
 
@@ -1547,7 +1541,7 @@ int nmod_mpolyd_gcd_brown_smprime(nmod_mpolyd_t G,
             goto successful;        
         }
 
-        if (nmod_poly_degree(modulus) > 0)
+        if (nmod_polydr_degree(modulus, fctx) > 0)
         {
             nmod_mpolyd_leadmon(leadmon_Gs, Gs);
             for (j = 0; j < nvars - 1; j++)
@@ -1563,7 +1557,7 @@ int nmod_mpolyd_gcd_brown_smprime(nmod_mpolyd_t G,
                     nmod_mpolyd_zero(Gs);
                     nmod_mpolyd_zero(Abars);
                     nmod_mpolyd_zero(Bbars);
-                    nmod_poly_one(modulus);
+                    nmod_polydr_one(modulus, fctx);
                 }
             }
         }
@@ -1571,15 +1565,15 @@ int nmod_mpolyd_gcd_brown_smprime(nmod_mpolyd_t G,
         nmod_mpolyd_mul_scalar(gs, gamma_eval, fctx);
         nmod_mpolyd_mul_scalar(gsm, gammam_eval, fctx);
 
-        if (nmod_poly_degree(modulus) > 0)
+        if (nmod_polydr_degree(modulus, fctx) > 0)
         {
-            temp = nmod_poly_evaluate_nmod(modulus, alpha);
+            temp = nmod_polydr_evaluate_nmod(modulus, alpha, fctx);
             FLINT_ASSERT(temp == 
-                        nmod_poly_evaluate_nmod(modulus, fctx->mod.n - alpha));
+                        nmod_polydr_evaluate_nmod(modulus, fctx->mod.n - alpha, fctx));
             temp = nmod_mul(temp, alpha, fctx->mod);
             temp = nmod_add(temp, temp, fctx->mod);
-            nmod_poly_scalar_mul_nmod(modulus, modulus,
-                                                  n_invmod(temp, fctx->mod.n));
+            nmod_polydr_scalar_mul_nmod(modulus, modulus,
+                                                  n_invmod(temp, fctx->mod.n), fctx);
 
             nmod_mpolyd_addinterp2(Gs, T, gs, gsm, modulus, alpha,
                                                            alpha_powers, fctx);
@@ -1589,20 +1583,20 @@ int nmod_mpolyd_gcd_brown_smprime(nmod_mpolyd_t G,
                                                            alpha_powers, fctx);
         } else
         {
-            nmod_poly_one(modulus);
+            nmod_polydr_one(modulus, fctx);
             nmod_mpolyd_startinterp2(Gs, gs, gsm, alpha, fctx);
             nmod_mpolyd_startinterp2(Abars, abars, abarsm, alpha, fctx);
             nmod_mpolyd_startinterp2(Bbars, bbars, bbarsm, alpha, fctx);
         }
 
-        nmod_poly_scalar_mul_nmod(modulus2, modulus, alpha2);
-        nmod_poly_shift_left(modulus, modulus, 2);
-        nmod_poly_sub(modulus, modulus, modulus2);
+        nmod_polydr_scalar_mul_nmod(modulus2, modulus, alpha2, fctx);
+        nmod_polydr_shift_left(modulus, modulus, 2, fctx);
+        nmod_polydr_sub(modulus, modulus, modulus2, fctx);
 
-        if (nmod_poly_degree(modulus) < bound)
+        if (nmod_polydr_degree(modulus, fctx) < bound)
             continue;
 
-        deggamma = nmod_poly_degree(gamma);
+        deggamma = nmod_polydr_degree(gamma, fctx);
         degGs = nmod_mpolyd_last_degree(Gs, fctx);
         degA = nmod_mpolyd_last_degree(A, fctx);
         degB = nmod_mpolyd_last_degree(B, fctx);
@@ -1618,7 +1612,7 @@ int nmod_mpolyd_gcd_brown_smprime(nmod_mpolyd_t G,
             nmod_mpolyd_zero(Gs);
             nmod_mpolyd_zero(Abars);
             nmod_mpolyd_zero(Bbars);
-            nmod_poly_one(modulus);
+            nmod_polydr_one(modulus, fctx);
             continue;
         }
 
@@ -1636,17 +1630,17 @@ cleanup:
     flint_free(alpha_powers);
     flint_free(alpham_powers);
 
-    nmod_poly_clear(cA);
-    nmod_poly_clear(cB);
-    nmod_poly_clear(cG);
+    nmod_polydr_clear(cA, fctx);
+    nmod_polydr_clear(cB, fctx);
+    nmod_polydr_clear(cG, fctx);
 
-    nmod_poly_clear(cAbar);
-    nmod_poly_clear(cBbar);
+    nmod_polydr_clear(cAbar, fctx);
+    nmod_polydr_clear(cBbar, fctx);
 
-    nmod_poly_clear(lcA);
-    nmod_poly_clear(lcB);
+    nmod_polydr_clear(lcA, fctx);
+    nmod_polydr_clear(lcB, fctx);
 
-    nmod_poly_clear(gamma);
+    nmod_polydr_clear(gamma, fctx);
 
     nmod_mpolyd_clear(T);
     nmod_mpolyd_clear(Gs);
@@ -1665,16 +1659,16 @@ cleanup:
     nmod_mpolyd_clear(abarsm);
     nmod_mpolyd_clear(bbarsm);
 
-    nmod_poly_clear(modulus);
-    nmod_poly_clear(modulus2);
+    nmod_polydr_clear(modulus, fctx);
+    nmod_polydr_clear(modulus2, fctx);
 
     return success;
 
 successful:
 
-    nmod_poly_init(cGs, fctx->mod.n);
-    nmod_poly_init(cAbars, fctx->mod.n);
-    nmod_poly_init(cBbars, fctx->mod.n);
+    nmod_polydr_init(cGs, fctx);
+    nmod_polydr_init(cAbars, fctx);
+    nmod_polydr_init(cBbars, fctx);
     nmod_mpolyd_last_content(cGs, Gs, fctx);
     nmod_mpolyd_last_content(cAbars, Abars, fctx);
     nmod_mpolyd_last_content(cBbars, Bbars, fctx);
@@ -1687,9 +1681,9 @@ successful:
     nmod_mpolyd_mul_last_poly(Abar, Abars, cAbar, fctx);
     nmod_mpolyd_mul_last_poly(Bbar, Bbars, cBbar, fctx);
 
-    nmod_poly_clear(cGs);
-    nmod_poly_clear(cAbars);
-    nmod_poly_clear(cBbars);
+    nmod_polydr_clear(cGs, fctx);
+    nmod_polydr_clear(cAbars, fctx);
+    nmod_polydr_clear(cBbars, fctx);
 
     success = 1;
     goto cleanup;

--- a/nmod_mpoly/mpolyu.c
+++ b/nmod_mpoly/mpolyu.c
@@ -364,7 +364,7 @@ void nmod_mpolyu_set(nmod_mpolyu_t A, const nmod_mpolyu_t B,
 
 
 
-void nmod_mpoly_cvtfrom_poly_notmain(nmod_mpoly_t A, nmod_poly_t a,
+void nmod_mpoly_cvtfrom_poly_notmain(nmod_mpoly_t A, nmod_polydr_t a,
                                          slong var, const nmod_mpoly_ctx_t ctx)
 {
     slong i;
@@ -381,12 +381,12 @@ void nmod_mpoly_cvtfrom_poly_notmain(nmod_mpoly_t A, nmod_poly_t a,
     oneexp = (ulong *)TMP_ALLOC(N*sizeof(ulong));
     mpoly_gen_monomial_sp(oneexp, var, A->bits, ctx->minfo);
 
-    nmod_mpoly_fit_length(A, nmod_poly_length(a), ctx);
+    nmod_mpoly_fit_length(A, nmod_polydr_length(a, ctx->ffinfo), ctx);
 
     k = 0;
-    for (i = nmod_poly_length(a) - 1; i >= 0; i--)
+    for (i = nmod_polydr_length(a, ctx->ffinfo) - 1; i >= 0; i--)
     {
-        mp_limb_t c = nmod_poly_get_coeff_ui(a, i);
+        mp_limb_t c = nmod_polydr_get_coeff_ui(a, i, ctx->ffinfo);
         if (c != UWORD(0))
         {
             A->coeffs[k] = c;
@@ -400,7 +400,7 @@ void nmod_mpoly_cvtfrom_poly_notmain(nmod_mpoly_t A, nmod_poly_t a,
 /*
     Set "A" to "a" where "a" is a polynomial in a non-main variable "var"
 */
-void nmod_mpolyu_cvtfrom_poly_notmain(nmod_mpolyu_t A, nmod_poly_t a,
+void nmod_mpolyu_cvtfrom_poly_notmain(nmod_mpolyu_t A, nmod_polydr_t a,
                                          slong var, const nmod_mpoly_ctx_t ctx)
 {
     nmod_mpolyu_fit_length(A, 1, ctx);
@@ -415,24 +415,24 @@ void nmod_mpolyu_cvtfrom_poly_notmain(nmod_mpolyu_t A, nmod_poly_t a,
     Assuming that "A" depends only on the main variable,
     convert it to a poly "a".
 */
-void nmod_mpolyu_cvtto_poly(nmod_poly_t a, nmod_mpolyu_t A,
+void nmod_mpolyu_cvtto_poly(nmod_polydr_t a, nmod_mpolyu_t A,
                                                     const nmod_mpoly_ctx_t ctx)
 {
     slong i;
-    nmod_poly_zero(a);
+    nmod_polydr_zero(a, ctx->ffinfo);
     for (i = 0; i < A->length; i++)
     {
         FLINT_ASSERT((A->coeffs + i)->length == 1);
         FLINT_ASSERT(mpoly_monomial_is_zero((A->coeffs + i)->exps, 
                       mpoly_words_per_exp((A->coeffs + i)->bits, ctx->minfo)));
-        nmod_poly_set_coeff_ui(a, A->exps[i], (A->coeffs + i)->coeffs[0]);
+        nmod_polydr_set_coeff_ui(a, A->exps[i], (A->coeffs + i)->coeffs[0], ctx->ffinfo);
     }
 }
 
 /*
     Convert a poly "a" to "A" in the main variable,
 */
-void nmod_mpolyu_cvtfrom_poly(nmod_mpolyu_t A, nmod_poly_t a,
+void nmod_mpolyu_cvtfrom_poly(nmod_mpolyu_t A, nmod_polydr_t a,
                                                     const nmod_mpoly_ctx_t ctx)
 {
     slong i;
@@ -441,9 +441,9 @@ void nmod_mpolyu_cvtfrom_poly(nmod_mpolyu_t A, nmod_poly_t a,
 
     nmod_mpolyu_zero(A, ctx);
     k = 0;
-    for (i = nmod_poly_length(a) - 1; i >= 0; i--)
+    for (i = nmod_polydr_length(a, ctx->ffinfo) - 1; i >= 0; i--)
     {
-        mp_limb_t c = nmod_poly_get_coeff_ui(a, i);
+        mp_limb_t c = nmod_polydr_get_coeff_ui(a, i, ctx->ffinfo);
         if (c != UWORD(0))
         {
             nmod_mpolyu_fit_length(A, k + 1, ctx);

--- a/nmod_mpoly/mpolyun.c
+++ b/nmod_mpoly/mpolyun.c
@@ -489,7 +489,7 @@ int nmod_mpolyn_CRT_fq_nmod_mpoly(slong * lastdeg,
     for (i = 0; i < A->length; i++)
     {
         FLINT_ASSERT(mpoly_monomial_equal(H->exps + N*i, A->exps + N*i, N));
-        nmod_polydr_rem(u, H->coeffs + i, ctxp->fqctx->modulus, ctx->ffinfo);
+        nmod_polydr_rem(u, H->coeffs + i, fq_nmod_ctx_modulusdr(ctxp->fqctx), ctx->ffinfo);
         fq_nmod_sub(v, A->coeffs + i, u, ctxp->fqctx);
         if (!fq_nmod_is_zero(v, ctxp->fqctx))
         {
@@ -503,7 +503,7 @@ int nmod_mpolyn_CRT_fq_nmod_mpoly(slong * lastdeg,
 
         FLINT_ASSERT(nmod_polydr_degree(H->coeffs + i, ctx->ffinfo)
                                  < nmod_polydr_degree(m, ctx->ffinfo)
-                                 + nmod_polydr_degree(ctxp->fqctx->modulus, ctx->ffinfo));
+                                 + nmod_polydr_degree(fq_nmod_ctx_modulusdr(ctxp->fqctx), ctx->ffinfo));
     }
 
     fq_nmod_clear(u, ctxp->fqctx);
@@ -524,7 +524,7 @@ int nmod_mpolyun_CRT_fq_nmod_mpolyu(slong * lastdeg,
     *lastdeg = -WORD(1);
 
     fq_nmod_init(inv_m_eval, ctxp->fqctx);
-    nmod_polydr_rem(inv_m_eval, m, ctxp->fqctx->modulus, ctx->ffinfo);
+    nmod_polydr_rem(inv_m_eval, m, fq_nmod_ctx_modulusdr(ctxp->fqctx), ctx->ffinfo);
     fq_nmod_inv(inv_m_eval, inv_m_eval, ctxp->fqctx);
 
     FLINT_ASSERT(H->bits == A->bits);
@@ -563,7 +563,7 @@ void nmod_mpolyn_redto_fq_nmod_mpoly(fq_nmod_mpoly_t A, nmod_mpolyn_t B,
     {
         fq_nmod_mpoly_fit_length(A, k + 1, ffctx);
         mpoly_monomial_set(A->exps + N*k, B->exps + N*i, N);
-        nmod_polydr_rem(A->coeffs + k, B->coeffs + i, ffctx->fqctx->modulus, ctx->ffinfo);
+        nmod_polydr_rem(A->coeffs + k, B->coeffs + i, fq_nmod_ctx_modulusdr(ffctx->fqctx), ctx->ffinfo);
         k += !fq_nmod_is_zero(A->coeffs + k, ffctx->fqctx);
     }
 
@@ -917,7 +917,7 @@ nmod_mpolyn_addinterp_fq_nmod_mpoly(slong * lastdeg,
                          < nmod_polydr_degree(m, ctx->ffinfo));
 
             /* F term ok, A term missing */
-            nmod_polydr_rem(v, Fcoeff + i, ffctx->fqctx->modulus, ctx->ffinfo);
+            nmod_polydr_rem(v, Fcoeff + i, fq_nmod_ctx_modulusdr(ffctx->fqctx), ctx->ffinfo);
             if (!fq_nmod_is_zero(v, ffctx->fqctx))
             {
                 changed = 1;
@@ -959,7 +959,7 @@ nmod_mpolyn_addinterp_fq_nmod_mpoly(slong * lastdeg,
                             < nmod_polydr_degree(m, ctx->ffinfo));
 
             /* F term ok, A term ok */
-            nmod_polydr_rem(u, Fcoeff + i, ffctx->fqctx->modulus, ctx->ffinfo);
+            nmod_polydr_rem(u, Fcoeff + i, fq_nmod_ctx_modulusdr(ffctx->fqctx), ctx->ffinfo);
             fq_nmod_sub(v, Acoeff + j, u, ffctx->fqctx);
             if (!fq_nmod_is_zero(v, ffctx->fqctx))
             {
@@ -1042,7 +1042,7 @@ int nmod_mpolyun_addinterp_fq_nmod_mpolyu(slong * lastdeg,
     zero->bits = A->bits;
 
     fq_nmod_init(inv_m_eval, ffctx->fqctx);
-    nmod_polydr_rem(inv_m_eval, m, ffctx->fqctx->modulus, ctx->ffinfo);
+    nmod_polydr_rem(inv_m_eval, m, fq_nmod_ctx_modulusdr(ffctx->fqctx), ctx->ffinfo);
     fq_nmod_inv(inv_m_eval, inv_m_eval, ffctx->fqctx);
 
     i = j = k = 0;

--- a/nmod_mpoly/mul_johnson.c
+++ b/nmod_mpoly/mul_johnson.c
@@ -15,7 +15,7 @@
 slong _nmod_mpoly_mul_johnson1(mp_limb_t ** coeff1, ulong ** exp1, slong * alloc,
               const mp_limb_t * coeff2, const ulong * exp2, slong len2,
               const mp_limb_t * coeff3, const ulong * exp3, slong len3,
-                                          ulong maskhi, const nmodf_ctx_t fctx)
+                                          ulong maskhi, const nmod_ctx_t fctx)
 {
     slong i, j;
     slong next_loc;
@@ -138,7 +138,7 @@ slong _nmod_mpoly_mul_johnson1(mp_limb_t ** coeff1, ulong ** exp1, slong * alloc
 slong _nmod_mpoly_mul_johnson(mp_limb_t ** coeff1, ulong ** exp1, slong * alloc,
                  const mp_limb_t * coeff2, const ulong * exp2, slong len2,
                  const mp_limb_t * coeff3, const ulong * exp3, slong len3,
-      mp_bitcnt_t bits, slong N, const ulong * cmpmask, const nmodf_ctx_t fctx)
+      mp_bitcnt_t bits, slong N, const ulong * cmpmask, const nmod_ctx_t fctx)
 {
     slong i, j;
     slong next_loc;

--- a/nmod_mpoly/set.c
+++ b/nmod_mpoly/set.c
@@ -13,7 +13,7 @@
 
 void _nmod_mpoly_set(mp_limb_t * coeff1, ulong * exps1,
                      const mp_limb_t * coeff2, const ulong * exps2, slong len2,
-                                               slong N, const nmodf_ctx_t fctx)
+                                               slong N, const nmod_ctx_t fctx)
 {
     slong i;
 

--- a/nmod_mpoly/sub.c
+++ b/nmod_mpoly/sub.c
@@ -14,7 +14,7 @@
 slong _nmod_mpoly_sub1(mp_limb_t * coeff1,       ulong * exp1,
                  const mp_limb_t * coeff2, const ulong * exp2, slong len2,
                  const mp_limb_t * coeff3, const ulong * exp3, slong len3,
-                                          ulong maskhi, const nmodf_ctx_t fctx)
+                                          ulong maskhi, const nmod_ctx_t fctx)
 {
     slong i = 0, j = 0, k = 0;
 
@@ -63,7 +63,7 @@ slong _nmod_mpoly_sub1(mp_limb_t * coeff1,       ulong * exp1,
 slong _nmod_mpoly_sub(ulong * coeff1,       ulong * exp1,
                 const ulong * coeff2, const ulong * exp2, slong len2,
                 const ulong * coeff3, const ulong * exp3, slong len3,
-                   slong N, const ulong * cmpmask, const nmodf_ctx_t fctx)
+                   slong N, const ulong * cmpmask, const nmod_ctx_t fctx)
 {
     slong i = 0, j = 0, k = 0;
 

--- a/nmod_mpoly/test/t-compose_nmod_polydr.c
+++ b/nmod_mpoly/test/t-compose_nmod_polydr.c
@@ -27,8 +27,8 @@ main(void)
     {
         nmod_mpoly_ctx_t ctx1;
         nmod_mpoly_t f;
-        nmod_poly_t g;
-        nmod_poly_struct ** vals1;
+        nmod_polydr_t g;
+        nmod_polydr_struct ** vals1;
         mp_limb_t fe, ge;
         mp_limb_t vals2, * vals3;
         slong nvars1;
@@ -42,7 +42,7 @@ main(void)
         nvars1 = ctx1->minfo->nvars;
 
         nmod_mpoly_init(f, ctx1);
-        nmod_poly_init(g, modulus);
+        nmod_polydr_init(g, ctx1->ffinfo);
 
         len1 = n_randint(state, 50/nvars1 + 1);
         len2 = n_randint(state, 100);
@@ -50,14 +50,14 @@ main(void)
 
         nmod_mpoly_randtest_bound(f, state, len1, exp_bound1, ctx1);
 
-        vals1 = (nmod_poly_struct **) flint_malloc(nvars1
-                                                * sizeof(nmod_poly_struct *));
+        vals1 = (nmod_polydr_struct **) flint_malloc(nvars1
+                                                * sizeof(nmod_polydr_struct *));
         for (v = 0; v < nvars1; v++)
         {
-            vals1[v] = (nmod_poly_struct *) flint_malloc(
-                                                    sizeof(nmod_poly_struct)); 
-            nmod_poly_init(vals1[v], modulus);
-            nmod_poly_randtest(vals1[v], state, len2);
+            vals1[v] = (nmod_polydr_struct *) flint_malloc(
+                                                    sizeof(nmod_polydr_struct)); 
+            nmod_polydr_init(vals1[v], ctx1->ffinfo);
+            nmod_polydr_randtest(vals1[v], state, len2, ctx1->ffinfo);
         }
 
         vals2 = n_randint(state, modulus);
@@ -65,15 +65,15 @@ main(void)
         vals3 = (mp_limb_t *) flint_malloc(nvars1*sizeof(mp_limb_t));
         for (v = 0; v < nvars1; v++)
         {
-            vals3[v] = nmod_poly_evaluate_nmod(vals1[v], vals2);
+            vals3[v] = nmod_polydr_evaluate_nmod(vals1[v], vals2, ctx1->ffinfo);
         }
 
         if (nmod_mpoly_total_degree_si(f, ctx1) < 100)
         {
-            nmod_mpoly_compose_nmod_poly(g, f, vals1, ctx1);
+            nmod_mpoly_compose_nmod_polydr(g, f, vals1, ctx1);
 
             fe = nmod_mpoly_evaluate_all_ui(f, vals3, ctx1);
-            ge = nmod_poly_evaluate_nmod(g, vals2);
+            ge = nmod_polydr_evaluate_nmod(g, vals2, ctx1->ffinfo);
 
             if (fe != ge)
             {
@@ -85,7 +85,7 @@ main(void)
 
         for (v = 0; v < nvars1; v++)
         {
-            nmod_poly_clear(vals1[v]);
+            nmod_polydr_clear(vals1[v], ctx1->ffinfo);
             flint_free(vals1[v]);
         }
         flint_free(vals1);
@@ -93,7 +93,7 @@ main(void)
         flint_free(vals3);
 
         nmod_mpoly_clear(f, ctx1);
-        nmod_poly_clear(g);
+        nmod_polydr_clear(g, ctx1->ffinfo);
 
         nmod_mpoly_ctx_clear(ctx1);
     }

--- a/nmod_poly.h
+++ b/nmod_poly.h
@@ -132,6 +132,9 @@ typedef struct
 
 typedef nmod_polydr_struct nmod_polydr_t[1];
 
+/* hackey way to get both parts of a nmod_poly_t */
+#define nmod_poly_polydr(p) ((nmod_polydr_struct*)(&p->coeffs))
+#define nmod_poly_ctx(p)    ((nmod_ctx_struct*)(&p->mod))
 
 typedef struct
 {

--- a/nmod_poly/add.c
+++ b/nmod_poly/add.c
@@ -34,6 +34,21 @@ _nmod_poly_add(mp_ptr res, mp_srcptr poly1, slong len1, mp_srcptr poly2,
 }
 
 void
+nmod_polydr_add(nmod_polydr_t res, const nmod_polydr_t poly1,
+                              const nmod_polydr_t poly2, const nmod_ctx_t ctx)
+{
+    slong max = FLINT_MAX(poly1->length, poly2->length);
+
+    nmod_polydr_fit_length(res, max, ctx);
+
+    _nmod_poly_add(res->coeffs, poly1->coeffs, poly1->length, poly2->coeffs,
+                   poly2->length, ctx->mod);
+
+    res->length = max;
+    _nmod_polydr_normalise(res);  /* there may have been cancellation */
+}
+
+void
 nmod_poly_add(nmod_poly_t res, const nmod_poly_t poly1,
               const nmod_poly_t poly2)
 {

--- a/nmod_poly/bit_pack.c
+++ b/nmod_poly/bit_pack.c
@@ -126,6 +126,39 @@ _nmod_poly_bit_pack(mp_ptr res, mp_srcptr poly, slong len, mp_bitcnt_t bits)
 }
 
 void
+nmod_polydr_bit_pack(fmpz_t f, const nmod_polydr_t poly,
+                   mp_bitcnt_t bit_size, const nmod_ctx_t ctx)
+{
+    slong len, limbs;
+    __mpz_struct * mpz;
+    slong i;
+
+    len = nmod_polydr_length(poly, ctx);
+
+    if (len == 0 || bit_size == 0)
+    {
+        fmpz_zero(f);
+        return;
+    }
+
+    mpz = _fmpz_promote(f);
+    mpz_realloc2(mpz, len * bit_size);
+
+    limbs = (len * bit_size - 1) / FLINT_BITS + 1;
+
+    _nmod_poly_bit_pack(mpz->_mp_d, poly->coeffs, len, bit_size);
+
+    for (i = limbs - 1; i >= 0; i--)
+    {
+        if (mpz->_mp_d[i] != 0)
+            break;
+    }
+
+    mpz->_mp_size = i + 1;
+    _fmpz_demote_val(f);
+}
+
+void
 nmod_poly_bit_pack(fmpz_t f, const nmod_poly_t poly,
                    mp_bitcnt_t bit_size)
 {

--- a/nmod_poly/bit_unpack.c
+++ b/nmod_poly/bit_unpack.c
@@ -198,6 +198,41 @@ _nmod_poly_bit_unpack(mp_ptr res, slong len, mp_srcptr mpn, mp_bitcnt_t bits,
     }
 }
 
+
+void
+nmod_polydr_bit_unpack(nmod_polydr_t poly, const fmpz_t f, mp_bitcnt_t bit_size,
+                                                          const nmod_ctx_t ctx)
+{
+    slong len;
+    mpz_t tmp;
+
+    if (fmpz_sgn(f) < 0)
+    {
+        flint_printf("Exception (nmod_poly_bit_unpack). f < 0.\n");
+        flint_abort();
+    }
+
+    if (bit_size == 0 || fmpz_is_zero(f))
+    {
+        nmod_polydr_zero(poly, ctx);
+        return;
+    }
+
+    len = (fmpz_bits(f) + bit_size - 1) / bit_size;
+
+    mpz_init2(tmp, bit_size*len);
+    flint_mpn_zero(tmp->_mp_d, tmp->_mp_alloc);
+    fmpz_get_mpz(tmp, f);
+
+    nmod_polydr_fit_length(poly, len, ctx);
+
+    _nmod_poly_bit_unpack(poly->coeffs, len, tmp->_mp_d, bit_size, ctx->mod);
+    poly->length = len;
+    _nmod_polydr_normalise(poly);
+
+    mpz_clear(tmp);
+}
+
 void
 nmod_poly_bit_unpack(nmod_poly_t poly, const fmpz_t f, mp_bitcnt_t bit_size)
 {

--- a/nmod_poly/clear.c
+++ b/nmod_poly/clear.c
@@ -17,6 +17,13 @@
 #include "nmod_poly.h"
 
 void
+nmod_polydr_clear(nmod_polydr_t poly, const nmod_ctx_t ctx)
+{
+    if (poly->coeffs)
+        flint_free(poly->coeffs);
+}
+
+void
 nmod_poly_clear(nmod_poly_t poly)
 {
     if (poly->coeffs)

--- a/nmod_poly/div.c
+++ b/nmod_poly/div.c
@@ -38,6 +38,53 @@ _nmod_poly_div(mp_ptr Q, mp_srcptr A, slong lenA,
 }
 
 void
+nmod_polydr_div(nmod_polydr_t Q, 
+            const nmod_polydr_t A, const nmod_polydr_t B, const nmod_ctx_t ctx)
+{
+    nmod_polydr_t tQ;
+    mp_ptr q;
+    slong A_len, B_len;
+
+    B_len = B->length;
+    
+    if (B_len == 0)
+    {
+        flint_printf("Exception (nmod_poly_divrem). Division by zero.\n");
+        flint_abort();
+    }
+
+    A_len = A->length;
+    
+    if (A_len < B_len)
+    {
+        nmod_polydr_zero(Q, ctx);
+        return;
+    }
+
+    if (Q == A || Q == B)
+    {
+        nmod_polydr_init2(tQ, A_len - B_len + 1, ctx);
+        q = tQ->coeffs;
+    }
+    else
+    {
+        nmod_polydr_fit_length(Q, A_len - B_len + 1, ctx);
+        q = Q->coeffs;
+    }
+
+    _nmod_poly_div(q, A->coeffs, A_len,
+                            B->coeffs, B_len, ctx->mod);
+
+    if (Q == A || Q == B)
+    {
+        nmod_polydr_swap(tQ, Q, ctx);
+        nmod_polydr_clear(tQ, ctx);
+    }
+    
+    Q->length = A_len - B_len + 1;
+}
+
+void
 nmod_poly_div(nmod_poly_t Q, 
                  const nmod_poly_t A, const nmod_poly_t B)
 {

--- a/nmod_poly/divrem.c
+++ b/nmod_poly/divrem.c
@@ -43,6 +43,67 @@ _nmod_poly_divrem(mp_ptr Q, mp_ptr R, mp_srcptr A, slong lenA,
         _nmod_poly_divrem_newton(Q, R, A, lenA, B, lenB, mod);
 }
 
+void nmod_polydr_divrem(nmod_polydr_t Q, nmod_polydr_t R,
+            const nmod_polydr_t A, const nmod_polydr_t B, const nmod_ctx_t ctx)
+{
+    const slong lenA = A->length, lenB = B->length;
+    nmod_polydr_t tQ, tR;
+    mp_ptr q, r;
+    
+    if (lenB == 0)
+    {
+        flint_printf("Exception (nmod_poly_divrem). Division by zero.");
+        flint_abort();
+    }
+
+    if (lenA < lenB)
+    {
+        nmod_polydr_set(R, A, ctx);
+        nmod_polydr_zero(Q, ctx);
+        return;
+    }
+
+    if (Q == A || Q == B)
+    {
+        nmod_polydr_init2(tQ, lenA - lenB + 1, ctx);
+        q = tQ->coeffs;
+    }
+    else
+    {
+        nmod_polydr_fit_length(Q, lenA - lenB + 1, ctx);
+        q = Q->coeffs;
+    }
+
+    if (R == A || R == B)
+    {
+        nmod_polydr_init2(tR, lenB - 1, ctx);
+        r = tR->coeffs;
+    }
+    else
+    {
+        nmod_polydr_fit_length(R, lenB - 1, ctx);
+        r = R->coeffs;
+    }
+
+    _nmod_poly_divrem(q, r, A->coeffs, lenA, B->coeffs, lenB, ctx->mod);
+
+    if (Q == A || Q == B)
+    {
+        nmod_polydr_swap(Q, tQ, ctx);
+        nmod_polydr_clear(tQ, ctx);
+    }
+    if (R == A || R == B)
+    {
+        nmod_polydr_swap(R, tR, ctx);
+        nmod_polydr_clear(tR, ctx);
+    }
+        
+    Q->length = lenA - lenB + 1;
+    R->length = lenB - 1;
+
+    _nmod_polydr_normalise(R);
+}
+
 void nmod_poly_divrem(nmod_poly_t Q, nmod_poly_t R,
                       const nmod_poly_t A, const nmod_poly_t B)
 {

--- a/nmod_poly/evaluate_fmpz.c
+++ b/nmod_poly/evaluate_fmpz.c
@@ -50,9 +50,15 @@ _nmod_poly_evaluate_fmpz(fmpz_t rop, const mp_srcptr poly, const slong len, cons
     fmpz_clear(t);
 }
 
+/* map the nmod_poly to Z[x] and evaluate in Z */
+void
+nmod_polydr_evaluate_fmpz(fmpz_t rop, const nmod_polydr_t poly, const fmpz_t c)
+{
+    _nmod_poly_evaluate_fmpz(rop, poly->coeffs, poly->length, c);
+}
+
 void
 nmod_poly_evaluate_fmpz(fmpz_t rop, const nmod_poly_t poly, const fmpz_t c)
 {
     _nmod_poly_evaluate_fmpz(rop, poly->coeffs, poly->length, c);
 }
-

--- a/nmod_poly/evaluate_nmod.c
+++ b/nmod_poly/evaluate_nmod.c
@@ -41,6 +41,13 @@ _nmod_poly_evaluate_nmod(mp_srcptr poly, slong len, mp_limb_t c, nmod_t mod)
 }
 
 mp_limb_t
+nmod_polydr_evaluate_nmod(const nmod_polydr_t poly, mp_limb_t c, const nmod_ctx_t ctx)
+{
+    FLINT_ASSERT(c < ctx->mod.n);
+    return _nmod_poly_evaluate_nmod(poly->coeffs, poly->length, c, ctx->mod);
+}
+
+mp_limb_t
 nmod_poly_evaluate_nmod(const nmod_poly_t poly, mp_limb_t c)
 {
     return _nmod_poly_evaluate_nmod(poly->coeffs, poly->length, c, poly->mod);

--- a/nmod_poly/fit_length.c
+++ b/nmod_poly/fit_length.c
@@ -17,6 +17,18 @@
 #include "nmod_poly.h"
 
 void
+nmod_polydr_fit_length(nmod_polydr_t poly, slong alloc, const nmod_ctx_t ctx)
+{
+    if (alloc > poly->alloc)
+    {
+        if (alloc < 2 * poly->alloc)
+            alloc = 2 * poly->alloc;
+
+        nmod_polydr_realloc(poly, alloc, ctx);
+    }
+}
+
+void
 nmod_poly_fit_length(nmod_poly_t poly, slong alloc)
 {
     if (alloc > poly->alloc)

--- a/nmod_poly/fprintf_pretty.c
+++ b/nmod_poly/fprintf_pretty.c
@@ -17,28 +17,29 @@
 #include "nmod_poly.h"
 
 
-int nmod_poly_fprint_pretty(FILE * f, const nmod_poly_t a, const char * x)
+static int _nmod_poly_fprint_pretty(FILE * f,
+                                mp_limb_t * Acoeff, slong Alen, const char * x)
 {
     size_t r;
     slong i;
 
-    if (a->length == 0)
+    if (Alen == 0)
     {
         r = fputc('0', f);
         r = ((int) r != EOF) ? 1 : EOF;
         return r;
     }
-    else if (a->length == 1)
+    else if (Alen == 1)
     {
-        r = flint_fprintf(f, "%wu", a->coeffs[0]);
+        r = flint_fprintf(f, "%wu", Acoeff[0]);
         return r;
     }
 
-    i = a->length - 1;
+    i = Alen - 1;
     r = 1;
     if (i == 1)
     {
-        switch (a->coeffs[1])
+        switch (Acoeff[1])
         {
             case UWORD(0):
                 break;
@@ -46,13 +47,13 @@ int nmod_poly_fprint_pretty(FILE * f, const nmod_poly_t a, const char * x)
                 r = flint_fprintf(f, "%s", x);
                 break;
             default:
-                r = flint_fprintf(f, "%wu*%s", a->coeffs[1], x);
+                r = flint_fprintf(f, "%wu*%s", Acoeff[1], x);
         }
         --i;
     }
     else
     {
-        switch (a->coeffs[i])
+        switch (Acoeff[i])
         {
             case UWORD(0):
                 break;
@@ -60,13 +61,13 @@ int nmod_poly_fprint_pretty(FILE * f, const nmod_poly_t a, const char * x)
                 r = flint_fprintf(f, "%s^%wd", x, i);
                 break;
             default:
-                r = flint_fprintf(f, "%wu*%s^%wd", a->coeffs[i], x, i);
+                r = flint_fprintf(f, "%wu*%s^%wd", Acoeff[i], x, i);
         }
         --i;
     }
     for (; (r > 0) && (i > 1); --i)
     {
-        switch (a->coeffs[i])
+        switch (Acoeff[i])
         {
             case UWORD(0):
                 break;
@@ -74,12 +75,12 @@ int nmod_poly_fprint_pretty(FILE * f, const nmod_poly_t a, const char * x)
                 r = flint_fprintf(f, "+%s^%wd", x, i);
                 break;
             default:
-                r = flint_fprintf(f, "+%wu*%s^%wd", a->coeffs[i], x, i);
+                r = flint_fprintf(f, "+%wu*%s^%wd", Acoeff[i], x, i);
         }
     }
     if (r > 0 && i == 1)
     {   
-        switch (a->coeffs[1])
+        switch (Acoeff[1])
         {   
             case UWORD(0):
                 break;
@@ -87,15 +88,26 @@ int nmod_poly_fprint_pretty(FILE * f, const nmod_poly_t a, const char * x)
                 r = flint_fprintf(f, "+%s", x);
                 break;
             default:
-                r = flint_fprintf(f, "+%wu*%s", a->coeffs[1], x);
+                r = flint_fprintf(f, "+%wu*%s", Acoeff[1], x);
         }
     }
     if (r > 0)
     {
-        if (a->coeffs[0] != UWORD(0))
-            r = flint_fprintf(f, "+%wu", a->coeffs[0]);
+        if (Acoeff[0] != UWORD(0))
+            r = flint_fprintf(f, "+%wu", Acoeff[0]);
     }
 
     return (int) r;
 }
 
+
+int nmod_polydr_fprint_pretty(FILE * f, const nmod_polydr_t A, const char * x,
+                                                          const nmod_ctx_t ctx)
+{
+    return _nmod_poly_fprint_pretty(f, A->coeffs, A->length, x);
+}
+
+int nmod_poly_fprint_pretty(FILE * f, const nmod_poly_t A, const char * x)
+{
+    return _nmod_poly_fprint_pretty(f, A->coeffs, A->length, x);
+}

--- a/nmod_poly/fread.c
+++ b/nmod_poly/fread.c
@@ -15,6 +15,36 @@
 #include "flint.h"
 #include "nmod_poly.h"
 
+int nmod_polydr_fread(FILE * f, nmod_polydr_t poly, const nmod_ctx_t ctx)
+{
+    slong i, length;
+    mp_limb_t n;
+
+    if (flint_fscanf(f, "%wd %wu", &length, &n) != 2)
+        return 0;
+
+    if (n != ctx->mod.n)
+        return 0;
+    
+    nmod_polydr_clear(poly, ctx);
+    nmod_polydr_init(poly, ctx); 
+    nmod_polydr_fit_length(poly, length, ctx);
+    poly->length = length;
+    
+    for (i = 0; i < length; i++)
+    {
+        if (!flint_fscanf(f, "%wu", &poly->coeffs[i]))
+        {
+            poly->length = i;
+            return 0;
+        }
+    }
+   
+    _nmod_polydr_normalise(poly);
+   
+    return 1;
+}
+
 int nmod_poly_fread(FILE * f, nmod_poly_t poly)
 {
     slong i, length;

--- a/nmod_poly/gcd.c
+++ b/nmod_poly/gcd.c
@@ -23,6 +23,58 @@ slong _nmod_poly_gcd(mp_ptr G, mp_srcptr A, slong lenA,
         return _nmod_poly_gcd_hgcd(G, A, lenA, B, lenB, mod);
 }
 
+void nmod_polydr_gcd(nmod_polydr_t G, 
+            const nmod_polydr_t A, const nmod_polydr_t B, const nmod_ctx_t ctx)
+{
+    if (A->length < B->length)
+    {
+        nmod_polydr_gcd(G, B, A, ctx);
+    }
+    else /* lenA >= lenB >= 0 */
+    {
+        slong lenA = A->length, lenB = B->length, lenG;
+        nmod_polydr_t tG;
+        mp_ptr g;
+
+        if (lenA == 0) /* lenA = lenB = 0 */
+        {
+            nmod_polydr_zero(G, ctx);
+        } 
+        else if (lenB == 0) /* lenA > lenB = 0 */
+        {
+            nmod_polydr_make_monic(G, A, ctx);
+        }
+        else /* lenA >= lenB >= 1 */
+        {
+            if (G == A || G == B)
+            {
+                nmod_polydr_init2(tG, FLINT_MIN(lenA, lenB), ctx);
+                g = tG->coeffs;
+            }
+            else
+            {
+                nmod_polydr_fit_length(G, FLINT_MIN(lenA, lenB), ctx);
+                g = G->coeffs;
+            }
+
+            lenG = _nmod_poly_gcd(g, A->coeffs, lenA,
+                                               B->coeffs, lenB, ctx->mod);
+
+            if (G == A || G == B)
+            {
+                nmod_polydr_swap(tG, G, ctx);
+                nmod_polydr_clear(tG, ctx);
+            }
+            G->length = lenG;
+
+            if (G->length == 1)
+                G->coeffs[0] = 1;
+            else
+                nmod_polydr_make_monic(G, G, ctx);
+        }
+    }
+}
+
 void nmod_poly_gcd(nmod_poly_t G, 
                              const nmod_poly_t A, const nmod_poly_t B)
 {

--- a/nmod_poly/gcd_euclidean.c
+++ b/nmod_poly/gcd_euclidean.c
@@ -82,6 +82,58 @@ slong _nmod_poly_gcd_euclidean(mp_ptr G, mp_srcptr A, slong lenA,
     return lenG;
 }
 
+void nmod_polydr_gcd_euclidean(nmod_polydr_t G, 
+            const nmod_polydr_t A, const nmod_polydr_t B, const nmod_ctx_t ctx)
+{
+    if (A->length < B->length)
+    {
+        nmod_polydr_gcd_euclidean(G, B, A, ctx);
+    }
+    else /* lenA >= lenB >= 0 */
+    {
+        slong lenA = A->length, lenB = B->length, lenG;
+        nmod_polydr_t tG;
+        mp_ptr g;
+
+        if (lenA == 0) /* lenA = lenB = 0 */
+        {
+            nmod_polydr_zero(G, ctx);
+        } 
+        else if (lenB == 0) /* lenA > lenB = 0 */
+        {
+            nmod_polydr_make_monic(G, A, ctx);
+        }
+        else /* lenA >= lenB >= 1 */
+        {
+            if (G == A || G == B)
+            {
+                nmod_polydr_init2(tG, FLINT_MIN(lenA, lenB), ctx);
+                g = tG->coeffs;
+            }
+            else
+            {
+                nmod_polydr_fit_length(G, FLINT_MIN(lenA, lenB), ctx);
+                g = G->coeffs;
+            }
+
+            lenG = _nmod_poly_gcd_euclidean(g, A->coeffs, lenA,
+                                               B->coeffs, lenB, ctx->mod);
+
+            if (G == A || G == B)
+            {
+                nmod_polydr_swap(tG, G, ctx);
+                nmod_polydr_clear(tG, ctx);
+            }
+            G->length = lenG;
+
+            if (G->length == 1)
+                G->coeffs[0] = 1;
+            else
+                nmod_polydr_make_monic(G, G, ctx);
+        }
+    }
+}
+
 void nmod_poly_gcd_euclidean(nmod_poly_t G, 
                              const nmod_poly_t A, const nmod_poly_t B)
 {

--- a/nmod_poly/get_str.c
+++ b/nmod_poly/get_str.c
@@ -17,7 +17,7 @@
 #include "flint.h"
 #include "nmod_poly.h"
 
-char * nmod_poly_get_str(const nmod_poly_t poly)
+static char * _nmod_poly_get_str(const mp_limb_t * Acoeff, slong Alen, nmod_t mod)
 {
     slong i;
     char * buf, * ptr;
@@ -29,22 +29,31 @@ char * nmod_poly_get_str(const nmod_poly_t poly)
     slong size = 11*2 + 1;
 #endif
 
-    for (i = 0; i < poly->length; i++)
+    for (i = 0; i < Alen; i++)
     {
-        if (poly->coeffs[i]) /* log(2)/log(10) < 0.30103, +1 for space/null */
-            size += (ulong) ceil(0.30103*FLINT_BIT_COUNT(poly->coeffs[i])) + 1;
+        if (Acoeff[i]) /* log(2)/log(10) < 0.30103, +1 for space/null */
+            size += (ulong) ceil(0.30103*FLINT_BIT_COUNT(Acoeff[i])) + 1;
         else size += 2;
     }
 
     buf = (char *) flint_malloc(size);  
-    ptr = buf + flint_sprintf(buf, "%wd %wu", poly->length, poly->mod.n);
+    ptr = buf + flint_sprintf(buf, "%wd %wu", Alen, mod.n);
    
-    if (poly->length)
+    if (Alen)
         ptr += flint_sprintf(ptr, " ");
 
-    for (i = 0; i < poly->length; i++)
-        ptr += flint_sprintf(ptr, " %wu", poly->coeffs[i]);
+    for (i = 0; i < Alen; i++)
+        ptr += flint_sprintf(ptr, " %wu", Acoeff[i]);
    
     return buf;
 }
 
+char * nmod_polydr_get_str(const nmod_polydr_t poly, const nmod_ctx_t ctx)
+{
+    return _nmod_poly_get_str(poly->coeffs, poly->length, ctx->mod);
+}
+
+char * nmod_poly_get_str(const nmod_poly_t poly)
+{
+    return _nmod_poly_get_str(poly->coeffs, poly->length, poly->mod);
+}

--- a/nmod_poly/get_str_pretty.c
+++ b/nmod_poly/get_str_pretty.c
@@ -16,32 +16,33 @@
 #include "flint.h"
 #include "nmod_poly.h"
 
-char * nmod_poly_get_str_pretty(const nmod_poly_t poly, const char * x)
+static char * _nmod_poly_get_str_pretty(const mp_limb_t * Acoeff, slong Alen,
+                                                                const char * x)
 {
     slong i;
     char * buf, * ptr;
 
     slong size = 0;
 
-    if (poly->length == 0)
+    if (Alen == 0)
     {
         buf = (char *) flint_malloc(2);
         buf[0] = '0';
         buf[1] = '\0';
         return buf;
     }
-    else if (poly->length == 1)
+    else if (Alen == 1)
     {
-        size = (ulong) ceil(0.30103*FLINT_BIT_COUNT(poly->coeffs[0])) + 1;
+        size = (ulong) ceil(0.30103*FLINT_BIT_COUNT(Acoeff[0])) + 1;
         buf = (char *) flint_malloc(size);
-        flint_sprintf(buf, "%wu", poly->coeffs[0]);
+        flint_sprintf(buf, "%wu", Acoeff[0]);
         return buf;
     }
 
-    for (i = 0; i < poly->length; i++)
+    for (i = 0; i < Alen; i++)
     {
-        if (poly->coeffs[i]) /* log(2)/log(10) < 0.30103, +3 for +*^ or null*/
-            size += (ulong) ceil(0.30103*FLINT_BIT_COUNT(poly->coeffs[i])) + 
+        if (Acoeff[i]) /* log(2)/log(10) < 0.30103, +3 for +*^ or null*/
+            size += (ulong) ceil(0.30103*FLINT_BIT_COUNT(Acoeff[i])) + 
                     (ulong) ceil(0.30103*FLINT_BIT_COUNT(i)) + strlen(x) + 3; 
     }
 
@@ -50,31 +51,31 @@ char * nmod_poly_get_str_pretty(const nmod_poly_t poly, const char * x)
     --i;
     if (i == 1)
     {
-        switch (poly->coeffs[1])
+        switch (Acoeff[1])
         {
             case UWORD(1):
                 ptr += flint_sprintf(ptr, "%s", x);
                 break;
             default:
-                ptr += flint_sprintf(ptr, "%wu*%s", poly->coeffs[1], x);
+                ptr += flint_sprintf(ptr, "%wu*%s", Acoeff[1], x);
         }
         --i;
     }
     else
     {
-        switch (poly->coeffs[i])
+        switch (Acoeff[i])
         {
             case UWORD(1):
                 ptr += flint_sprintf(ptr, "%s^%wd", x, i);
                 break;
             default:
-                ptr += flint_sprintf(ptr, "%wu*%s^%wd", poly->coeffs[i], x, i);
+                ptr += flint_sprintf(ptr, "%wu*%s^%wd", Acoeff[i], x, i);
         }
         --i;
     }
     for (; i > 1; --i)
     {
-        switch (poly->coeffs[i])
+        switch (Acoeff[i])
         {
             case UWORD(0):
                 break;
@@ -82,13 +83,13 @@ char * nmod_poly_get_str_pretty(const nmod_poly_t poly, const char * x)
                 ptr += flint_sprintf(ptr, "+%s^%wd", x, i);
                 break;
             default:
-                ptr += flint_sprintf(ptr, "+%wu*%s^%wd", poly->coeffs[i], x, i);
+                ptr += flint_sprintf(ptr, "+%wu*%s^%wd", Acoeff[i], x, i);
         }
         
     }
     if (i == 1)
     {   
-        switch (poly->coeffs[1])
+        switch (Acoeff[1])
         {   
             case UWORD(0):
                 break;
@@ -96,14 +97,24 @@ char * nmod_poly_get_str_pretty(const nmod_poly_t poly, const char * x)
                 ptr += flint_sprintf(ptr, "+%s", x);
                 break;
             default:
-                ptr += flint_sprintf(ptr, "+%wu*%s", poly->coeffs[1], x);
+                ptr += flint_sprintf(ptr, "+%wu*%s", Acoeff[1], x);
         }
     }
     {
-        if (poly->coeffs[0] != UWORD(0))
-            ptr += flint_sprintf(ptr, "+%wu", poly->coeffs[0]);
+        if (Acoeff[0] != UWORD(0))
+            ptr += flint_sprintf(ptr, "+%wu", Acoeff[0]);
     }
 
     return buf;
 }
 
+char * nmod_polydr_get_str_pretty(const nmod_polydr_t A, const char * x,
+                                                          const nmod_ctx_t ctx)
+{
+    return _nmod_poly_get_str_pretty(A->coeffs, A->length, x);
+}
+
+char * nmod_poly_get_str_pretty(const nmod_poly_t A, const char * x)
+{
+    return _nmod_poly_get_str_pretty(A->coeffs, A->length, x);
+}

--- a/nmod_poly/init.c
+++ b/nmod_poly/init.c
@@ -17,6 +17,14 @@
 #include "nmod_poly.h"
 
 void
+nmod_polydr_init(nmod_polydr_t poly, const nmod_ctx_t ctx)
+{
+    poly->coeffs = NULL;
+    poly->alloc = 0;
+    poly->length = 0;
+}
+
+void
 nmod_poly_init_preinv(nmod_poly_t poly, mp_limb_t n, mp_limb_t ninv)
 {
     poly->coeffs = NULL;

--- a/nmod_poly/init2.c
+++ b/nmod_poly/init2.c
@@ -17,6 +17,17 @@
 #include "nmod_poly.h"
 
 void
+nmod_polydr_init2(nmod_polydr_t poly, slong alloc, const nmod_ctx_t ctx)
+{
+    poly->alloc = alloc;
+    poly->length = 0;
+    if (alloc)
+        poly->coeffs = (mp_ptr) flint_malloc(alloc * sizeof(mp_limb_t));
+    else
+        poly->coeffs = NULL;
+}
+
+void
 nmod_poly_init2_preinv(nmod_poly_t poly,
                        mp_limb_t n, mp_limb_t ninv, slong alloc)
 {
@@ -33,6 +44,7 @@ nmod_poly_init2_preinv(nmod_poly_t poly,
     poly->alloc = alloc;
     poly->length = 0;
 }
+
 
 void
 nmod_poly_init2(nmod_poly_t poly, mp_limb_t n, slong alloc)

--- a/nmod_poly/inv_series_newton.c
+++ b/nmod_poly/inv_series_newton.c
@@ -74,6 +74,38 @@ _nmod_poly_inv_series_newton(mp_ptr Qinv, mp_srcptr Q, slong Qlen, slong n, nmod
 }
 
 void
+nmod_polydr_inv_series_newton(nmod_polydr_t Qinv, const nmod_polydr_t Q,
+                                                 slong n, const nmod_ctx_t ctx)
+{
+    slong Qlen = Q->length;
+
+    Qlen = FLINT_MIN(Qlen, n);
+
+    if (Qlen == 0)
+    {
+        flint_printf("Exception (nmod_poly_inv_series_newton). Division by zero.\n");
+        flint_abort();
+    }
+
+    if (Qinv != Q)
+    {
+        nmod_polydr_fit_length(Qinv, n, ctx);
+        _nmod_poly_inv_series_newton(Qinv->coeffs, Q->coeffs, Qlen, n, ctx->mod);
+    }
+    else
+    {
+        nmod_polydr_t t;
+        nmod_polydr_init2(t, n, ctx);
+        _nmod_poly_inv_series_newton(t->coeffs, Q->coeffs, Qlen, n, ctx->mod);
+        nmod_polydr_swap(Qinv, t, ctx);
+        nmod_polydr_clear(t, ctx);
+    }
+
+    Qinv->length = n;
+    _nmod_polydr_normalise(Qinv);
+}
+
+void
 nmod_poly_inv_series_newton(nmod_poly_t Qinv, const nmod_poly_t Q, slong n)
 {
     slong Qlen = Q->length;

--- a/nmod_poly/make_monic.c
+++ b/nmod_poly/make_monic.c
@@ -25,6 +25,21 @@ void _nmod_poly_make_monic(mp_ptr output,
     _nmod_vec_scalar_mul_nmod(output, input, len, inv, mod);
 }
 
+void nmod_polydr_make_monic(nmod_polydr_t output, const nmod_polydr_t input,
+                                                          const nmod_ctx_t ctx)
+{
+    if (input->length == 0)
+    {
+        flint_printf("Exception (nmod_poly_make_monic). Division by zero.\n");
+        flint_abort();
+    }
+
+    nmod_polydr_fit_length(output, input->length, ctx);
+    _nmod_poly_make_monic(output->coeffs, 
+                            input->coeffs, input->length, ctx->mod);
+    output->length = input->length;
+}
+
 void nmod_poly_make_monic(nmod_poly_t output, const nmod_poly_t input)
 {
     if (input->length == 0)
@@ -38,4 +53,3 @@ void nmod_poly_make_monic(nmod_poly_t output, const nmod_poly_t input)
                             input->coeffs, input->length, input->mod);
     output->length = input->length;
 }
-

--- a/nmod_poly/mul.c
+++ b/nmod_poly/mul.c
@@ -89,6 +89,13 @@ void nmod_polydr_mul(nmod_polydr_t res, const nmod_polydr_t poly1,
 void nmod_poly_mul(nmod_poly_t res, const nmod_poly_t poly1, const nmod_poly_t poly2)
 {
     slong len1, len2, len_out;
+
+    nmod_polydr_mul(nmod_poly_polydr(res),
+                    nmod_poly_polydr(poly1),
+                    nmod_poly_polydr(poly2),
+                    nmod_poly_ctx(poly1)); /* use the modulus of poly1 */
+    return;
+
     
     len1 = poly1->length;
     len2 = poly2->length;

--- a/nmod_poly/mul.c
+++ b/nmod_poly/mul.c
@@ -39,6 +39,53 @@ void _nmod_poly_mul(mp_ptr res, mp_srcptr poly1, slong len1,
         _nmod_poly_mul_KS(res, poly1, len1, poly2, len2, 0, mod);
 }
 
+void nmod_polydr_mul(nmod_polydr_t res, const nmod_polydr_t poly1,
+                               const nmod_polydr_t poly2, const nmod_ctx_t ctx)
+{
+    slong len1, len2, len_out;
+    
+    len1 = poly1->length;
+    len2 = poly2->length;
+
+    if (len1 == 0 || len2 == 0)
+    {
+        nmod_polydr_zero(res, ctx);
+        return;
+    }
+
+    len_out = poly1->length + poly2->length - 1;
+
+    if (res == poly1 || res == poly2)
+    {
+        nmod_polydr_t temp;
+        nmod_polydr_init2(temp, len_out, ctx);
+
+        if (len1 >= len2)
+            _nmod_poly_mul(temp->coeffs, poly1->coeffs, len1,
+                           poly2->coeffs, len2, ctx->mod);
+        else
+            _nmod_poly_mul(temp->coeffs, poly2->coeffs, len2,
+                           poly1->coeffs, len1, ctx->mod);
+        
+        nmod_polydr_swap(temp, res, ctx);
+        nmod_polydr_clear(temp, ctx);
+    }
+    else
+    {
+        nmod_polydr_fit_length(res, len_out, ctx);
+        
+        if (len1 >= len2)
+            _nmod_poly_mul(res->coeffs, poly1->coeffs, len1,
+                           poly2->coeffs, len2, ctx->mod);
+        else
+            _nmod_poly_mul(res->coeffs, poly2->coeffs, len2,
+                           poly1->coeffs, len1, ctx->mod);
+    }
+
+    res->length = len_out;
+    _nmod_polydr_normalise(res);
+}
+
 void nmod_poly_mul(nmod_poly_t res, const nmod_poly_t poly1, const nmod_poly_t poly2)
 {
     slong len1, len2, len_out;

--- a/nmod_poly/mul.c
+++ b/nmod_poly/mul.c
@@ -88,54 +88,8 @@ void nmod_polydr_mul(nmod_polydr_t res, const nmod_polydr_t poly1,
 
 void nmod_poly_mul(nmod_poly_t res, const nmod_poly_t poly1, const nmod_poly_t poly2)
 {
-    slong len1, len2, len_out;
-
     nmod_polydr_mul(nmod_poly_polydr(res),
                     nmod_poly_polydr(poly1),
                     nmod_poly_polydr(poly2),
                     nmod_poly_ctx(poly1)); /* use the modulus of poly1 */
-    return;
-
-    
-    len1 = poly1->length;
-    len2 = poly2->length;
-
-    if (len1 == 0 || len2 == 0)
-    {
-        nmod_poly_zero(res);
-
-        return;
-    }
-
-    len_out = poly1->length + poly2->length - 1;
-
-    if (res == poly1 || res == poly2)
-    {
-        nmod_poly_t temp;
-
-        nmod_poly_init2(temp, poly1->mod.n, len_out);
-
-        if (len1 >= len2)
-            _nmod_poly_mul(temp->coeffs, poly1->coeffs, len1,
-                           poly2->coeffs, len2, poly1->mod);
-        else
-            _nmod_poly_mul(temp->coeffs, poly2->coeffs, len2,
-                           poly1->coeffs, len1, poly1->mod);
-        
-        nmod_poly_swap(temp, res);
-        nmod_poly_clear(temp);
-    } else
-    {
-        nmod_poly_fit_length(res, len_out);
-        
-        if (len1 >= len2)
-            _nmod_poly_mul(res->coeffs, poly1->coeffs, len1,
-                           poly2->coeffs, len2, poly1->mod);
-        else
-            _nmod_poly_mul(res->coeffs, poly2->coeffs, len2,
-                           poly1->coeffs, len1, poly1->mod);
-    }
-
-    res->length = len_out;
-    _nmod_poly_normalise(res);
 }

--- a/nmod_poly/neg.c
+++ b/nmod_poly/neg.c
@@ -17,6 +17,16 @@
 #include "nmod_poly.h"
 
 void
+nmod_polydr_neg(nmod_polydr_t res, const nmod_polydr_t poly1, const nmod_ctx_t ctx)
+{
+    nmod_polydr_fit_length(res, poly1->length, ctx);
+
+    _nmod_vec_neg(res->coeffs, poly1->coeffs, poly1->length, ctx->mod);
+
+    res->length = poly1->length;
+}
+
+void
 nmod_poly_neg(nmod_poly_t res, const nmod_poly_t poly1)
 {
     nmod_poly_fit_length(res, poly1->length);

--- a/nmod_poly/pow.c
+++ b/nmod_poly/pow.c
@@ -22,6 +22,68 @@ _nmod_poly_pow(mp_ptr res, mp_srcptr poly, slong len, ulong e, nmod_t mod)
 }
 
 void
+nmod_polydr_pow(nmod_polydr_t res, const nmod_polydr_t poly, ulong e,
+                                                          const nmod_ctx_t ctx)
+{
+    const slong len = poly->length;
+    slong rlen;
+
+    if ((len < 2) | (e < UWORD(3)))
+    {
+        if (len == 0)
+        {
+            if (e == 0)
+                nmod_polydr_one(res, ctx);
+            else
+                nmod_polydr_zero(res, ctx);
+        }
+        else if (len == 1)
+        {
+            nmod_polydr_fit_length(res, 1, ctx);
+            res->coeffs[0] = n_powmod2_ui_preinv(poly->coeffs[0], e,
+                                                   ctx->mod.n, ctx->mod.ninv);
+            res->length = 1;
+            _nmod_polydr_normalise(res);
+        }
+        else if (e == UWORD(0))
+        {
+            nmod_polydr_set_coeff_ui(res, 0, UWORD(1), ctx);
+            res->length = 1;
+            _nmod_polydr_normalise(res);
+        }
+        else if (e == UWORD(1))
+        {
+            nmod_polydr_set(res, poly, ctx);
+        }
+        else  /* e == UWORD(2) */
+        {
+            nmod_polydr_mul(res, poly, poly, ctx);
+        }
+
+        return;
+    }
+
+    rlen = (slong) e * (len - 1) + 1;
+
+    if (res != poly)
+    {
+        nmod_polydr_fit_length(res, rlen, ctx);
+        _nmod_poly_pow(res->coeffs, poly->coeffs, len, e, ctx->mod);
+    }
+    else
+    {
+        nmod_polydr_t t;
+        nmod_polydr_init2(t, rlen, ctx);
+        _nmod_poly_pow(t->coeffs, poly->coeffs, len, e, ctx->mod);
+        nmod_polydr_swap(res, t, ctx);
+        nmod_polydr_clear(t, ctx);
+    }
+
+    res->length = rlen;
+    _nmod_polydr_normalise(res);
+}
+
+void
 nmod_poly_pow(nmod_poly_t res, const nmod_poly_t poly, ulong e)
 {
     const slong len = poly->length;

--- a/nmod_poly/randtest.c
+++ b/nmod_poly/randtest.c
@@ -17,6 +17,15 @@
 #include "nmod_poly.h"
 
 void
+nmod_polydr_randtest(nmod_polydr_t poly, flint_rand_t state, slong len, const nmod_ctx_t ctx)
+{
+    nmod_polydr_fit_length(poly, len, ctx);
+    _nmod_vec_randtest(poly->coeffs, state, len, ctx->mod);
+    poly->length = len;
+    _nmod_polydr_normalise(poly);
+}
+
+void
 nmod_poly_randtest(nmod_poly_t poly, flint_rand_t state, slong len)
 {
     nmod_poly_fit_length(poly, len);

--- a/nmod_poly/realloc.c
+++ b/nmod_poly/realloc.c
@@ -17,6 +17,31 @@
 #include "nmod_poly.h"
 
 void
+nmod_polydr_realloc(nmod_polydr_t poly, slong alloc, const nmod_ctx_t ctx)
+{
+    if (alloc == 0)
+    {
+        nmod_polydr_clear(poly, ctx);
+        poly->length = 0;
+        poly->alloc = 0;
+        poly->coeffs = NULL;
+
+        return;
+    }
+
+    poly->coeffs = (mp_ptr) flint_realloc(poly->coeffs, alloc * sizeof(mp_limb_t));
+
+    poly->alloc = alloc;
+
+    /* truncate poly if necessary */
+    if (poly->length > alloc)
+    {
+        poly->length = alloc;
+        _nmod_polydr_normalise(poly);
+    }
+}
+
+void
 nmod_poly_realloc(nmod_poly_t poly, slong alloc)
 {
     if (alloc == 0)

--- a/nmod_poly/rem.c
+++ b/nmod_poly/rem.c
@@ -44,6 +44,47 @@ void _nmod_poly_rem(mp_ptr R, mp_srcptr A, slong lenA,
     }
 }
 
+void nmod_polydr_rem(nmod_polydr_t R, const nmod_polydr_t A,
+                                   const nmod_polydr_t B, const nmod_ctx_t ctx)
+{
+    const slong lenA = A->length, lenB = B->length;
+    nmod_polydr_t tR;
+    mp_ptr r;
+
+    if (lenB == 0)
+    {
+        flint_printf("Exception (nmod_poly_rem). Division by zero.\n");
+        flint_abort();
+    }
+    if (lenA < lenB)
+    {
+        nmod_polydr_set(R, A, ctx);
+        return;
+    }
+
+    if (R == A || R == B)
+    {
+        nmod_polydr_init2(tR, lenB - 1, ctx);
+        r = tR->coeffs;
+    }
+    else
+    {
+        nmod_polydr_fit_length(R, lenB - 1, ctx);
+        r = R->coeffs;
+    }
+
+    _nmod_poly_rem(r, A->coeffs, lenA, B->coeffs, lenB, ctx->mod);
+
+    if (R == A || R == B)
+    {
+        nmod_polydr_swap(R, tR, ctx);
+        nmod_polydr_clear(tR, ctx);
+    }
+        
+    R->length = lenB - 1;
+    _nmod_polydr_normalise(R);
+}
+
 void nmod_poly_rem(nmod_poly_t R, const nmod_poly_t A, const nmod_poly_t B)
 {
     const slong lenA = A->length, lenB = B->length;

--- a/nmod_poly/reverse.c
+++ b/nmod_poly/reverse.c
@@ -41,6 +41,17 @@ void _nmod_poly_reverse(mp_ptr output, mp_srcptr input, slong len, slong m)
     }
 }
 
+void nmod_polydr_reverse(nmod_polydr_t output, const nmod_polydr_t input, slong m,
+                                                          const nmod_ctx_t ctx)
+{
+    nmod_polydr_fit_length(output, m, ctx);
+     
+    _nmod_poly_reverse(output->coeffs, input->coeffs, input->length, m);
+
+    output->length = m;
+    _nmod_polydr_normalise(output);
+}
+
 void nmod_poly_reverse(nmod_poly_t output, const nmod_poly_t input, slong m)
 {
     nmod_poly_fit_length(output, m);

--- a/nmod_poly/scalar_mul_nmod.c
+++ b/nmod_poly/scalar_mul_nmod.c
@@ -16,6 +16,27 @@
 #include "nmod_poly.h"
 
 void
+nmod_polydr_scalar_mul_nmod(nmod_polydr_t res, const nmod_polydr_t poly1,
+                                             mp_limb_t c, const nmod_ctx_t ctx)
+{
+    FLINT_ASSERT(c < ctx->mod.n);
+
+    if ((poly1->length == 0) || (c == 0))
+    {
+        nmod_polydr_zero(res, ctx);
+        return;
+    }
+
+    nmod_polydr_fit_length(res, poly1->length, ctx);
+
+    _nmod_vec_scalar_mul_nmod(res->coeffs, poly1->coeffs, poly1->length,
+                              c, ctx->mod);
+
+    res->length = poly1->length;
+    _nmod_polydr_normalise(res);  /* there may have been cancellation */
+}
+
+void
 nmod_poly_scalar_mul_nmod(nmod_poly_t res, const nmod_poly_t poly1, mp_limb_t c)
 {
     if ((poly1->length == 0) || (c == 0))

--- a/nmod_poly/set_coeff_ui.c
+++ b/nmod_poly/set_coeff_ui.c
@@ -15,6 +15,48 @@
 #include "nmod_vec.h"
 #include "nmod_poly.h"
 
+void nmod_polydr_set_coeff_ui(nmod_polydr_t poly, slong j, ulong c,
+                                                          const nmod_ctx_t ctx)
+{
+    if (c >= ctx->mod.n)
+        NMOD_RED(c, c, ctx->mod);
+
+    if (j + 1 < poly->length) /* interior */
+    {
+        poly->coeffs[j] = c;
+        return;
+    }
+
+    nmod_polydr_fit_length(poly, j + 1, ctx);
+
+    if (j + 1 == poly->length) /* leading coeff */
+    {
+        if (c != 0)
+        {
+            poly->coeffs[j] = c;
+        }
+        else
+        {
+            poly->length--;
+            _nmod_polydr_normalise(poly);
+        }
+    }
+    else /* extend polynomial */
+    {
+        if (c == 0)
+        {
+            return;
+        }
+        else
+        {
+            flint_mpn_zero(poly->coeffs + poly->length, j - poly->length);
+
+            poly->coeffs[j] = c;
+            poly->length = j + 1;
+        }
+    }
+}
+
 void nmod_poly_set_coeff_ui(nmod_poly_t poly, slong j, ulong c)
 {
     if (c >= poly->mod.n)

--- a/nmod_poly/shift_left.c
+++ b/nmod_poly/shift_left.c
@@ -20,6 +20,16 @@ void _nmod_poly_shift_left(mp_ptr res, mp_srcptr poly, slong len, slong k)
     flint_mpn_zero(res, k);
 }
 
+void nmod_polydr_shift_left(nmod_polydr_t res, const nmod_polydr_t poly, slong k,
+                                                          const nmod_ctx_t ctx)
+{
+    nmod_polydr_fit_length(res, poly->length + k, ctx);
+   
+    _nmod_poly_shift_left(res->coeffs, poly->coeffs, poly->length, k);
+   
+    res->length = poly->length + k;
+}
+
 void nmod_poly_shift_left(nmod_poly_t res, const nmod_poly_t poly, slong k)
 {
     nmod_poly_fit_length(res, poly->length + k);

--- a/nmod_poly/shift_right.c
+++ b/nmod_poly/shift_right.c
@@ -19,6 +19,24 @@ void _nmod_poly_shift_right(mp_ptr res, mp_srcptr poly, slong len, slong k)
     flint_mpn_copyi(res, poly + k, len);
 }
 
+void nmod_polydr_shift_right(nmod_polydr_t res, const nmod_polydr_t poly, slong k,
+                                                          const nmod_ctx_t ctx)
+{
+    if (k >= poly->length) /* shift all coeffs out */
+    {
+        res->length = 0;
+    }
+    else
+    {
+        const slong len = poly->length - k;
+        nmod_polydr_fit_length(res, len, ctx);
+
+        _nmod_poly_shift_right(res->coeffs, poly->coeffs, len, k);
+
+        res->length = len;
+    }
+}
+
 void nmod_poly_shift_right(nmod_poly_t res, const nmod_poly_t poly, slong k)
 {
     if (k >= poly->length) /* shift all coeffs out */

--- a/nmod_poly/sub.c
+++ b/nmod_poly/sub.c
@@ -37,6 +37,21 @@ _nmod_poly_sub(mp_ptr res, mp_srcptr poly1, slong len1, mp_srcptr poly2,
 }
 
 void
+nmod_polydr_sub(nmod_polydr_t res, const nmod_polydr_t poly1,
+                              const nmod_polydr_t poly2, const nmod_ctx_t ctx)
+{
+    slong max = FLINT_MAX(poly1->length, poly2->length);
+
+    nmod_polydr_fit_length(res, max, ctx);
+
+    _nmod_poly_sub(res->coeffs, poly1->coeffs, poly1->length, poly2->coeffs,
+                   poly2->length, ctx->mod);
+
+    res->length = max;
+    _nmod_polydr_normalise(res);  /* there may have been cancellation */
+}
+
+void
 nmod_poly_sub(nmod_poly_t res, const nmod_poly_t poly1,
               const nmod_poly_t poly2)
 {


### PR DESCRIPTION
This first commit is the smallest possible to get fq_nmod_t = nmod_polydr_t. There is now a nmod_ctx_t for these nmod_polydr_t's. If you don't like how I have changed nmod_poly/mul.c ect, then the nmod_poly_t will have to be changed to be able to reuse the code there.