### PR TITLE
New function poly_factor_split_single

### DIFF
--- a/doc/source/fq_nmod_poly_factor.rst
+++ b/doc/source/fq_nmod_poly_factor.rst
@@ -138,7 +138,7 @@ Factorisation
 .. function:: void fq_nmod_poly_factor_split_single(fq_nmod_poly_t linfactor, const fq_nmod_poly_t input, const fq_nmod_ctx_t ctx)
 
     Assuming ``input`` is a product of factors all of degree 1, finds a single
-    factor of ``input`` and places it in ``linfactor``.
+    linear factor of ``input`` and places it in ``linfactor``.
     Requires that ``input`` be monic and non-constant.
 
 .. function:: void fq_nmod_poly_factor_distinct_deg(fq_nmod_poly_factor_t res, const fq_nmod_poly_t poly, slong * const *degs, const fq_nmod_ctx_t ctx)

--- a/doc/source/fq_nmod_poly_factor.rst
+++ b/doc/source/fq_nmod_poly_factor.rst
@@ -135,6 +135,12 @@ Factorisation
     factors.  Requires that ``pol`` be monic, non-constant and
     squarefree.
 
+.. function:: void fq_nmod_poly_factor_split_single(fq_nmod_poly_t linfactor, const fq_nmod_poly_t input, const fq_nmod_ctx_t ctx)
+
+    Assuming ``input`` is a product of factors all of degree 1, finds a single
+    factor of ``input`` and places it in ``linfactor``.
+    Requires that ``input`` be monic and non-constant.
+
 .. function:: void fq_nmod_poly_factor_distinct_deg(fq_nmod_poly_factor_t res, const fq_nmod_poly_t poly, slong * const *degs, const fq_nmod_ctx_t ctx)
 
     Factorises a monic non-constant squarefree polymnomial ``poly``

--- a/doc/source/fq_poly_factor.rst
+++ b/doc/source/fq_poly_factor.rst
@@ -88,7 +88,6 @@ Basic Operations
 Irreducibility Testing
 --------------------------------------------------------------------------------
 
-
 .. function:: int fq_poly_is_irreducible(const fq_poly_t f, const fq_ctx_t ctx)
 
     Returns 1 if the polynomial ``f`` is irreducible, otherwise returns 0.
@@ -135,6 +134,12 @@ Factorisation
     degree ``d``, finds all those factors and places them in
     factors.  Requires that ``pol`` be monic, non-constant and
     squarefree.
+
+.. function:: void fq_poly_factor_split_single(fq_poly_t linfactor, const fq_poly_t input, const fq_ctx_t ctx)
+
+    Assuming ``input`` is a product of factors all of degree 1, finds a single
+    factor of ``input`` and places it in ``linfactor``.
+    Requires that ``input`` be monic and non-constant.
 
 .. function:: void fq_poly_factor_distinct_deg(fq_poly_factor_t res, const fq_poly_t poly, slong * const *degs, const fq_ctx_t ctx)
 

--- a/doc/source/fq_poly_factor.rst
+++ b/doc/source/fq_poly_factor.rst
@@ -138,7 +138,7 @@ Factorisation
 .. function:: void fq_poly_factor_split_single(fq_poly_t linfactor, const fq_poly_t input, const fq_ctx_t ctx)
 
     Assuming ``input`` is a product of factors all of degree 1, finds a single
-    factor of ``input`` and places it in ``linfactor``.
+    linear factor of ``input`` and places it in ``linfactor``.
     Requires that ``input`` be monic and non-constant.
 
 .. function:: void fq_poly_factor_distinct_deg(fq_poly_factor_t res, const fq_poly_t poly, slong * const *degs, const fq_ctx_t ctx)

--- a/doc/source/fq_zech_poly_factor.rst
+++ b/doc/source/fq_zech_poly_factor.rst
@@ -138,7 +138,7 @@ Factorisation
 .. function:: void fq_zech_poly_factor_split_single(fq_zech_poly_t linfactor, const fq_zech_poly_t input, const fq_zech_ctx_t ctx)
 
     Assuming ``input`` is a product of factors all of degree 1, finds a single
-    factor of ``input`` and places it in ``linfactor``.
+    linear factor of ``input`` and places it in ``linfactor``.
     Requires that ``input`` be monic and non-constant.
 
 .. function:: void fq_zech_poly_factor_distinct_deg(fq_zech_poly_factor_t res, const fq_zech_poly_t poly, slong * const *degs, const fq_zech_ctx_t ctx)

--- a/doc/source/fq_zech_poly_factor.rst
+++ b/doc/source/fq_zech_poly_factor.rst
@@ -135,6 +135,12 @@ Factorisation
     factors.  Requires that ``pol`` be monic, non-constant and
     squarefree.
 
+.. function:: void fq_zech_poly_factor_split_single(fq_zech_poly_t linfactor, const fq_zech_poly_t input, const fq_zech_ctx_t ctx)
+
+    Assuming ``input`` is a product of factors all of degree 1, finds a single
+    factor of ``input`` and places it in ``linfactor``.
+    Requires that ``input`` be monic and non-constant.
+
 .. function:: void fq_zech_poly_factor_distinct_deg(fq_zech_poly_factor_t res, const fq_zech_poly_t poly, slong * const *degs, const fq_zech_ctx_t ctx)
 
     Factorises a monic non-constant squarefree polymnomial ``poly``

--- a/fq_nmod_poly_factor/factor_split_single.c
+++ b/fq_nmod_poly_factor/factor_split_single.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2013 Mike Hansen
+    Copyright (C) 2019 Edouard Rousseau
 
     This file is part of FLINT.
 
@@ -20,4 +20,3 @@
 #include "fq_poly_factor_templates/factor_split_single.c"
 #undef CAP_T
 #undef T
-

--- a/fq_nmod_poly_factor/factor_split_single.c
+++ b/fq_nmod_poly_factor/factor_split_single.c
@@ -1,0 +1,23 @@
+/*
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fq_nmod_poly.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq_nmod
+#define CAP_T FQ_NMOD
+#include "fq_poly_factor_templates/factor_split_single.c"
+#undef CAP_T
+#undef T
+

--- a/fq_nmod_poly_factor/test/t-factor_split_single.c
+++ b/fq_nmod_poly_factor/test/t-factor_split_single.c
@@ -1,0 +1,28 @@
+/*
+    Copyright (C) 2007 David Howden
+    Copyright (C) 2007, 2008, 2009, 2010 William Hart
+    Copyright (C) 2008 Richard Howell-Peak
+    Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fq_nmod_poly.h"
+
+
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq_nmod
+#define CAP_T FQ_NMOD
+#include "fq_poly_factor_templates/test/t-factor_split_single.c"
+#undef CAP_T
+#undef T

--- a/fq_nmod_poly_factor/test/t-factor_split_single.c
+++ b/fq_nmod_poly_factor/test/t-factor_split_single.c
@@ -1,9 +1,5 @@
 /*
-    Copyright (C) 2007 David Howden
-    Copyright (C) 2007, 2008, 2009, 2010 William Hart
-    Copyright (C) 2008 Richard Howell-Peak
-    Copyright (C) 2011 Fredrik Johansson
-    Copyright (C) 2013 Mike Hansen
+    Copyright (C) 2019 Edouard Rousseau
 
     This file is part of FLINT.
 
@@ -14,8 +10,6 @@
 */
 
 #include "fq_nmod_poly.h"
-
-
 
 #ifdef T
 #undef T

--- a/fq_poly_factor/factor_split_single.c
+++ b/fq_poly_factor/factor_split_single.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2013 Mike Hansen
+    Copyright (C) 2019 Edouard Rousseau
 
     This file is part of FLINT.
 
@@ -20,4 +20,3 @@
 #include "fq_poly_factor_templates/factor_split_single.c"
 #undef CAP_T
 #undef T
-

--- a/fq_poly_factor/factor_split_single.c
+++ b/fq_poly_factor/factor_split_single.c
@@ -1,0 +1,23 @@
+/*
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fq_poly.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq
+#define CAP_T FQ
+#include "fq_poly_factor_templates/factor_split_single.c"
+#undef CAP_T
+#undef T
+

--- a/fq_poly_factor/test/t-factor_split_single.c
+++ b/fq_poly_factor/test/t-factor_split_single.c
@@ -1,9 +1,5 @@
 /*
-    Copyright (C) 2007 David Howden
-    Copyright (C) 2007, 2008, 2009, 2010 William Hart
-    Copyright (C) 2008 Richard Howell-Peak
-    Copyright (C) 2011 Fredrik Johansson
-    Copyright (C) 2013 Mike Hansen
+    Copyright (C) 2019 Edouard Rousseau
 
     This file is part of FLINT.
 
@@ -14,8 +10,6 @@
 */
 
 #include "fq_poly.h"
-
-
 
 #ifdef T
 #undef T

--- a/fq_poly_factor/test/t-factor_split_single.c
+++ b/fq_poly_factor/test/t-factor_split_single.c
@@ -1,0 +1,28 @@
+/*
+    Copyright (C) 2007 David Howden
+    Copyright (C) 2007, 2008, 2009, 2010 William Hart
+    Copyright (C) 2008 Richard Howell-Peak
+    Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fq_poly.h"
+
+
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq
+#define CAP_T FQ
+#include "fq_poly_factor_templates/test/t-factor_split_single.c"
+#undef CAP_T
+#undef T

--- a/fq_poly_factor_templates.h
+++ b/fq_poly_factor_templates.h
@@ -139,6 +139,10 @@ FLINT_DLL void TEMPLATE(T, poly_iterated_frobenius_preinv)(TEMPLATE(T, poly_t)* 
                                             const TEMPLATE(T, poly_t) vinv,
                                             const TEMPLATE(T, ctx_t) ctx);
 
+FLINT_DLL void TEMPLATE(T, poly_factor_split_single)(TEMPLATE(T, poly_t) linfactor,
+                                            const TEMPLATE(T, poly_t) input,
+                                            const TEMPLATE(T, ctx_t) ctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/fq_poly_factor_templates/factor_split_single.c
+++ b/fq_poly_factor_templates/factor_split_single.c
@@ -1,0 +1,84 @@
+/*
+    Copyright (C) 2007 David Howden
+    Copyright (C) 2007, 2008, 2009, 2010 William Hart
+    Copyright (C) 2008 Richard Howell-Peak
+    Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef T
+
+#include "templates.h"
+
+void
+TEMPLATE(T, poly_factor_split_single) (TEMPLATE(T, poly_t) linfactor,
+                          const TEMPLATE(T, poly_t) input,
+                          const TEMPLATE(T, ctx_t) ctx)
+{
+    if (input->length == 2)
+    {
+        TEMPLATE(T, poly_set) (linfactor, input, ctx);
+    }
+    else
+    {
+        flint_rand_t state;
+        ulong deflation;
+        TEMPLATE(T, poly_t) pol;
+
+        flint_randinit(state);
+        TEMPLATE(T, poly_init) (pol, ctx);
+        TEMPLATE(T, poly_set) (linfactor, input, ctx);
+        deflation = TEMPLATE(T, poly_deflation) (input, ctx);
+
+        if (deflation == 1 || deflation == TEMPLATE(T, poly_degree)(input, ctx))
+        {
+            TEMPLATE(T, poly_set) (pol, input, ctx);
+
+            while (TEMPLATE(T, poly_degree)(linfactor, ctx) != 1) {
+                while (!TEMPLATE(T, poly_factor_equal_deg_prob)
+                       (linfactor, state, pol, 1, ctx))
+                {
+                };
+                TEMPLATE(T, poly_set) (pol, linfactor, ctx);
+            }   
+
+        }
+        else
+        {
+            TEMPLATE(T, poly_deflate) (pol, input, deflation, ctx);
+
+            while (TEMPLATE(T, poly_degree)(pol, ctx) != 1) {
+                while (!TEMPLATE(T, poly_factor_equal_deg_prob)
+                       (linfactor, state, pol, 1, ctx))
+                {
+                };
+                TEMPLATE(T, poly_set) (pol, linfactor, ctx);
+            }   
+            
+            TEMPLATE(T, poly_inflate) (pol, linfactor, deflation, ctx);
+
+            while (TEMPLATE(T, poly_degree)(pol, ctx) != 1) {
+                while (!TEMPLATE(T, poly_factor_equal_deg_prob)
+                       (linfactor, state, pol, 1, ctx))
+                {
+                };
+                TEMPLATE(T, poly_set) (pol, linfactor, ctx);
+            }   
+
+        }
+
+        flint_randclear(state);
+        TEMPLATE(T, poly_clear) (pol, ctx);
+
+    }
+}
+
+#endif
+

--- a/fq_poly_factor_templates/factor_split_single.c
+++ b/fq_poly_factor_templates/factor_split_single.c
@@ -1,9 +1,5 @@
 /*
-    Copyright (C) 2007 David Howden
-    Copyright (C) 2007, 2008, 2009, 2010 William Hart
-    Copyright (C) 2008 Richard Howell-Peak
-    Copyright (C) 2011 Fredrik Johansson
-    Copyright (C) 2013 Mike Hansen
+    Copyright (C) 2019 Edouard Rousseau
 
     This file is part of FLINT.
 
@@ -48,7 +44,6 @@ TEMPLATE(T, poly_factor_split_single) (TEMPLATE(T, poly_t) linfactor,
                 };
                 TEMPLATE(T, poly_set) (pol, linfactor, ctx);
             }   
-
         }
         else
         {
@@ -71,14 +66,10 @@ TEMPLATE(T, poly_factor_split_single) (TEMPLATE(T, poly_t) linfactor,
                 };
                 TEMPLATE(T, poly_set) (pol, linfactor, ctx);
             }   
-
         }
 
         flint_randclear(state);
         TEMPLATE(T, poly_clear) (pol, ctx);
-
     }
 }
-
 #endif
-

--- a/fq_poly_factor_templates/test/t-factor_split_single.c
+++ b/fq_poly_factor_templates/test/t-factor_split_single.c
@@ -1,0 +1,85 @@
+/*
+    Copyright (C) 2007 David Howden
+    Copyright (C) 2007, 2008, 2009, 2010 William Hart
+    Copyright (C) 2008 Richard Howell-Peak
+    Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef T
+
+#include "templates.h"
+
+int
+main(void)
+{
+    int iter;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("factor_split_single....");
+    fflush(stdout);
+
+    /* Compute a random spliting polynomial then check factorization */
+    for (iter = 0; iter < 100 * flint_test_multiplier(); iter++)
+    {
+
+        int len;
+        TEMPLATE(T, ctx_t) ctx;
+        TEMPLATE(T, poly_t) a, b, q, r;
+
+        len = n_randint(state, 15) + 1;
+        TEMPLATE(T, ctx_randtest) (ctx, state);
+        TEMPLATE(T, poly_init) (a, ctx);
+        TEMPLATE(T, poly_init) (b, ctx);
+        TEMPLATE(T, poly_init) (q, ctx);
+        TEMPLATE(T, poly_init) (r, ctx);
+
+        TEMPLATE(T, poly_randtest_monic) (a, state, 2, ctx);
+
+        /* random polynomial of degree len */
+        while (TEMPLATE(T, poly_degree) (a, ctx) < len)
+        {
+            TEMPLATE(T, poly_randtest_monic) (b, state, 2, ctx);
+            TEMPLATE(T, poly_mul)(a, a, b, ctx);
+        }
+
+        /* b should be a factor of a */
+        TEMPLATE(T, poly_factor_split_single) (b, a, ctx);
+
+        /* check that b divides a */
+        TEMPLATE(T, poly_divrem) (q, r, a, b, ctx);
+        if (!TEMPLATE(T, poly_is_zero) (r, ctx))
+        {
+            flint_printf("FAIL:\n");
+            flint_printf
+                ("Error: factor does not divide original polynomial\n");
+            flint_printf("factor:\n");
+            TEMPLATE(T, poly_print) (b, ctx);
+            flint_printf("\n\n");
+            flint_printf("polynomial:\n");
+            TEMPLATE(T, poly_print) (a, ctx);
+            flint_printf("\n\n");
+            abort();
+        }
+
+        TEMPLATE(T, poly_clear) (a, ctx);
+        TEMPLATE(T, poly_clear) (b, ctx);
+        TEMPLATE(T, poly_clear) (q, ctx);
+        TEMPLATE(T, poly_clear) (r, ctx);
+
+        TEMPLATE(T, ctx_clear) (ctx);
+    }
+    FLINT_TEST_CLEANUP(state);
+    flint_printf("PASS\n");
+    return 0;
+}
+
+
+#endif

--- a/fq_poly_factor_templates/test/t-factor_split_single.c
+++ b/fq_poly_factor_templates/test/t-factor_split_single.c
@@ -1,9 +1,5 @@
 /*
-    Copyright (C) 2007 David Howden
-    Copyright (C) 2007, 2008, 2009, 2010 William Hart
-    Copyright (C) 2008 Richard Howell-Peak
-    Copyright (C) 2011 Fredrik Johansson
-    Copyright (C) 2013 Mike Hansen
+    Copyright (C) 2019 Edouard Rousseau
 
     This file is part of FLINT.
 
@@ -29,7 +25,6 @@ main(void)
     /* Compute a random spliting polynomial then check factorization */
     for (iter = 0; iter < 100 * flint_test_multiplier(); iter++)
     {
-
         int len;
         TEMPLATE(T, ctx_t) ctx;
         TEMPLATE(T, poly_t) a, b, q, r;
@@ -41,9 +36,10 @@ main(void)
         TEMPLATE(T, poly_init) (q, ctx);
         TEMPLATE(T, poly_init) (r, ctx);
 
+        /* random splitting monic polynomial of degree len */
+
         TEMPLATE(T, poly_randtest_monic) (a, state, 2, ctx);
 
-        /* random polynomial of degree len */
         while (TEMPLATE(T, poly_degree) (a, ctx) < len)
         {
             TEMPLATE(T, poly_randtest_monic) (b, state, 2, ctx);
@@ -80,6 +76,4 @@ main(void)
     flint_printf("PASS\n");
     return 0;
 }
-
-
 #endif

--- a/fq_zech_poly_factor/factor_split_single.c
+++ b/fq_zech_poly_factor/factor_split_single.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2013 Mike Hansen
+    Copyright (C) 2019 Edouard Rousseau
 
     This file is part of FLINT.
 
@@ -20,4 +20,3 @@
 #include "fq_poly_factor_templates/factor_split_single.c"
 #undef CAP_T
 #undef T
-

--- a/fq_zech_poly_factor/factor_split_single.c
+++ b/fq_zech_poly_factor/factor_split_single.c
@@ -1,0 +1,23 @@
+/*
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fq_zech_poly.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq_zech
+#define CAP_T FQ_ZECH
+#include "fq_poly_factor_templates/factor_split_single.c"
+#undef CAP_T
+#undef T
+

--- a/fq_zech_poly_factor/test/t-factor_split_single.c
+++ b/fq_zech_poly_factor/test/t-factor_split_single.c
@@ -1,0 +1,28 @@
+/*
+    Copyright (C) 2007 David Howden
+    Copyright (C) 2007, 2008, 2009, 2010 William Hart
+    Copyright (C) 2008 Richard Howell-Peak
+    Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fq_zech_poly.h"
+
+
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq_zech
+#define CAP_T FQ_ZECH
+#include "fq_poly_factor_templates/test/t-factor_split_single.c"
+#undef CAP_T
+#undef T

--- a/fq_zech_poly_factor/test/t-factor_split_single.c
+++ b/fq_zech_poly_factor/test/t-factor_split_single.c
@@ -1,9 +1,5 @@
 /*
-    Copyright (C) 2007 David Howden
-    Copyright (C) 2007, 2008, 2009, 2010 William Hart
-    Copyright (C) 2008 Richard Howell-Peak
-    Copyright (C) 2011 Fredrik Johansson
-    Copyright (C) 2013 Mike Hansen
+    Copyright (C) 2019 Edouard Rousseau
 
     This file is part of FLINT.
 
@@ -14,8 +10,6 @@
 */
 
 #include "fq_zech_poly.h"
-
-
 
 #ifdef T
 #undef T


### PR DESCRIPTION
I needed a function to find only one factor of a polynomial for which we know there are only linear factors. This is quite specific so I don't know if you want to have it in flint (but I hope you do). 

It uses `factor_poly_equal_degree_prob` and the deflation trick. So it is always as fast as just calling `factor_poly_equal_degree_prob` until you get a degree 1 polynomial, and sometimes it's faster thanks to the trick.

It lacks documentation but I am pushing it for comments.