### PR TITLE
docs: replace 2^64 by 2^{64}

### DIFF
--- a/doc/latex/flint-manual.tex
+++ b/doc/latex/flint-manual.tex
@@ -827,7 +827,7 @@ Weiferich prime search. (Funded by the Nuffield Foundation)
 
 $\bullet$ Brian Gladman -- MSVC support
 
-$\bullet$ Dana Jacobsen -- test BPSW primality code up to $2^64$ against
+$\bullet$ Dana Jacobsen -- test BPSW primality code up to $2^{64}$ against
 Feitma's tables and sped up and corrected \code{n_is_prime} and
 \code{n_is_probabprime}. Improvements to \code{n_nextprime} and
 \code{n_isprime}.

--- a/doc/source/ulong_extras.rst
+++ b/doc/source/ulong_extras.rst
@@ -783,10 +783,10 @@ Primality testing
 
     Tests if `n` is a prime. This first sieves for small prime factors,
     then simply calls ``n_is_probabprime()``. This has been checked
-    against the tables of Feitsma and Galway 
-    \url{http://www.cecm.sfu.ca/Pseudoprimes/index-2-to-64.html} and thus 
-    constitutes a check for primality (rather than just pseudoprimality) 
-    up to `2^64`.
+    against the tables of Feitsma and Galway
+    \url{http://www.cecm.sfu.ca/Pseudoprimes/index-2-to-64.html} and thus
+    constitutes a check for primality (rather than just pseudoprimality)
+    up to `2^{64}`.
 
     In future, this test may produce and check a certificate of 
     primality. This is likely to be significantly slower for prime
@@ -855,7 +855,7 @@ Primality testing
 
     There are no known counterexamples to this being a primality test.
 
-    Up to `2^64` the test we use has been checked against tables of 
+    Up to `2^{64}` the test we use has been checked against tables of
     pseudoprimes. Thus it is a primality test up to this limit.
 
 .. function:: int n_is_probabprime_lucas(ulong n)
@@ -883,7 +883,7 @@ Primality testing
     calling the function ``n_is_probabprime_BPSW()``. There are no known 
     counterexamples, and it has been checked against the tables of Feitsma
     and Galway and up to the accuracy of those tables, this is an exhaustive
-    check up to `2^64`, i.e. there are no counterexamples.
+    check up to `2^{64}`, i.e. there are no counterexamples.
 
 
 Square root and perfect power testing


### PR DESCRIPTION
My editor automatically removed spaces at end-of-line, tell me if I should revert that part. Otherwise, the diff is best seen with the "Hide whitespace changes" option.