### PR TITLE
Fix CMake install issue and HAVE_CPU_SET_T issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,9 +75,9 @@ set(HEADERS
 )
 
 foreach (build_dir IN LISTS BUILD_DIRS TEMPLATE_DIRS)
-    file(GLOB TEMP "${build_dir}/*.c")
+    file(GLOB TEMP RELATIVE "${CMAKE_SOURCE_DIR}" "${build_dir}/*.c")
     list(APPEND SOURCES ${TEMP})
-    file(GLOB TEMP "${build_dir}/*.h")
+    file(GLOB TEMP RELATIVE "${CMAKE_SOURCE_DIR}" "${build_dir}/*.h")
     list(APPEND HEADERS ${TEMP})
 endforeach ()
 

--- a/config.h.in
+++ b/config.h.in
@@ -288,7 +288,7 @@
 #cmakedefine WANT_ASSERT
 
 /* Define if you cpu_set_t in sched.h */
-#cmakedefine HAVE_CPU_SET_T
+#cmakedefine01 HAVE_CPU_SET_T
 
 /* Define if your processor stores words with the most significant byte first
    (like Motorola and SPARC, unlike Intel and VAX). */


### PR DESCRIPTION
I'm working on using the trunk branch in Macaulay2. This PR fixes issues that I run into while working on that.

Is `HAVE_CPU_SET_T` expected to be defined on a typical Linux build?

cc: @mikestillman