### PR TITLE
flush standard output in flint_memory_error

### DIFF
--- a/memory_manager.c
+++ b/memory_manager.c
@@ -49,6 +49,7 @@ void __flint_set_memory_functions_init()
 static void flint_memory_error(size_t size)
 {
     flint_printf("Exception (FLINT memory_manager). Unable to allocate memory (%ld).\n", size);
+    fflush(stdout);
     flint_abort();
 }
 


### PR DESCRIPTION
See https://trac.sagemath.org/ticket/28334: when FLINT is used in Sage, without flushing stdout, the printed error message can sometimes appear at pseudo-random times.