### PR TITLE
Remove unneessary and possibly dangerious overshadowing of mp_bitcnt_t

### DIFF
--- a/flint.h
+++ b/flint.h
@@ -144,8 +144,6 @@ FLINT_DLL void flint_set_abort(void (*func)(void));
     #define FLINT_D_BITS 31
 #endif
 
-#define mp_bitcnt_t ulong
-
 #if HAVE_TLS
 #if __STDC_VERSION__ >= 201112L
 #define FLINT_TLS_PREFIX _Thread_local


### PR DESCRIPTION
AFAICT this line can be traced back to f988d3eaab92ad477fe73cb346060fc0b700c566 where it wasn't added for any immediately obvious reason (perhaps it was a temporary workaround to some other problem).

It was later updated to read `#define mp_limb_t ulong` which is dangerous since `ulong` is defined in flint.h as `#define ulong mp_limb_t`, where it's not necessarily the case that `mp_limb_t` is the same underlying type as `mp_bitcnt_t` depending on how GMP was configured.