### PR TITLE
fmpq_mpoly_content

### DIFF
--- a/doc/source/fmpq_mpoly.rst
+++ b/doc/source/fmpq_mpoly.rst
@@ -230,7 +230,7 @@ Coefficients
 --------------------------------------------------------------------------------
 
 
-.. function:: void fmpq_mpoly_denominator(fmpz_t d, const fmpq_mpoly_t A, const fmpq_mpoly_ctx_t ctx)
+.. function:: void fmpq_mpoly_get_denominator(fmpz_t d, const fmpq_mpoly_t A, const fmpq_mpoly_ctx_t ctx)
 
     Set ``d`` to the denominator of ``A``, the smallest positive integer `d` such that `d*A` has integer coefficients.
 
@@ -556,6 +556,14 @@ Division
 Greatest Common Divisor
 --------------------------------------------------------------------------------
 
+.. function:: fmpq_mpoly_content(fmpq_t g, const fmpq_mpoly_t A, const fmpq_mpoly_ctx_t ctx)
+
+    Set ``g`` to the (nonnegative) gcd of the coefficients of ``A``.
+
+.. function:: void fmpq_mpoly_term_content(fmpq_mpoly_t M, const fmpq_mpoly_t A, const fmpq_mpoly_ctx_t ctx)
+
+    Sets ``M`` to the GCD of the terms of ``A``.
+    If ``A`` is zero, ``M`` will be zero. Otherwise, ``M`` will be a monomial with coefficient one.
 
 .. function:: int fmpq_mpoly_gcd(fmpq_mpoly_t G, const fmpq_mpoly_t A, const fmpq_mpoly_t B, const fmpq_mpoly_ctx_t ctx)
 

--- a/fmpq_mpoly.h
+++ b/fmpq_mpoly.h
@@ -344,7 +344,7 @@ slong fmpq_mpoly_total_degree_si(const fmpq_mpoly_t A,
 /* Coefficients **************************************************************/
 
 FMPQ_MPOLY_INLINE
-void fmpq_mpoly_denominator(fmpz_t d, const fmpq_mpoly_t A,
+void fmpq_mpoly_get_denominator(fmpz_t d, const fmpq_mpoly_t A,
                                                     const fmpq_mpoly_ctx_t ctx)
 {
     fmpz_set(d, fmpq_denref(A->content));
@@ -691,6 +691,13 @@ FLINT_DLL void fmpq_mpoly_divrem_ideal(fmpq_mpoly_struct ** q, fmpq_mpoly_t r,
                                                    const fmpq_mpoly_ctx_t ctx);
 
 /* GCD ***********************************************************************/
+
+FMPQ_MPOLY_INLINE
+void fmpq_mpoly_content(fmpq_t g, const fmpq_mpoly_t A,
+                                                    const fmpq_mpoly_ctx_t ctx)
+{
+    fmpq_abs(g, A->content);
+}
 
 FLINT_DLL void fmpq_mpoly_term_content(fmpq_mpoly_t M, const fmpq_mpoly_t A,
                                                    const fmpq_mpoly_ctx_t ctx);

--- a/fmpq_mpoly/test/t-content.c
+++ b/fmpq_mpoly/test/t-content.c
@@ -1,0 +1,75 @@
+/*
+    Copyright (C) 2018 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fmpq_mpoly.h"
+
+int
+main(void)
+{
+    slong i, j, k;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("content....");
+    fflush(stdout);
+
+    /* Check content is gcd of coefficients */
+    for (i = 0; i < 50 * flint_test_multiplier(); i++)
+    {
+        fmpq_mpoly_ctx_t ctx;
+        fmpq_mpoly_t f;
+        fmpq_t g1, g2, t;
+        slong len;
+        flint_bitcnt_t coeff_bits, exp_bits;
+
+        fmpq_mpoly_ctx_init_rand(ctx, state, 20);
+        fmpq_mpoly_init(f, ctx);
+        fmpq_init(g1);
+        fmpq_init(g2);
+        fmpq_init(t);
+
+        len = n_randint(state, 50);
+        exp_bits = n_randint(state, 200) + 2;
+        coeff_bits = n_randint(state, 100);
+
+        for (j = 0; j < 10; j++)
+        {
+            fmpq_mpoly_randtest_bits(f, state, len, coeff_bits, exp_bits, ctx);
+
+            fmpq_zero(g1);
+            for (k = 0; k < fmpq_mpoly_length(f, ctx); k++)
+            {
+                fmpq_mpoly_get_term_coeff_fmpq(t, f, k, ctx);
+                fmpq_gcd(g1, g1, t);
+            }
+
+            fmpq_mpoly_content(g2, f, ctx);
+
+            if (!fmpq_equal(g1, g2))
+            {
+                printf("FAIL\n");
+                flint_printf("Check content\ni = %wd, j = %wd\n", i, j);
+                flint_abort();
+            }
+        }
+
+        fmpq_clear(g1);
+        fmpq_clear(g2);
+        fmpq_clear(t);
+        fmpq_mpoly_clear(f, ctx);
+        fmpq_mpoly_ctx_clear(ctx);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+
+    flint_printf("PASS\n");
+    return 0;
+}
+

--- a/fmpq_mpoly/test/t-equal_is_fmpq.c
+++ b/fmpq_mpoly/test/t-equal_is_fmpq.c
@@ -178,9 +178,9 @@ main(void)
         fmpq_set_si(q, WORD(2), WORD(3));
         result = result && !fmpq_mpoly_equal_fmpq(f, q, ctx);
 
-        fmpq_mpoly_denominator(a, f, ctx);
+        fmpq_mpoly_get_denominator(a, f, ctx);
         result = result && fmpz_equal_si(a, WORD(3));
-        fmpq_mpoly_denominator(a, g, ctx);
+        fmpq_mpoly_get_denominator(a, g, ctx);
         result = result && fmpz_equal_si(a, WORD(1));
 
         fmpz_set_si(a, WORD(1));
@@ -219,9 +219,9 @@ main(void)
         fmpq_set_si(q, WORD(2), WORD(3));
         result = result && !fmpq_mpoly_equal_fmpq(f, q, ctx);
 
-        fmpq_mpoly_denominator(a, f, ctx);
+        fmpq_mpoly_get_denominator(a, f, ctx);
         result = result && fmpz_equal_si(a, WORD(15));
-        fmpq_mpoly_denominator(a, g, ctx);
+        fmpq_mpoly_get_denominator(a, g, ctx);
         result = result && fmpz_equal_si(a, WORD(1));
 
         fmpz_set_si(a, WORD(1));


### PR DESCRIPTION
note that that the denominator function has been renamed fmpq_mpoly_get_denominator and the content function is called fmpq_mpoly_content. These both match the corresponding functions for univars. There is not a get numerator yet because that could involve a possible change of ordering, which is not not yet handled by the library anywhere.