### PR TITLE
empty factor struct before filling it

### DIFF
--- a/fmpz_poly_factor/factor.c
+++ b/fmpz_poly_factor/factor.c
@@ -18,6 +18,8 @@ void fmpz_poly_factor(fmpz_poly_factor_t fac, const fmpz_poly_t G)
     const slong lenG = G->length;
     fmpz_poly_t g;
 
+    fac->num = 0;
+
     if (lenG == 0)
     {
         fmpz_set_ui(&fac->c, 0);


### PR DESCRIPTION
The documentation for fmpz_poly_factor does not say it needs a "freshly initialized factor structure".