### PR TITLE
configure: fix typo in mingw64 detection

### DIFF
--- a/configure
+++ b/configure
@@ -352,7 +352,7 @@ if [ -z "$BUILD" ]; then
    ARCH=`uname -m`
 
    if [ "$(uname | cut -d_ -f1)" = "MSYS" ]; then
-      if [ "$(ARCH)" = "x86_64" ]; then
+      if [ "$ARCH" = "x86_64" ]; then
          OS="MINGW64"
       else
          OS="MINGW32"


### PR DESCRIPTION
This corrects the CFLAGS for the mingw64 build and removes all those (200MB of) warnings.

see https://github.com/JuliaPackaging/Yggdrasil/pull/661

@thofma