### PR TITLE
add option to skip primality test in fmpz_factor_smooth

### DIFF
--- a/doc/source/fmpz_factor.rst
+++ b/doc/source/fmpz_factor.rst
@@ -64,11 +64,26 @@ A separate ``int`` field holds the sign, which may be `-1`, `0` or `1`.
     increasing ``bits``. However, the quadratic sieve may be faster if
     ``bits`` is set to more than one third of the number of bits of `n`.
 
-    If ``proved`` is set to `1` the function will prove all factors prime
-    (other than the last factor, if the return value is `0`), otherwise they
-    will be probable primes.
+    The function uses trial factoring up to ``bits = 15``, followed by
+    a primality test and a perfect power test to check if the factorisation
+    is complete. If ``bits`` is at least 16, it proceeds to use the
+    elliptic curve method to look for larger factors.
 
-    The function uses trial factoring and the elliptic curve method.
+    The behavior of primality testing is determined by the ``proved``
+    parameter:
+
+    If ``proved`` is set to `1` the function will prove all factors prime
+    (other than the last factor, if the return value is `0`).
+
+    If ``proved`` is set to `0`, the function will only check that factors are
+    probable primes.
+
+    If ``proved`` is set to `-1`, the function will not test primality
+    after performing trial division. A perfect power test is still performed.
+
+    As an exception to the rules stated above, this function will call
+    ``n_factor`` internally if `n` or the remainder after trial division
+    is smaller than one word, guaranteeing a complete factorisation.
 
 .. function:: void fmpz_factor_si(fmpz_factor_t factor, slong n)
 

--- a/fmpz_factor/factor_smooth.c
+++ b/fmpz_factor/factor_smooth.c
@@ -43,7 +43,7 @@ int _is_prime(const fmpz_t n, int proved)
     if (proved)
         return fmpz_is_prime(n);
     else
-	return fmpz_is_probabprime(n);
+    	return fmpz_is_probabprime(n);
 }
 
 int fmpz_factor_smooth(fmpz_factor_t factor, const fmpz_t n,
@@ -154,7 +154,8 @@ int fmpz_factor_smooth(fmpz_factor_t factor, const fmpz_t n,
             _fmpz_factor_extend_factor_ui(factor, xd[0]);
 
         ret = 1;
-    } else 
+    }
+    else 
     {
         fmpz_t n2, f;
         __mpz_struct * data;
@@ -165,12 +166,12 @@ int fmpz_factor_smooth(fmpz_factor_t factor, const fmpz_t n,
         flint_mpn_copyi(data->_mp_d, xd, xsize);
         data->_mp_size = xsize;
 
-        if (_is_prime(n2, proved))
+        if (proved != -1 && _is_prime(n2, proved))
         {
             _fmpz_factor_append(factor, n2, 1);
-
             ret = 1; 
-        } else
+        }
+        else
         {
             fmpz_t root;
 
@@ -190,7 +191,8 @@ int fmpz_factor_smooth(fmpz_factor_t factor, const fmpz_t n,
                 _fmpz_factor_concat(factor, fac, exp);
 
                 fmpz_factor_clear(fac);
-            } else if (bits >= 16) /* trial factored already up to 15 bits */
+            }
+            else if (bits >= 16) /* trial factored already up to 15 bits */
             {
                 int found;
                 flint_rand_t state;


### PR DESCRIPTION
This allows passing proved = -1 to skip the primality test (still performing a perfect power test), enabling much faster partial factorisation of huge numbers.