### PR TITLE
fq_nmod_init: nmod_poly_init2_preinv -> nmod_poly_init_preinv

### DIFF
--- a/fq_nmod.h
+++ b/fq_nmod.h
@@ -155,7 +155,7 @@ FQ_NMOD_INLINE void fq_nmod_ctx_print(const fq_nmod_ctx_t ctx)
 
 FQ_NMOD_INLINE void fq_nmod_init(fq_nmod_t rop, const fq_nmod_ctx_t ctx)
 {
-    nmod_poly_init2_preinv(rop, ctx->mod.n, ctx->mod.ninv, fq_nmod_ctx_degree(ctx));
+    nmod_poly_init_preinv(rop, ctx->mod.n, ctx->mod.ninv);
 }
 
 FQ_NMOD_INLINE void fq_nmod_init2(fq_nmod_t rop, const fq_nmod_ctx_t ctx)


### PR DESCRIPTION
At the moment `fq_nmod_init` and `fq_nmod_init2` are identical, and both use `nmod_poly_init2_preinv`

Furthermore, the documentation (https://github.com/wbhart/flint2/blob/trunk/doc/source/fq_nmod.rst#memory-management) *seems* to imply that, with `fq_nmod_init` (instead of init2) we don't allocate any coefficients, just like in `nmod_init` or `nmod_poly_init_preinv`.

In this PR I convert the `nmod_poly_init2_preinv` in  `fq_nmod_init` to  a`nmod_poly_init_preinv`






 