### PR TITLE
Fix some mpoly div

### DIFF
--- a/fmpz_mpoly/div_monagan_pearce.c
+++ b/fmpz_mpoly/div_monagan_pearce.c
@@ -253,6 +253,7 @@ slong _fmpz_mpoly_div_monagan_pearce1(fmpz ** polyq, ulong ** expq,
             if (ds == FLINT_SIGN_EXT(acc_sm[1]) && d1 < lc_abs)
             {
                 ulong qq, rr, nhi, nlo;
+                FLINT_ASSERT(0 < lc_norm && lc_norm < FLINT_BITS);
                 nhi = (d1 << lc_norm) | (d0 >> (FLINT_BITS - lc_norm));
                 nlo = d0 << lc_norm;
                 udiv_qrnnd_preinv(qq, rr, nhi, nlo, lc_n, lc_i);
@@ -261,10 +262,12 @@ slong _fmpz_mpoly_div_monagan_pearce1(fmpz ** polyq, ulong ** expq,
                 if (qq == 0)
                     continue;
 
-                if ((qq & (WORD(3) << (FLINT_BITS - 2))) == 0)
+                if (qq <= COEFF_MAX)
                 {
                     _fmpz_demote(q_coeff + q_len);
-                    q_coeff[q_len] = (qq^ds^lc_sign) - (ds^lc_sign);
+                    q_coeff[q_len] = qq;
+                    if (ds != lc_sign)
+                        q_coeff[q_len] = -q_coeff[q_len];
                 }
                 else
                 {
@@ -609,32 +612,38 @@ slong _fmpz_mpoly_div_monagan_pearce(fmpz ** polyq,
             if (ds == FLINT_SIGN_EXT(acc_sm[1]) && d1 < lc_abs)
             {
                 ulong qq, rr, nhi, nlo;
+                FLINT_ASSERT(0 < lc_norm && lc_norm < FLINT_BITS);
                 nhi = (d1 << lc_norm) | (d0 >> (FLINT_BITS - lc_norm));
                 nlo = d0 << lc_norm;
                 udiv_qrnnd_preinv(qq, rr, nhi, nlo, lc_n, lc_i);
                 (void) rr;
+
                 if (qq == 0)
-                {
                     continue;
-                }
-                if ((qq & (WORD(3) << (FLINT_BITS - 2))) == 0)
+
+                if (qq <= COEFF_MAX)
                 {
                     _fmpz_demote(q_coeff + q_len);
-                    q_coeff[q_len] = (qq^ds^lc_sign) - (ds^lc_sign);
-                } else
+                    q_coeff[q_len] = qq;
+                    if (ds != lc_sign)
+                        q_coeff[q_len] = -q_coeff[q_len];
+                }
+                else
                 {
                     small = 0;
                     fmpz_set_ui(q_coeff + q_len, qq);
                     if (ds != lc_sign)
                         fmpz_neg(q_coeff + q_len, q_coeff + q_len);
                 }
-            } else
+            }
+            else
             {
                 small = 0;
                 fmpz_set_signed_uiuiui(acc_lg, acc_sm[2], acc_sm[1], acc_sm[0]);
                 goto large_lt_divides;
             }
-        } else
+        }
+        else
         {
             if (fmpz_is_zero(acc_lg))
             {

--- a/fmpz_mpoly/div_monagan_pearce.c
+++ b/fmpz_mpoly/div_monagan_pearce.c
@@ -51,7 +51,7 @@ slong _fmpz_mpoly_div_monagan_pearce1(fmpz ** polyq, ulong ** expq,
     ulong acc_sm[3];
     int lt_divides, small;
     slong bits2, bits3;
-    ulong lc_norm, lc_abs, lc_sign, lc_n, lc_i;
+    ulong lc_norm = 0, lc_abs = 0, lc_sign = 0, lc_n = 0, lc_i = 0;
     TMP_INIT;
 
     TMP_START;
@@ -95,11 +95,14 @@ slong _fmpz_mpoly_div_monagan_pearce1(fmpz ** polyq, ulong ** expq,
     HEAP_ASSIGN(heap[1], exp2[0], x);
 
     /* precompute leading cofficient info assuming "small" case */
-    lc_abs = FLINT_ABS(poly3[0]);
-    lc_sign = FLINT_SIGN_EXT(poly3[0]);
-    count_leading_zeros(lc_norm, lc_abs);
-    lc_n = lc_abs << lc_norm;
-    invert_limb(lc_i, lc_n);
+    if (small)
+    {
+        lc_abs = FLINT_ABS(poly3[0]);
+        lc_sign = FLINT_SIGN_EXT(poly3[0]);
+        count_leading_zeros(lc_norm, lc_abs);
+        lc_n = lc_abs << lc_norm;
+        invert_limb(lc_i, lc_n);
+    }
 
     while (heap_len > 1)
     {
@@ -351,7 +354,7 @@ slong _fmpz_mpoly_div_monagan_pearce(fmpz ** polyq,
     slong * hind;
     int lt_divides, small;
     slong bits2, bits3;
-    ulong lc_norm, lc_abs, lc_sign, lc_n, lc_i;
+    ulong lc_norm = 0, lc_abs = 0, lc_sign = 0, lc_n = 0, lc_i = 0;
     TMP_INIT;
 
     if (N == 1)
@@ -412,12 +415,15 @@ slong _fmpz_mpoly_div_monagan_pearce(fmpz ** polyq,
     heap[1].exp = exp_list[exp_next++];
     mpoly_monomial_set(heap[1].exp, exp2, N);
 
-    /* precompute leading cofficient info assuming "small" case */
-    lc_abs = FLINT_ABS(poly3[0]);
-    lc_sign = FLINT_SIGN_EXT(poly3[0]);
-    count_leading_zeros(lc_norm, lc_abs);
-    lc_n = lc_abs << lc_norm;
-    invert_limb(lc_i, lc_n);
+    /* precompute leading cofficient info in "small" case */
+    if (small)
+    {
+        lc_abs = FLINT_ABS(poly3[0]);
+        lc_sign = FLINT_SIGN_EXT(poly3[0]);
+        count_leading_zeros(lc_norm, lc_abs);
+        lc_n = lc_abs << lc_norm;
+        invert_limb(lc_i, lc_n);
+    }
 
     while (heap_len > 1)
     {

--- a/fmpz_mpoly/divides_heap_threaded.c
+++ b/fmpz_mpoly/divides_heap_threaded.c
@@ -1156,16 +1156,19 @@ slong _fmpz_mpoly_divides_stripe1(
             if (ds == FLINT_SIGN_EXT(acc_sm[1]) && d1 < lc_abs)
             {
                 ulong qq, rr, nhi, nlo;
+                FLINT_ASSERT(0 < lc_norm && lc_norm < FLINT_BITS);
                 nhi = (d1 << lc_norm) | (d0 >> (FLINT_BITS - lc_norm));
                 nlo = d0 << lc_norm;
                 udiv_qrnnd_preinv(qq, rr, nhi, nlo, lc_n, lc_i);
-                if (rr != WORD(0))
+                if (rr != UWORD(0))
                     goto not_exact_division;
 
-                if ((qq & (WORD(3) << (FLINT_BITS - 2))) == WORD(0))
+                if (qq <= COEFF_MAX)
                 {
                     _fmpz_demote(Qcoeff + Qlen);
-                    Qcoeff[Qlen] = (qq^(ds^lc_sign)) - (ds^lc_sign);
+                    Qcoeff[Qlen] = qq;
+                    if (ds != lc_sign)
+                        Qcoeff[Qlen] = -Qcoeff[Qlen];
                 }
                 else
                 {
@@ -1531,16 +1534,19 @@ slong _fmpz_mpoly_divides_stripe(
             if (ds == FLINT_SIGN_EXT(acc_sm[1]) && d1 < lc_abs)
             {
                 ulong qq, rr, nhi, nlo;
+                FLINT_ASSERT(0 < lc_norm && lc_norm < FLINT_BITS);
                 nhi = (d1 << lc_norm) | (d0 >> (FLINT_BITS - lc_norm));
                 nlo = d0 << lc_norm;
                 udiv_qrnnd_preinv(qq, rr, nhi, nlo, lc_n, lc_i);
-                if (rr != WORD(0))
+                if (rr != UWORD(0))
                     goto not_exact_division;
 
-                if ((qq & (WORD(3) << (FLINT_BITS - 2))) == WORD(0))
+                if (qq <= COEFF_MAX)
                 {
                     _fmpz_demote(Qcoeff + Qlen);
-                    Qcoeff[Qlen] = (qq^(ds^lc_sign)) - (ds^lc_sign);
+                    Qcoeff[Qlen] = qq;
+                    if (ds != lc_sign)
+                        Qcoeff[Qlen] = -Qcoeff[Qlen];
                 }
                 else
                 {

--- a/fmpz_mpoly/divides_monagan_pearce.c
+++ b/fmpz_mpoly/divides_monagan_pearce.c
@@ -216,6 +216,7 @@ slong _fmpz_mpoly_divides_monagan_pearce1(fmpz ** poly1, ulong ** exp1,
             if (ds == FLINT_SIGN_EXT(acc_sm[1]) && d1 < lc_abs)
             {
                 ulong qq, rr, nhi, nlo;
+                FLINT_ASSERT(0 < lc_norm && lc_norm < FLINT_BITS);
                 nhi = (d1 << lc_norm) | (d0 >> (FLINT_BITS - lc_norm));
                 nlo = d0 << lc_norm;
                 udiv_qrnnd_preinv(qq, rr, nhi, nlo, lc_n, lc_i);
@@ -536,6 +537,7 @@ slong _fmpz_mpoly_divides_monagan_pearce(fmpz ** poly1, ulong ** exp1,
             if (ds == FLINT_SIGN_EXT(acc_sm[1]) && d1 < lc_abs)
             {
                 ulong qq, rr, nhi, nlo;
+                FLINT_ASSERT(0 < lc_norm && lc_norm < FLINT_BITS);
                 nhi = (d1 << lc_norm) | (d0 >> (FLINT_BITS - lc_norm));
                 nlo = d0 << lc_norm;
                 udiv_qrnnd_preinv(qq, rr, nhi, nlo, lc_n, lc_i);

--- a/fmpz_mpoly/divrem_ideal_monagan_pearce.c
+++ b/fmpz_mpoly/divrem_ideal_monagan_pearce.c
@@ -77,6 +77,8 @@ slong _fmpz_mpoly_divrem_ideal_monagan_pearce1(fmpz_mpoly_struct ** polyq,
     small = FLINT_ABS(bits2) <= (FLINT_ABS(bits3) + FLINT_BIT_COUNT(len3) + FLINT_BITS - 2)
           && FLINT_ABS(bits3) <= FLINT_BITS - 2;
 
+    small = 0;
+
     next_loc = len3 + 4;   /* something bigger than heap can ever be */
     heap = (mpoly_heap1_s *) TMP_ALLOC((len3 + 1)*sizeof(mpoly_heap1_s));
     store = store_base = (slong *) TMP_ALLOC(3*len3*sizeof(mpoly_nheap_t *));
@@ -390,6 +392,8 @@ slong _fmpz_mpoly_divrem_ideal_monagan_pearce(fmpz_mpoly_struct ** polyq,
     small = FLINT_ABS(bits2) <= (FLINT_ABS(bits3) +
            FLINT_BIT_COUNT(len3) + FLINT_BITS - 2) &&
            FLINT_ABS(bits3) <= FLINT_BITS - 2;
+
+    small = 0;
 
     next_loc = len3 + 4;   /* something bigger than heap can ever be */
     heap = (mpoly_heap_s *) TMP_ALLOC((len3 + 1)*sizeof(mpoly_heap_s));

--- a/fmpz_mpoly/divrem_ideal_monagan_pearce.c
+++ b/fmpz_mpoly/divrem_ideal_monagan_pearce.c
@@ -77,8 +77,6 @@ slong _fmpz_mpoly_divrem_ideal_monagan_pearce1(fmpz_mpoly_struct ** polyq,
     small = FLINT_ABS(bits2) <= (FLINT_ABS(bits3) + FLINT_BIT_COUNT(len3) + FLINT_BITS - 2)
           && FLINT_ABS(bits3) <= FLINT_BITS - 2;
 
-    small = 0;
-
     next_loc = len3 + 4;   /* something bigger than heap can ever be */
     heap = (mpoly_heap1_s *) TMP_ALLOC((len3 + 1)*sizeof(mpoly_heap1_s));
     store = store_base = (slong *) TMP_ALLOC(3*len3*sizeof(mpoly_nheap_t *));
@@ -228,7 +226,7 @@ slong _fmpz_mpoly_divrem_ideal_monagan_pearce1(fmpz_mpoly_struct ** polyq,
                             slong r1;
                             slong tq;
                             sdiv_qrnnd(tq, r1, c[1], c[0], mb[w]);
-                            if (COEFF_IS_MPZ(FLINT_ABS(tq))) /* quotient too large */
+                            if (tq > COEFF_MAX || tq < COEFF_MIN)
                             {
                                 small = 0;
                                 fmpz_set_signed_uiuiui(qc, c[2], c[1], c[0]);
@@ -244,7 +242,7 @@ slong _fmpz_mpoly_divrem_ideal_monagan_pearce1(fmpz_mpoly_struct ** polyq,
                                     polyq[w]->exps[k[w]] = texp;
                                 }
                                 c[0] = r1;
-                                c[2] = c[1] = r1 < 0 ? ~WORD(0) : WORD(0);
+                                c[2] = c[1] = -(slong)(r1 < 0);
                             }
                         }
                     } 
@@ -392,8 +390,6 @@ slong _fmpz_mpoly_divrem_ideal_monagan_pearce(fmpz_mpoly_struct ** polyq,
     small = FLINT_ABS(bits2) <= (FLINT_ABS(bits3) +
            FLINT_BIT_COUNT(len3) + FLINT_BITS - 2) &&
            FLINT_ABS(bits3) <= FLINT_BITS - 2;
-
-    small = 0;
 
     next_loc = len3 + 4;   /* something bigger than heap can ever be */
     heap = (mpoly_heap_s *) TMP_ALLOC((len3 + 1)*sizeof(mpoly_heap_s));
@@ -578,7 +574,7 @@ slong _fmpz_mpoly_divrem_ideal_monagan_pearce(fmpz_mpoly_struct ** polyq,
                             slong r1;
                             slong tq;
                             sdiv_qrnnd(tq, r1, c[1], c[0], mb[w]);
-                            if (COEFF_IS_MPZ(FLINT_ABS(tq))) /* quotient too large */
+                            if (tq > COEFF_MAX || tq < COEFF_MIN)
                             {
                                 small = 0;
                                 fmpz_set_signed_uiuiui(qc, c[2], c[1], c[0]);
@@ -594,7 +590,7 @@ slong _fmpz_mpoly_divrem_ideal_monagan_pearce(fmpz_mpoly_struct ** polyq,
                                     mpoly_monomial_set(polyq[w]->exps + k[w]*N, texp, N);
                                 }
                                 c[0] = r1;
-                                c[2] = c[1] = r1 < 0 ? ~WORD(0) : WORD(0);
+                                c[2] = c[1] = -(slong)(r1 < 0);
                             }
                         }
                     } 

--- a/fmpz_mpoly/divrem_monagan_pearce.c
+++ b/fmpz_mpoly/divrem_monagan_pearce.c
@@ -55,7 +55,7 @@ slong _fmpz_mpoly_divrem_monagan_pearce1(slong * lenr,
     ulong acc_sm[3];
     int lt_divides, small;
     slong bits2, bits3;
-    ulong lc_norm, lc_abs, lc_sign, lc_n, lc_i;
+    ulong lc_norm = 0, lc_abs = 0, lc_sign = 0, lc_n = 0, lc_i = 0;
     TMP_INIT;
 
     TMP_START;
@@ -100,12 +100,15 @@ slong _fmpz_mpoly_divrem_monagan_pearce1(slong * lenr,
     x->next = NULL;
     HEAP_ASSIGN(heap[1], exp2[0], x);
 
-    /* precompute leading cofficient info assuming "small" case */
-    lc_abs = FLINT_ABS(poly3[0]);
-    lc_sign = FLINT_SIGN_EXT(poly3[0]);
-    count_leading_zeros(lc_norm, lc_abs);
-    lc_n = lc_abs << lc_norm;
-    invert_limb(lc_i, lc_n);
+    /* precompute leading cofficient info in "small" case */
+    if (small)
+    {
+        lc_abs = FLINT_ABS(poly3[0]);
+        lc_sign = FLINT_SIGN_EXT(poly3[0]);
+        count_leading_zeros(lc_norm, lc_abs);
+        lc_n = lc_abs << lc_norm;
+        invert_limb(lc_i, lc_n);
+    }
 
     while (heap_len > 1)
     {
@@ -367,7 +370,7 @@ slong _fmpz_mpoly_divrem_monagan_pearce(slong * lenr,
     slong * hind;
     int lt_divides, small;
     slong bits2, bits3;
-    ulong lc_norm, lc_abs, lc_sign, lc_n, lc_i;
+    ulong lc_norm = 0, lc_abs = 0, lc_sign = 0, lc_n = 0, lc_i = 0;
     TMP_INIT;
 
     if (N == 1)
@@ -431,12 +434,15 @@ slong _fmpz_mpoly_divrem_monagan_pearce(slong * lenr,
     heap[1].exp = exp_list[exp_next++];
     mpoly_monomial_set(heap[1].exp, exp2, N);
 
-    /* precompute leading cofficient info assuming "small" case */
-    lc_abs = FLINT_ABS(poly3[0]);
-    lc_sign = FLINT_SIGN_EXT(poly3[0]);
-    count_leading_zeros(lc_norm, lc_abs);
-    lc_n = lc_abs << lc_norm;
-    invert_limb(lc_i, lc_n);
+    /* precompute leading cofficient info in "small" case */
+    if (small)
+    {
+        lc_abs = FLINT_ABS(poly3[0]);
+        lc_sign = FLINT_SIGN_EXT(poly3[0]);
+        count_leading_zeros(lc_norm, lc_abs);
+        lc_n = lc_abs << lc_norm;
+        invert_limb(lc_i, lc_n);
+    }
    
     while (heap_len > 1)
     {

--- a/fmpz_mpoly/divrem_monagan_pearce.c
+++ b/fmpz_mpoly/divrem_monagan_pearce.c
@@ -236,6 +236,7 @@ slong _fmpz_mpoly_divrem_monagan_pearce1(slong * lenr,
             if (ds == FLINT_SIGN_EXT(acc_sm[1]) && d1 < lc_abs)
             {
                 ulong qq, rr, nhi, nlo;
+                FLINT_ASSERT(0 < lc_norm && lc_norm < FLINT_BITS);
                 nhi = (d1 << lc_norm) | (d0 >> (FLINT_BITS - lc_norm));
                 nlo = d0 << lc_norm;
                 udiv_qrnnd_preinv(qq, rr, nhi, nlo, lc_n, lc_i);
@@ -243,33 +244,40 @@ slong _fmpz_mpoly_divrem_monagan_pearce1(slong * lenr,
                 if (rr != 0)
                 {
                     _fmpz_mpoly_fit_length(&r_coeff, &r_exp, allocr, r_len + 1, 1);
-                    fmpz_set_si(r_coeff + r_len, (rr^ds) - ds);
+                    if (ds == 0)
+                        fmpz_set_si(r_coeff + r_len, rr);
+                    else
+                        fmpz_neg_ui(r_coeff + r_len, rr);
                     r_exp[r_len] = exp;
                     r_len++;
                 }
+
                 if (qq == 0)
-                {
                     continue;
-                }
-                if ((qq & (WORD(3) << (FLINT_BITS - 2))) == 0)
+
+                if (qq <= COEFF_MAX)
                 {
                     _fmpz_demote(q_coeff + q_len);
-                    q_coeff[q_len] = (qq^ds^lc_sign) - (ds^lc_sign);
-                } else
+                    q_coeff[q_len] = qq;
+                    if (ds != lc_sign)
+                        q_coeff[q_len] = -q_coeff[q_len];
+                }
+                else
                 {
                     small = 0;
                     fmpz_set_ui(q_coeff + q_len, qq);
                     if (ds != lc_sign)
                         fmpz_neg(q_coeff + q_len, q_coeff + q_len);
                 }
-            } else
+            }
+            else
             {
                 small = 0;
                 fmpz_set_signed_uiuiui(acc_lg, acc_sm[2], acc_sm[1], acc_sm[0]);
                 goto large_lt_divides;
             }
-
-        } else
+        }
+        else
         {
             if (fmpz_is_zero(acc_lg))
             {
@@ -601,6 +609,7 @@ slong _fmpz_mpoly_divrem_monagan_pearce(slong * lenr,
             if (ds == FLINT_SIGN_EXT(acc_sm[1]) && d1 < lc_abs)
             {
                 ulong qq, rr, nhi, nlo;
+                FLINT_ASSERT(0 < lc_norm && lc_norm < FLINT_BITS);
                 nhi = (d1 << lc_norm) | (d0 >> (FLINT_BITS - lc_norm));
                 nlo = d0 << lc_norm;
                 udiv_qrnnd_preinv(qq, rr, nhi, nlo, lc_n, lc_i);
@@ -608,33 +617,40 @@ slong _fmpz_mpoly_divrem_monagan_pearce(slong * lenr,
                 if (rr != 0)
                 {
                     _fmpz_mpoly_fit_length(&r_coeff, &r_exp, allocr, r_len + 1, N);
-                    fmpz_set_si(r_coeff + r_len, (rr^ds) - ds);
+                    if (ds == 0)
+                        fmpz_set_ui(r_coeff + r_len, rr);
+                    else
+                        fmpz_neg_ui(r_coeff + r_len, rr);
                     mpoly_monomial_set(r_exp + r_len*N, exp, N);
                     r_len++;
                 }
+
                 if (qq == 0)
-                {
                     continue;
-                }
-                if ((qq & (WORD(3) << (FLINT_BITS - 2))) == 0)
+
+                if (qq <= COEFF_MAX)
                 {
                     _fmpz_demote(q_coeff + q_len);
-                    q_coeff[q_len] = (qq^ds^lc_sign) - (ds^lc_sign);
-                } else
+                    q_coeff[q_len] = qq;
+                    if (ds != lc_sign)
+                        q_coeff[q_len] = -q_coeff[q_len];
+                }
+                else
                 {
                     small = 0;
                     fmpz_set_ui(q_coeff + q_len, qq);
                     if (ds != lc_sign)
                         fmpz_neg(q_coeff + q_len, q_coeff + q_len);
                 }
-            } else
+            }
+            else
             {
                 small = 0;
                 fmpz_set_signed_uiuiui(acc_lg, acc_sm[2], acc_sm[1], acc_sm[0]);
                 goto large_lt_divides;
             }
-
-        } else
+        }
+        else
         {
             if (fmpz_is_zero(acc_lg))
             {

--- a/fmpz_mpoly/quasidiv_heap.c
+++ b/fmpz_mpoly/quasidiv_heap.c
@@ -30,7 +30,7 @@ slong _fmpz_mpoly_quasidiv_heap1(fmpz_t scale,
     ulong * q_exp = *expq;
     ulong acc_sm[3]; /* for accumulating coefficients */
     ulong mask, exp;
-    ulong lc_norm, lc_abs, lc_sign, lc_n, lc_i;
+    ulong lc_norm = 0, lc_abs = 0, lc_sign = 0, lc_n = 0, lc_i = 0;
     fmpz_t lc_abs_lg, ns, gcd, acc_lg, r, tp;
     slong bits2, bits3;
     int lt_divides, scale_is_one, small;
@@ -83,11 +83,14 @@ slong _fmpz_mpoly_quasidiv_heap1(fmpz_t scale,
 
     /* precompute leading cofficient info */
     fmpz_abs(lc_abs_lg, poly3 + 0);
-    lc_abs = FLINT_ABS(poly3[0]);
-    lc_sign = FLINT_SIGN_EXT(poly3[0]);
-    count_leading_zeros(lc_norm, lc_abs);
-    lc_n = lc_abs << lc_norm;
-    invert_limb(lc_i, lc_n);
+    if (small)
+    {
+        lc_abs = FLINT_ABS(poly3[0]);
+        lc_sign = FLINT_SIGN_EXT(poly3[0]);
+        count_leading_zeros(lc_norm, lc_abs);
+        lc_n = lc_abs << lc_norm;
+        invert_limb(lc_i, lc_n);
+    }
 
     while (heap_len > 1)
     {
@@ -387,7 +390,7 @@ slong _fmpz_mpoly_quasidiv_heap(fmpz_t scale,
     ulong acc_sm[3]; /* for accumulating coefficients */
     slong exp_next;
     ulong mask;
-    ulong lc_norm, lc_abs, lc_sign, lc_n, lc_i;
+    ulong lc_norm = 0, lc_abs = 0, lc_sign = 0, lc_n = 0, lc_i = 0;
     fmpz_t lc_abs_lg, ns, gcd, acc_lg, r, tp;
     slong bits2, bits3;
     int lt_divides, scale_is_one, small;
@@ -463,11 +466,14 @@ slong _fmpz_mpoly_quasidiv_heap(fmpz_t scale,
 
     /* precompute leading cofficient info */
     fmpz_abs(lc_abs_lg, poly3 + 0);
-    lc_abs = FLINT_ABS(poly3[0]);
-    lc_sign = FLINT_SIGN_EXT(poly3[0]);
-    count_leading_zeros(lc_norm, lc_abs);
-    lc_n = lc_abs << lc_norm;
-    invert_limb(lc_i, lc_n);
+    if (small)
+    {
+        lc_abs = FLINT_ABS(poly3[0]);
+        lc_sign = FLINT_SIGN_EXT(poly3[0]);
+        count_leading_zeros(lc_norm, lc_abs);
+        lc_n = lc_abs << lc_norm;
+        invert_limb(lc_i, lc_n);
+    }
 
     while (heap_len > 1)
     {

--- a/fmpz_mpoly/quasidiv_heap.c
+++ b/fmpz_mpoly/quasidiv_heap.c
@@ -277,6 +277,7 @@ slong _fmpz_mpoly_quasidiv_heap1(fmpz_t scale,
             if (ds == FLINT_SIGN_EXT(acc_sm[1]) && d1 < lc_abs)
             {
                 ulong qq, rr, nhi, nlo;
+                FLINT_ASSERT(0 < lc_norm && lc_norm < FLINT_BITS);
                 nhi = (d1 << lc_norm) | (d0 >> (FLINT_BITS - lc_norm));
                 nlo = d0 << lc_norm;
                 udiv_qrnnd_preinv(qq, rr, nhi, nlo, lc_n, lc_i);
@@ -691,6 +692,7 @@ slong _fmpz_mpoly_quasidiv_heap(fmpz_t scale,
             if (ds == FLINT_SIGN_EXT(acc_sm[1]) && d1 < lc_abs)
             {
                 ulong qq, rr, nhi, nlo;
+                FLINT_ASSERT(0 < lc_norm && lc_norm < FLINT_BITS);
                 nhi = (d1 << lc_norm) | (d0 >> (FLINT_BITS - lc_norm));
                 nlo = d0 << lc_norm;
                 udiv_qrnnd_preinv(qq, rr, nhi, nlo, lc_n, lc_i);

--- a/fmpz_mpoly/quasidivrem_heap.c
+++ b/fmpz_mpoly/quasidivrem_heap.c
@@ -38,7 +38,7 @@ slong _fmpz_mpoly_quasidivrem_heap1(fmpz_t scale, slong * lenr,
     ulong * r_exp = *expr;
     ulong acc_sm[3]; /* for accumulating coefficients */
     ulong mask, exp;
-    ulong lc_norm, lc_abs, lc_sign, lc_n, lc_i;
+    ulong lc_norm = 0, lc_abs = 0, lc_sign = 0, lc_n = 0, lc_i = 0;
     fmpz_t lc_abs_lg, ns, gcd, acc_lg, r, tp;
     slong bits2, bits3;
     int lt_divides, scaleis1, small;
@@ -93,11 +93,14 @@ slong _fmpz_mpoly_quasidivrem_heap1(fmpz_t scale, slong * lenr,
 
     /* precompute leading cofficient info */
     fmpz_abs(lc_abs_lg, poly3 + 0);
-    lc_abs = FLINT_ABS(poly3[0]);
-    lc_sign = FLINT_SIGN_EXT(poly3[0]);
-    count_leading_zeros(lc_norm, lc_abs);
-    lc_n = lc_abs << lc_norm;
-    invert_limb(lc_i, lc_n);
+    if (small)
+    {
+        lc_abs = FLINT_ABS(poly3[0]);
+        lc_sign = FLINT_SIGN_EXT(poly3[0]);
+        count_leading_zeros(lc_norm, lc_abs);
+        lc_n = lc_abs << lc_norm;
+        invert_limb(lc_i, lc_n);
+    }
 
     while (heap_len > 1)
     {
@@ -364,7 +367,6 @@ slong _fmpz_mpoly_quasidivrem_heap(fmpz_t scale, slong * lenr,
     slong * store, * store_base;
     mpoly_heap_t * x;
     slong * hind;
-
     fmpz * q_coeff = *polyq;
     fmpz * r_coeff = *polyr;
     ulong * q_exp = *expq;
@@ -374,9 +376,7 @@ slong _fmpz_mpoly_quasidivrem_heap(fmpz_t scale, slong * lenr,
     ulong acc_sm[3]; /* for accumulating coefficients */
     slong exp_next;
     ulong mask;
-
-    ulong lc_norm, lc_abs, lc_sign, lc_n, lc_i;
-
+    ulong lc_norm = 0, lc_abs = 0, lc_sign = 0, lc_n = 0, lc_i = 0;
     fmpz_t lc_abs_lg, ns, gcd, acc_lg, r, tp;
     slong bits2, bits3;
     int lt_divides, scaleis1, small;
@@ -453,11 +453,14 @@ slong _fmpz_mpoly_quasidivrem_heap(fmpz_t scale, slong * lenr,
 
     /* precompute leading cofficient info */
     fmpz_abs(lc_abs_lg, poly3 + 0);
-    lc_abs = FLINT_ABS(poly3[0]);
-    lc_sign = FLINT_SIGN_EXT(poly3[0]);
-    count_leading_zeros(lc_norm, lc_abs);
-    lc_n = lc_abs << lc_norm;
-    invert_limb(lc_i, lc_n);
+    if (small)
+    {
+        lc_abs = FLINT_ABS(poly3[0]);
+        lc_sign = FLINT_SIGN_EXT(poly3[0]);
+        count_leading_zeros(lc_norm, lc_abs);
+        lc_n = lc_abs << lc_norm;
+        invert_limb(lc_i, lc_n);
+    }
 
     while (heap_len > 1)
     {

--- a/fmpz_mpoly/quasidivrem_heap.c
+++ b/fmpz_mpoly/quasidivrem_heap.c
@@ -236,35 +236,40 @@ slong _fmpz_mpoly_quasidivrem_heap1(fmpz_t scale, slong * lenr,
             {
                 fmpz_set_signed_uiuiui(r_coeff + r_len, acc_sm[2], acc_sm[1], acc_sm[0]);
                 r_exp[r_len] = exp;
-                fmpz_set_ui(rs + r_len, 1);
+                fmpz_one(rs + r_len);
                 r_len++;
                 continue;
             }
             if (ds == FLINT_SIGN_EXT(acc_sm[1]) && d1 < lc_abs)
             {
                 ulong qq, rr, nhi, nlo;
+                FLINT_ASSERT(0 < lc_norm && lc_norm < FLINT_BITS);
                 nhi = (d1 << lc_norm) | (d0 >> (FLINT_BITS - lc_norm));
                 nlo = d0 << lc_norm;
                 udiv_qrnnd_preinv(qq, rr, nhi, nlo, lc_n, lc_i);
-                if (rr ==0 && (qq & (WORD(3) << (FLINT_BITS - 2))) == 0)
+                if (rr == 0 && qq <= COEFF_MAX)
                 {
                     _fmpz_demote(q_coeff + q_len);
-                    q_coeff[q_len] = (qq^ds^lc_sign) - (ds^lc_sign);
-                    fmpz_set_ui(qs + q_len, 1);
-                } else
+                    q_coeff[q_len] = qq;
+                    if (ds != lc_sign)
+                        q_coeff[q_len] = -q_coeff[q_len];
+                    fmpz_one(qs + q_len);
+                }
+                else
                 {
                     small = 0;
                     fmpz_set_signed_uiuiui(acc_lg, acc_sm[2], acc_sm[1], acc_sm[0]);
                     goto large_lt_divides;
                 }
-            } else
+            }
+            else
             {
                 small = 0;
                 fmpz_set_signed_uiuiui(acc_lg, acc_sm[2], acc_sm[1], acc_sm[0]);
                 goto large_lt_divides;
             }
-
-        } else
+        }
+        else
         {
             if (fmpz_is_zero(acc_lg))
                 continue;
@@ -625,35 +630,40 @@ slong _fmpz_mpoly_quasidivrem_heap(fmpz_t scale, slong * lenr,
             {
                 fmpz_set_signed_uiuiui(r_coeff + r_len, acc_sm[2], acc_sm[1], acc_sm[0]);
                 mpoly_monomial_set(r_exp + r_len*N, exp, N);
-                fmpz_set_ui(rs + r_len, 1);
+                fmpz_one(rs + r_len);
                 r_len++;
                 continue;
             }
             if (ds == FLINT_SIGN_EXT(acc_sm[1]) && d1 < lc_abs)
             {
                 ulong qq, rr, nhi, nlo;
+                FLINT_ASSERT(0 < lc_norm && lc_norm < FLINT_BITS);
                 nhi = (d1 << lc_norm) | (d0 >> (FLINT_BITS - lc_norm));
                 nlo = d0 << lc_norm;
                 udiv_qrnnd_preinv(qq, rr, nhi, nlo, lc_n, lc_i);
-                if (rr ==0 && (qq & (WORD(3) << (FLINT_BITS - 2))) == 0)
+                if (rr == 0 && qq <= COEFF_MAX)
                 {
                     _fmpz_demote(q_coeff + q_len);
-                    q_coeff[q_len] = (qq^ds^lc_sign) - (ds^lc_sign);
-                    fmpz_set_ui(qs + q_len, 1);
-                } else
+                    q_coeff[q_len] = qq;
+                    if (ds != lc_sign)
+                        q_coeff[q_len] = -q_coeff[q_len];
+                    fmpz_one(qs + q_len);
+                }
+                else
                 {
                     small = 0;
                     fmpz_set_signed_uiuiui(acc_lg, acc_sm[2], acc_sm[1], acc_sm[0]);
                     goto large_lt_divides;
                 }
-            } else
+            }
+            else
             {
                 small = 0;
                 fmpz_set_signed_uiuiui(acc_lg, acc_sm[2], acc_sm[1], acc_sm[0]);
                 goto large_lt_divides;
             }
-
-        } else
+        }
+        else
         {
             if (fmpz_is_zero(acc_lg))
                 continue;

--- a/gmpcompat.h
+++ b/gmpcompat.h
@@ -33,7 +33,7 @@
   } while (0)
 
 
-#if (defined(__MINGW64__) || defined(__mips64)) && !defined(__MPIR_VERSION)
+#if defined(__MINGW64__) && !defined(__MPIR_VERSION)
 
 #define FLINT_MOCK_MPZ_UI(xxx, yyy) \
    __mpz_struct (xxx)[1] = {{ 1, 0, NULL }}; \

--- a/longlong.h
+++ b/longlong.h
@@ -531,42 +531,32 @@
           udiv_qrnnd_int((q), (r), (n1), (n0), (d)); \
     } while (0)
 
-#define sdiv_qrnnd(q, r, n1, n0, d) \
-  do {                              \
-    mp_limb_t __n1, __n0, __d;      \
-    int __sgn1 = 0, __sgn2 = 0;     \
-    if ((n1) & __highbit)           \
-    {                               \
-       __n0 = -(n0);                \
-       __n1 = ~(n1) + (__n0 == 0);  \
-       __sgn1 = ~__sgn1;            \
-    } else                          \
-    {                               \
-      __n0 = (n0);                  \
-      __n1 = (n1);                  \
-    }                               \
-    if ((d) & __highbit)            \
-    {                               \
-        __d = -(d);                 \
-        __sgn2 = ~__sgn2;           \
-    } else                          \
-    {                               \
-        __d = (d);                  \
-    }                               \
-    udiv_qrnnd((q), (r), (mp_limb_t) __n1, (mp_limb_t) __n0, (mp_limb_t) __d); \
-    if (__sgn1 ^ __sgn2)            \
-    {                               \
-        (q) = -(q);                 \
-        if (!__sgn2)                \
-        {                           \
-            (q)--;                  \
-            (r) = (__d) - (r);      \
-        }                           \
-    } else if (__sgn1 && __sgn2)    \
-    {                               \
-       (q)++;                       \
-       (r) = (__d) - (r);           \
-    }                               \
+#define sdiv_qrnnd(q, r, n1, n0, d)         \
+  do {                                      \
+    mp_limb_t __n1, __n0, __d;              \
+    mp_limb_t __q, __r;                     \
+    unsigned int __sgn_n = 0, __sgn_d = 0;  \
+    if ((n1) & __highbit)                   \
+    {                                       \
+       __n0 = -(n0);                        \
+       __n1 = ~(n1) + (__n0 == 0);          \
+       __sgn_n = ~__sgn_n;                  \
+    } else                                  \
+    {                                       \
+      __n0 = (n0);                          \
+      __n1 = (n1);                          \
+    }                                       \
+    if ((d) & __highbit)                    \
+    {                                       \
+        __d = -(d);                         \
+        __sgn_d = ~__sgn_d;                 \
+    } else                                  \
+    {                                       \
+        __d = (d);                          \
+    }                                       \
+    udiv_qrnnd(__q, __r, __n1, __n0, __d);  \
+    q = (__sgn_n == __sgn_d) ? __q : -__q;  \
+    r = (__sgn_n == 0) ? __r : -__r;        \
   } while (0)
 
 #if GMP_LIMB_BITS == 32

--- a/test/t-sdiv_qrnnd.c
+++ b/test/t-sdiv_qrnnd.c
@@ -61,10 +61,10 @@ int main(void)
         }
 
         /* check rounding of q was towards zero */
-        if ((nsgn >= 0 && d > 0 && !(0 <= r && r <= d)) ||
-            (nsgn >= 0 && d < 0 && WORD_MAX + d >= 0 && !(0 <= r && r <= -d)) ||
-            (nsgn < 0 && d > 0 && WORD_MIN + d <= 0 && !(-d <= r && r <= 0)) ||
-            (nsgn < 0 && d < 0 && !(d <= r && r <= 0)))
+        if ((nsgn >= 0 && d > 0 && !(0 <= r && r < d)) ||
+            (nsgn >= 0 && d < 0 && WORD_MAX + d >= 0 && !(0 <= r && r < -d)) ||
+            (nsgn < 0 && d > 0 && WORD_MIN + d <= 0 && !(-d < r && r <= 0)) ||
+            (nsgn < 0 && d < 0 && !(d < r && r <= 0)))
         {
             flint_printf("FAIL: check remainder\n");
             flint_printf("nsgn: %d\n", nsgn);

--- a/test/t-sdiv_qrnnd.c
+++ b/test/t-sdiv_qrnnd.c
@@ -18,43 +18,45 @@
 
 int main(void)
 {
-   int i, result;
-   FLINT_TEST_INIT(state);
-   
+    slong i;
+    FLINT_TEST_INIT(state);
 
-   flint_printf("sdiv_qrnnd....");
-   fflush(stdout);
+    flint_printf("sdiv_qrnnd....");
+    fflush(stdout);
 
-   for (i = 0; i < 1000000; i++)
-   {
-      mp_limb_signed_t d, nh, nl, q, r, ph, pl;
+    for (i = 0; i < 1000000*flint_test_multiplier(); i++)
+    {
+        mp_limb_signed_t d, nh, nl, q, r, ph, pl;
 
-      do 
-      {
-         d = n_randtest_not_zero(state);
-         nh = n_randtest(state);
-      } while ((FLINT_ABS(nh) >= FLINT_ABS(d)/2) || (nh == WORD_MIN));
+        do
+        {
+            d = n_randtest_not_zero(state);
+            nh = n_randtest(state);
+        } while ((FLINT_ABS(nh) >= FLINT_ABS(d)/2) || (nh == WORD_MIN));
 
-      nl = n_randtest(state);
+        nl = n_randtest(state);
 
-      sdiv_qrnnd(q, r, nh, nl, d);
-      smul_ppmm(ph, pl, d, q);
-      if (r < WORD(0)) sub_ddmmss(ph, pl, ph, pl, UWORD(0), -r);
-      else add_ssaaaa(ph, pl, ph, pl, UWORD(0), r);
+        sdiv_qrnnd(q, r, nh, nl, d);
+        smul_ppmm(ph, pl, d, q);
+        add_ssaaaa(ph, pl, ph, pl, FLINT_SIGN_EXT(r), r);
 
-      result = ((ph == nh) && (pl == nl));
+        if (ph != nh ||
+            pl != nl ||
+            (d > 0 && r >= d) ||
+            (d < 0 && r <= d))
+        {
+            flint_printf("FAIL:\n");
+            flint_printf("nh = %wd, nl = %wd\n", nh, nl);
+            flint_printf("d = %wd\n", d);
+            flint_printf("q = %wd\n", q);
+            flint_printf("r = %wd\n", r);
+            flint_printf("ph = %wu, pl = %wu\n", ph, pl);
+            flint_abort();
+        }
+    }
 
-      if (!result)
-      {
-         flint_printf("FAIL:\n");
-         flint_printf("nh = %wu, nl = %wu, d = %wu\n", nh, nl, d); 
-         flint_printf("ph = %wu, pl = %wu\n", ph, pl);
-         flint_abort();
-      }
-   }
+    FLINT_TEST_CLEANUP(state);
 
-   FLINT_TEST_CLEANUP(state);
-   
-   flint_printf("PASS\n");
-   return 0;
+    flint_printf("PASS\n");
+    return 0;
 }

--- a/test/t-sdiv_qrnnd.c
+++ b/test/t-sdiv_qrnnd.c
@@ -26,6 +26,7 @@ int main(void)
 
     for (i = 0; i < 1000000*flint_test_multiplier(); i++)
     {
+        int nsgn;
         mp_limb_signed_t d, nh, nl, q, r, ph, pl;
 
         do
@@ -36,22 +37,41 @@ int main(void)
 
         nl = n_randtest(state);
 
+        if (nh < 0)
+            nsgn = -1;
+        else if (nh > 0 || nl != 0)
+            nsgn = +1;
+        else
+            nsgn = 0;
+
         sdiv_qrnnd(q, r, nh, nl, d);
         smul_ppmm(ph, pl, d, q);
         add_ssaaaa(ph, pl, ph, pl, FLINT_SIGN_EXT(r), r);
 
-        /* check n = q*d + r and |r| < |d| when possible */
-        if (ph != nh ||
-            pl != nl ||
-            (d > 0 && WORD_MIN + d <= 0 && (r >= d || r <= -d)) ||
-            (d < 0 && WORD_MAX + d >= 0 && (r <= d || r >= -d)))
+        /* check n = q*d + r */
+        if (ph != nh || pl != nl)
         {
-            flint_printf("FAIL:\n");
+            flint_printf("FAIL: check identity\n");
             flint_printf("nh = %wd, nl = %wd\n", nh, nl);
             flint_printf("d = %wd\n", d);
             flint_printf("q = %wd\n", q);
             flint_printf("r = %wd\n", r);
             flint_printf("ph = %wu, pl = %wu\n", ph, pl);
+            flint_abort();
+        }
+
+        /* check rounding of q was towards zero */
+        if ((nsgn >= 0 && d > 0 && !(0 <= r && r <= d)) ||
+            (nsgn >= 0 && d < 0 && WORD_MAX + d >= 0 && !(0 <= r && r <= -d)) ||
+            (nsgn < 0 && d > 0 && WORD_MIN + d <= 0 && !(-d <= r && r <= 0)) ||
+            (nsgn < 0 && d < 0 && !(d <= r && r <= 0)))
+        {
+            flint_printf("FAIL: check remainder\n");
+            flint_printf("nsgn: %d\n", nsgn);
+            flint_printf("nh = %wd, nl = %wd\n", nh, nl);
+            flint_printf("d = %wd\n", d);
+            flint_printf("q = %wd\n", q);
+            flint_printf("r = %wd\n", r);
             flint_abort();
         }
     }

--- a/test/t-sdiv_qrnnd.c
+++ b/test/t-sdiv_qrnnd.c
@@ -40,10 +40,11 @@ int main(void)
         smul_ppmm(ph, pl, d, q);
         add_ssaaaa(ph, pl, ph, pl, FLINT_SIGN_EXT(r), r);
 
+        /* check n = q*d + r and |r| < |d| when possible */
         if (ph != nh ||
             pl != nl ||
-            (d > 0 && r >= d) ||
-            (d < 0 && r <= d))
+            (d > 0 && WORD_MIN + d <= 0 && (r >= d || r <= -d)) ||
+            (d < 0 && WORD_MAX + d >= 0 && (r <= d || r >= -d)))
         {
             flint_printf("FAIL:\n");
             flint_printf("nh = %wd, nl = %wd\n", nh, nl);


### PR DESCRIPTION
The first two comments fix stuff that was seemingly not causing problems on mips but that should have been fixed eventually anyways. The third and forth commits try to address the problems in fmpz_mpoly_divrem_ideal_monagan_pearce.
@benlorenz , it would be helpful if you could test `fmpz_mpoly/test/t-divrem_ideal_monagan_pearce` with the third and forth commits on your mips installation.`--enable-assert` would be good too.