### PR TITLE
get rid of the threaded functions

### DIFF
--- a/doc/source/fmpq_mpoly.rst
+++ b/doc/source/fmpq_mpoly.rst
@@ -577,16 +577,12 @@ Greatest Common Divisor
 
 .. function:: int fmpq_mpoly_gcd(fmpq_mpoly_t G, const fmpq_mpoly_t A, const fmpq_mpoly_t B, const fmpq_mpoly_ctx_t ctx)
 
-.. function:: int fmpq_mpoly_gcd_threaded(fmpq_mpoly_t G, const fmpq_mpoly_t A, const fmpq_mpoly_t B, const fmpq_mpoly_ctx_t ctx, slong thread_limit)
-
     Try to set ``G`` to the monic GCD of ``A`` and ``B``. The GCD of zero and zero is defined to be zero.
     If the return is ``1`` the function was successful. Otherwise the return is  ``0`` and ``G`` is left untouched.
-    The threaded version takes an upper limit on the number of threads to use, while the first version calls the threaded version with ``thread_limit = MPOLY_DEFAULT_THREAD_LIMIT``.
 
 .. function:: int fmpq_mpoly_gcd_cofactors(fmpq_mpoly_t G, fmpq_mpoly_t Abar, fmpq_mpoly_t Bbar, const fmpq_mpoly_t A, const fmpq_mpoly_t B, const fmpq_mpoly_ctx_t ctx)
-              int fmpq_mpoly_gcd_cofactors_threaded(fmpq_mpoly_t G, fmpq_mpoly_t Abar, fmpq_mpoly_t Bbar, const fmpq_mpoly_t A, const fmpq_mpoly_t B, const fmpq_mpoly_ctx_t ctx, slong thread_limit)
 
-    Do the operation of :func:`fmpq_mpoly_gcd` / :func:`fmpq_mpoly_gcd_threaded` but also compute the cofactors ``Abar = A/G`` and ``Bbar = B/G`` if successful.
+    Do the operation of :func:`fmpq_mpoly_gcd` and also compute ``Abar = A/G`` and ``Bbar = B/G`` if successful.
 
 
 Univariate Functions

--- a/doc/source/fmpz_mpoly.rst
+++ b/doc/source/fmpz_mpoly.rst
@@ -542,10 +542,7 @@ Multiplication
 
 .. function:: void fmpz_mpoly_mul(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx)
 
-.. function:: void fmpz_mpoly_mul_threaded(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx, slong thread_limit)
-
     Set ``A`` to ``B`` times ``C``.
-    The threaded version takes an upper limit on the number of threads to use, while the first version calls the threaded version with ``thread_limit = MPOLY_DEFAULT_THREAD_LIMIT``.
 
 .. function:: void fmpz_mpoly_mul_johnson(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx)
 
@@ -564,7 +561,7 @@ Multiplication
 
 .. function:: int fmpz_mpoly_mul_dense(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx)
 
-    Try to set ``A`` to ``B`` times ``C`` using univariate arithmetic.
+    Try to set ``A`` to ``B`` times ``C`` using dense arithmetic.
     If the return is ``0``, the operation was unsuccessful. Otherwise, it was successful and the return is ``1``.
 
 

--- a/doc/source/fmpz_mpoly.rst
+++ b/doc/source/fmpz_mpoly.rst
@@ -638,17 +638,12 @@ Greatest Common Divisor
 
 .. function:: int fmpz_mpoly_gcd(fmpz_mpoly_t G, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx)
 
-.. function:: int fmpz_mpoly_gcd_threaded(fmpz_mpoly_t G, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx, slong thread_limit)
-
     Try to set ``G`` to the GCD of ``A`` and ``B`` with positive leading coefficient. The GCD of zero and zero is defined to be zero.
     If the return is ``1`` the function was successful. Otherwise the return is  ``0`` and ``G`` is left untouched.
-    The threaded version takes an upper limit on the number of threads to use, while the first version calls the threaded version with ``thread_limit = MPOLY_DEFAULT_THREAD_LIMIT``.
 
 .. function:: int fmpz_mpoly_gcd_cofactors(fmpz_mpoly_t G, fmpz_mpoly_t Abar, fmpz_mpoly_t Bbar, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx)
 
-.. function:: int fmpz_mpoly_gcd_cofactors_threaded(fmpz_mpoly_t G, fmpz_mpoly_t Abar, fmpz_mpoly_t Bbar, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx, slong thread_limit)
-
-    Do the operation of :func:`fmpz_mpoly_gcd` / :func:`fmpz_mpoly_gcd_threaded` but also compute the cofactors ``Abar = A/G`` and ``Bbar = B/G`` if successful.
+    Do the operation of :func:`fmpz_mpoly_gcd` and also compute ``Abar = A/G`` and ``Bbar = B/G`` if successful.
 
 .. function:: int fmpz_mpoly_gcd_brown(fmpz_mpoly_t G, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx)
 

--- a/doc/source/fmpz_mpoly.rst
+++ b/doc/source/fmpz_mpoly.rst
@@ -545,15 +545,13 @@ Multiplication
     Set ``A`` to ``B`` times ``C``.
 
 .. function:: void fmpz_mpoly_mul_johnson(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx)
-
-.. function:: void fmpz_mpoly_mul_heap_threaded(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx, slong thread_limit)
+              void fmpz_mpoly_mul_heap_threaded(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx, slong thread_limit)
 
     Set ``A`` to ``B`` times ``C`` using Johnson's heap-based method.
     The threaded version takes an upper limit on the number of threads to use, while the first version always uses one thread.
 
 .. function:: int fmpz_mpoly_mul_array(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx)
-
-.. function:: int fmpz_mpoly_mul_array_threaded(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx)
+              int fmpz_mpoly_mul_array_threaded(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx)
 
     Try to set ``A`` to ``B`` times ``C`` using arrays.
     If the return is ``0``, the operation was unsuccessful. Otherwise, it was successful and the return is ``1``.
@@ -586,14 +584,10 @@ Division
 
 .. function:: int fmpz_mpoly_divides(fmpz_mpoly_t Q, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx)
 
-.. function:: int fmpz_mpoly_divides_threaded(fmpz_mpoly_t Q, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx, slong thread_limit)
-
     If ``A`` is divisible by ``B``, set ``Q`` to the exact quotient and return ``1``. Otherwise, set ``Q`` to zero and return ``0``.
-    The threaded version takes an upper limit on the number of threads to use, while the first version calls the threaded version with ``thread_limit = MPOLY_DEFAULT_THREAD_LIMIT``.
 
 .. function:: int fmpz_mpoly_divides_monagan_pearce(fmpz_mpoly_t Q, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx)
-
-.. function:: int fmpz_mpoly_divides_heap_threaded(fmpz_mpoly_t Q, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx, slong thread_limit)
+              int fmpz_mpoly_divides_heap_threaded(fmpz_mpoly_t Q, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx, slong thread_limit)
 
     Perform the operation of func::fmpz_mpoly_divides using the algorithm of Michael Monagan and Roman Pearce.
     The threaded version takes an upper limit on the number of threads to use, while the first version always uses one thread.
@@ -620,7 +614,7 @@ Division
 
     This function is as per :func:`fmpz_mpoly_divrem` except that it takes an array of divisor polynomials ``B`` and it returns an array of quotient polynomials ``Q``.
     The number of divisor (and hence quotient) polynomials, is given by ``len``.
-    Note that this function is not very useful if the leading coefficient in the array ``B`` is not a unit.
+    Note that this function is not very useful if there is no unit among the leading coefficients in the array ``B``.
 
 .. function:: void fmpz_mpoly_quasidivrem_ideal(fmpz_t scale, fmpz_mpoly_struct ** Q, fmpz_mpoly_t R, const fmpz_mpoly_t A, fmpz_mpoly_struct * const * B, slong len, const fmpz_mpoly_ctx_t ctx)
 
@@ -646,8 +640,7 @@ Greatest Common Divisor
     Do the operation of :func:`fmpz_mpoly_gcd` and also compute ``Abar = A/G`` and ``Bbar = B/G`` if successful.
 
 .. function:: int fmpz_mpoly_gcd_brown(fmpz_mpoly_t G, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx)
-
-.. function:: int fmpz_mpoly_gcd_brown_threaded(fmpz_mpoly_t G, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx, slong thread_limit)
+              int fmpz_mpoly_gcd_brown_threaded(fmpz_mpoly_t G, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx, slong thread_limit)
 
     Try to set ``G`` to the GCD of ``A`` and ``B`` using Brown's algorithm.
     The threaded version takes an upper limit on the number of threads to use, while the first version always uses one thread.

--- a/doc/source/nmod_mpoly.rst
+++ b/doc/source/nmod_mpoly.rst
@@ -532,16 +532,13 @@ The greatest common divisor functions assume that the modulus is prime.
     If ``A`` is zero, ``M`` will be zero. Otherwise, ``M`` will be a monomial with coefficient one.
 
 .. function:: int nmod_mpoly_gcd(nmod_mpoly_t G, const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx)
-              int nmod_mpoly_gcd_threaded(nmod_mpoly_t G, const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx, slong thread_limit)
 
-    Try to set ``G`` to the GCD of ``A`` and ``B`` with positive leading coefficient. The GCD of zero and zero is defined to be zero.
+    Try to set ``G`` to the monic GCD of ``A`` and ``B``. The GCD of zero and zero is defined to be zero.
     If the return is ``1`` the function was successful. Otherwise the return is  ``0`` and ``G`` is left untouched.
-    The threaded version takes an upper limit on the number of threads to use, while the first version calls the threaded version with ``thread_limit = MPOLY_DEFAULT_THREAD_LIMIT``.
 
 .. function:: int nmod_mpoly_gcd_cofactors(nmod_mpoly_t G, nmod_mpoly_t Abar, nmod_mpoly_t Bbar, const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx)
-              int nmod_mpoly_gcd_cofactors_threaded(nmod_mpoly_t G, nmod_mpoly_t Abar, nmod_mpoly_t Bbar, const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx, slong thread_limit)
 
-    Do the operation of :func:`nmod_mpoly_gcd` / :func:`nmod_mpoly_gcd_threaded` but also compute the cofactors ``Abar = A/G`` and ``Bbar = B/G`` if successful.
+    Do the operation of :func:`nmod_mpoly_gcd` and also compute ``Abar = A/G`` and ``Bbar = B/G`` if successful.
 
 .. function:: int nmod_mpoly_gcd_brown(nmod_mpoly_t G, const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx)
               int nmod_mpoly_gcd_brown_threaded(nmod_mpoly_t G, const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx, slong thread_limit)

--- a/doc/source/nmod_mpoly.rst
+++ b/doc/source/nmod_mpoly.rst
@@ -423,10 +423,8 @@ Evaluation
     Return `1` for success and `0` for failure.
 
 .. function:: int nmod_mpoly_compose_nmod_mpoly_geobucket(nmod_mpoly_t A, const nmod_mpoly_t B, nmod_mpoly_struct * const * C, const nmod_mpoly_ctx_t ctxB, const nmod_mpoly_ctx_t ctxAC)
-
-.. function:: int nmod_mpoly_compose_nmod_mpoly_horner(nmod_mpoly_t A, const nmod_mpoly_t B, nmod_mpoly_struct * const * C, const nmod_mpoly_ctx_t ctxB, const nmod_mpoly_ctx_t ctxAC)
-
-.. function:: int nmod_mpoly_compose_nmod_mpoly(nmod_mpoly_t A, const nmod_mpoly_t B, nmod_mpoly_struct * const * C, const nmod_mpoly_ctx_t ctxB, const nmod_mpoly_ctx_t ctxAC)
+              int nmod_mpoly_compose_nmod_mpoly_horner(nmod_mpoly_t A, const nmod_mpoly_t B, nmod_mpoly_struct * const * C, const nmod_mpoly_ctx_t ctxB, const nmod_mpoly_ctx_t ctxAC)
+              int nmod_mpoly_compose_nmod_mpoly(nmod_mpoly_t A, const nmod_mpoly_t B, nmod_mpoly_struct * const * C, const nmod_mpoly_ctx_t ctxB, const nmod_mpoly_ctx_t ctxAC)
 
     Set ``A`` to the evaluation of ``B`` where the variables are replaced by the corresponding elements of the array ``C``.
     Both ``A`` and the elements of ``C`` have context object ``ctxAC``, while ``B`` has context object ``ctxB``.
@@ -446,10 +444,8 @@ Multiplication
 
 
 .. function:: void nmod_mpoly_mul(nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx)
-              void nmod_mpoly_mul(nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx, slong thread_limit)
 
     Set ``A`` to ``B`` times ``C``.
-    The threaded version takes an upper limit on the number of threads to use, while the first version calls the threaded version with ``thread_limit = MPOLY_DEFAULT_THREAD_LIMIT``.
 
 .. function:: void nmod_mpoly_mul_johnson(nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx)
               void nmod_mpoly_mul_heap_threaded(nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx)
@@ -468,7 +464,6 @@ Multiplication
 
     Try to set ``A`` to ``B`` times `C` using univariate arithmetic.
     If the return is ``0``, the operation was unsuccessful. Otherwise, it was successful and the return is ``1``.
-
 
 
 Powering

--- a/fmpq_mpoly.h
+++ b/fmpq_mpoly.h
@@ -739,9 +739,6 @@ FLINT_DLL void fmpq_mpoly_term_content(fmpq_mpoly_t M, const fmpq_mpoly_t A,
 FLINT_DLL int fmpq_mpoly_gcd(fmpq_mpoly_t G, const fmpq_mpoly_t A,
                              const fmpq_mpoly_t B, const fmpq_mpoly_ctx_t ctx);
 
-FLINT_DLL int fmpq_mpoly_gcd_threaded(fmpq_mpoly_t G, const fmpq_mpoly_t A,
-         const fmpq_mpoly_t B, const fmpq_mpoly_ctx_t ctx, slong thread_limit);
-
 
 FLINT_DLL void fmpq_mpoly_inflate(fmpq_mpoly_t A, const fmpq_mpoly_t B,
           const fmpz * shift, const fmpz * stride, const fmpq_mpoly_ctx_t ctx);
@@ -749,10 +746,6 @@ FLINT_DLL void fmpq_mpoly_inflate(fmpq_mpoly_t A, const fmpq_mpoly_t B,
 FLINT_DLL int fmpq_mpoly_gcd_cofactors(fmpq_mpoly_t G, fmpq_mpoly_t Abar,
              fmpq_mpoly_t Bbar, const fmpq_mpoly_t A, const fmpq_mpoly_t B,
                                                    const fmpq_mpoly_ctx_t ctx);
-
-FLINT_DLL int fmpq_mpoly_gcd_cofactors_threaded(fmpq_mpoly_t G, fmpq_mpoly_t Abar,
-              fmpq_mpoly_t Bbar, const fmpq_mpoly_t A, const fmpq_mpoly_t B,
-                               const fmpq_mpoly_ctx_t ctx, slong thread_limit);
 
 
 /******************************************************************************

--- a/fmpq_mpoly/divides.c
+++ b/fmpq_mpoly/divides.c
@@ -11,11 +11,9 @@
 
 #include "fmpq_mpoly.h"
 
-
 /* return 1 if quotient is exact */
-int fmpq_mpoly_divides(fmpq_mpoly_t Q,
-                  const fmpq_mpoly_t A, const fmpq_mpoly_t B,
-                                                    const fmpq_mpoly_ctx_t ctx)
+int fmpq_mpoly_divides(fmpq_mpoly_t Q, const fmpq_mpoly_t A,
+                              const fmpq_mpoly_t B, const fmpq_mpoly_ctx_t ctx)
 {
     int res;
 

--- a/fmpq_mpoly/gcd.c
+++ b/fmpq_mpoly/gcd.c
@@ -12,13 +12,12 @@
 #include "fmpq_mpoly.h"
 
 
-int fmpq_mpoly_gcd_threaded(fmpq_mpoly_t G, const fmpq_mpoly_t A,
-         const fmpq_mpoly_t B, const fmpq_mpoly_ctx_t ctx, slong thread_limit)
+int fmpq_mpoly_gcd(fmpq_mpoly_t G, const fmpq_mpoly_t A, const fmpq_mpoly_t B,
+                                                    const fmpq_mpoly_ctx_t ctx)
 {
     int success;
 
-    success = fmpz_mpoly_gcd_threaded(G->zpoly, A->zpoly, B->zpoly,
-                                                      ctx->zctx, thread_limit);
+    success = fmpz_mpoly_gcd(G->zpoly, A->zpoly, B->zpoly, ctx->zctx);
     if (!success)
         return 0;
 
@@ -35,8 +34,3 @@ int fmpq_mpoly_gcd_threaded(fmpq_mpoly_t G, const fmpq_mpoly_t A,
     return 1;
 }
 
-int fmpq_mpoly_gcd(fmpq_mpoly_t G, const fmpq_mpoly_t A,
-                              const fmpq_mpoly_t B, const fmpq_mpoly_ctx_t ctx)
-{
-    return fmpq_mpoly_gcd_threaded(G, A, B, ctx, MPOLY_DEFAULT_THREAD_LIMIT);
-}

--- a/fmpq_mpoly/gcd_cofactors.c
+++ b/fmpq_mpoly/gcd_cofactors.c
@@ -12,15 +12,15 @@
 #include "fmpq_mpoly.h"
 
 
-int fmpq_mpoly_gcd_cofactors_threaded(fmpq_mpoly_t G, fmpq_mpoly_t Abar,
+int fmpq_mpoly_gcd_cofactors(fmpq_mpoly_t G, fmpq_mpoly_t Abar,
               fmpq_mpoly_t Bbar, const fmpq_mpoly_t A, const fmpq_mpoly_t B,
-                                const fmpq_mpoly_ctx_t ctx, slong thread_limit)
+                                                    const fmpq_mpoly_ctx_t ctx)
 {
     fmpq_t cAbar, cBbar;
     int success;
 
-    success = fmpz_mpoly_gcd_cofactors_threaded(G->zpoly, Abar->zpoly,
-                     Bbar->zpoly, A->zpoly, B->zpoly, ctx->zctx, thread_limit);
+    success = fmpz_mpoly_gcd_cofactors(G->zpoly, Abar->zpoly, Bbar->zpoly,
+                                                A->zpoly, B->zpoly, ctx->zctx);
     if (!success)
         return 0;
 
@@ -48,10 +48,3 @@ int fmpq_mpoly_gcd_cofactors_threaded(fmpq_mpoly_t G, fmpq_mpoly_t Abar,
     return 1;
 }
 
-int fmpq_mpoly_gcd_cofactors(fmpq_mpoly_t G, fmpq_mpoly_t Abar,
-             fmpq_mpoly_t Bbar, const fmpq_mpoly_t A, const fmpq_mpoly_t B,
-                                                    const fmpq_mpoly_ctx_t ctx)
-{
-    return fmpq_mpoly_gcd_cofactors_threaded(G, Abar, Bbar, A, B, ctx,
-                                                   MPOLY_DEFAULT_THREAD_LIMIT);
-}

--- a/fmpz_mpoly.h
+++ b/fmpz_mpoly.h
@@ -728,10 +728,6 @@ FLINT_DLL void fmpz_mpoly_compose_fmpz_mpoly_gen(fmpz_mpoly_t A,
 FLINT_DLL void fmpz_mpoly_mul(fmpz_mpoly_t A,
        const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
 
-FLINT_DLL void fmpz_mpoly_mul_threaded(fmpz_mpoly_t A,
-       const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx,
-                                                           slong thread_limit);
-
 FLINT_DLL void fmpz_mpoly_mul_johnson(fmpz_mpoly_t A,
        const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
 

--- a/fmpz_mpoly.h
+++ b/fmpz_mpoly.h
@@ -806,10 +806,6 @@ FLINT_DLL slong _fmpz_mpoly_pow_fps(fmpz ** poly1, ulong ** exp1,
 FLINT_DLL int fmpz_mpoly_divides(fmpz_mpoly_t Q,
        const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
 
-FLINT_DLL int fmpz_mpoly_divides_threaded(fmpz_mpoly_t Q,
-       const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx,
-                                                           slong thread_limit);
-
 FLINT_DLL int fmpz_mpoly_divides_monagan_pearce(fmpz_mpoly_t Q,
        const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
 
@@ -819,7 +815,7 @@ FLINT_DLL int fmpz_mpoly_divides_heap_threaded(fmpz_mpoly_t Q,
 
 FLINT_DLL int _fmpz_mpoly_divides_heap_threaded(fmpz_mpoly_t Q,
        const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx,
-                              thread_pool_handle * handles, slong num_handles);
+                        const thread_pool_handle * handles, slong num_handles);
 
 FLINT_DLL slong _fmpz_mpoly_divides_array(fmpz ** poly1, ulong ** exp1,
          slong * alloc, const fmpz * poly2, const ulong * exp2, slong len2,

--- a/fmpz_mpoly.h
+++ b/fmpz_mpoly.h
@@ -928,10 +928,6 @@ FLINT_DLL void fmpz_mpoly_term_content(fmpz_mpoly_t M, const fmpz_mpoly_t A,
 FLINT_DLL int fmpz_mpoly_gcd(fmpz_mpoly_t G,
        const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
 
-FLINT_DLL int fmpz_mpoly_gcd_threaded(fmpz_mpoly_t G,
-       const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx,
-                                                           slong thread_limit);
-
 FLINT_DLL int _fmpz_mpoly_gcd(fmpz_mpoly_t G, flint_bitcnt_t Gbits,
        const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx,
                         const thread_pool_handle * handles, slong num_handles);
@@ -939,10 +935,6 @@ FLINT_DLL int _fmpz_mpoly_gcd(fmpz_mpoly_t G, flint_bitcnt_t Gbits,
 FLINT_DLL int fmpz_mpoly_gcd_cofactors(fmpz_mpoly_t G,
                 fmpz_mpoly_t Abar, fmpz_mpoly_t Bbar, const fmpz_mpoly_t A,
                              const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
-
-FLINT_DLL int fmpz_mpoly_gcd_cofactors_threaded(fmpz_mpoly_t G,
-                 fmpz_mpoly_t Abar, fmpz_mpoly_t Bbar, const fmpz_mpoly_t A,
-         const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx, slong thread_limit);
 
 FLINT_DLL int _fmpz_mpoly_gcd_cofactors(fmpz_mpoly_t G, flint_bitcnt_t Gbits,
                                    fmpz_mpoly_t Abar, flint_bitcnt_t Abarbits,

--- a/fmpz_mpoly/divides.c
+++ b/fmpz_mpoly/divides.c
@@ -12,24 +12,24 @@
 #include "fmpz_mpoly.h"
 #include "thread_pool.h"
 
-int fmpz_mpoly_divides_threaded(
+int fmpz_mpoly_divides(
     fmpz_mpoly_t Q,
     const fmpz_mpoly_t A,
     const fmpz_mpoly_t B,
-    const fmpz_mpoly_ctx_t ctx,
-    slong thread_limit)
+    const fmpz_mpoly_ctx_t ctx)
 {
     thread_pool_handle * handles;
     slong num_handles;
     int divides;
-    slong i;
+    slong thread_limit;
+
+    thread_limit = A->length/1024;
 
     if (B->length < 2 || A->length < 2)
     {
         if (B->length == 0)
         {
-            flint_throw(FLINT_DIVZERO,
-                             "Divide by zero in fmpz_mpoly_divides_threaded");
+            flint_throw(FLINT_DIVZERO, "Divide by zero in fmpz_mpoly_divides");
         }
 
         if (A->length == 0)
@@ -41,49 +41,15 @@ int fmpz_mpoly_divides_threaded(
         return fmpz_mpoly_divides_monagan_pearce(Q, A, B, ctx);
     }
 
-    handles = NULL;
-    num_handles = 0;
-    if (thread_limit > 1 && global_thread_pool_initialized)
-    {
-        slong max_num_handles;
-        max_num_handles = thread_pool_get_size(global_thread_pool);
-        max_num_handles = FLINT_MIN(thread_limit - 1, max_num_handles);
-        if (max_num_handles > 0)
-        {
-            handles = (thread_pool_handle *) flint_malloc(
-                                   max_num_handles*sizeof(thread_pool_handle));
-            num_handles = thread_pool_request(global_thread_pool,
-                                                     handles, max_num_handles);
-        }
-    }
+    num_handles = flint_request_threads(&handles, thread_limit);
 
-    if (num_handles > 0)
-    {
-        divides = _fmpz_mpoly_divides_heap_threaded(Q, A, B, ctx,
-                                                         handles, num_handles);
-    }
-    else
-    {
-        divides = fmpz_mpoly_divides_monagan_pearce(Q, A, B, ctx);
-    }
+    divides = (num_handles > 0)
+            ? _fmpz_mpoly_divides_heap_threaded(Q, A, B, ctx,
+                                                          handles, num_handles)
+            : fmpz_mpoly_divides_monagan_pearce(Q, A, B, ctx);
 
-    for (i = 0; i < num_handles; i++)
-    {
-        thread_pool_give_back(global_thread_pool, handles[i]);
-    }
-    if (handles)
-    {
-        flint_free(handles);
-    }
+    flint_give_back_threads(handles, num_handles);
 
     return divides;
 }
 
-int fmpz_mpoly_divides(
-    fmpz_mpoly_t Q,
-    const fmpz_mpoly_t A,
-    const fmpz_mpoly_t B,
-    const fmpz_mpoly_ctx_t ctx)
-{
-    return fmpz_mpoly_divides_threaded(Q, A, B, ctx, MPOLY_DEFAULT_THREAD_LIMIT);
-}

--- a/fmpz_mpoly/divides_heap_threaded.c
+++ b/fmpz_mpoly/divides_heap_threaded.c
@@ -1984,7 +1984,7 @@ int _fmpz_mpoly_divides_heap_threaded(
     const fmpz_mpoly_t A,
     const fmpz_mpoly_t B,
     const fmpz_mpoly_ctx_t ctx,
-    thread_pool_handle * handles,
+    const thread_pool_handle * handles,
     slong num_handles)
 {
     ulong mask;

--- a/fmpz_mpoly/gcd_cofactors.c
+++ b/fmpz_mpoly/gcd_cofactors.c
@@ -1216,9 +1216,9 @@ cleanup:
         }
 
 #if WANT_ASSERT
-        fmpz_mpoly_mul_threaded(T, G, Abar, ctx, 0);
+        fmpz_mpoly_mul(T, G, Abar, ctx);
         FLINT_ASSERT(fmpz_mpoly_equal(T, Asave, ctx));
-        fmpz_mpoly_mul_threaded(T, G, Bbar, ctx, 0);
+        fmpz_mpoly_mul(T, G, Bbar, ctx);
         FLINT_ASSERT(fmpz_mpoly_equal(T, Bsave, ctx));
 #endif
     }

--- a/fmpz_mpoly/gcd_cofactors.c
+++ b/fmpz_mpoly/gcd_cofactors.c
@@ -1235,21 +1235,22 @@ cleanup:
 }
 
 
-int fmpz_mpoly_gcd_cofactors_threaded(
+int fmpz_mpoly_gcd_cofactors(
     fmpz_mpoly_t G,
     fmpz_mpoly_t Abar,
     fmpz_mpoly_t Bbar,
     const fmpz_mpoly_t A,
     const fmpz_mpoly_t B,
-    const fmpz_mpoly_ctx_t ctx,
-    slong thread_limit)
+    const fmpz_mpoly_ctx_t ctx)
 {
-    slong i;
     flint_bitcnt_t Gbits;
     int success;
     thread_pool_handle * handles;
     slong num_handles;
+    slong thread_limit;
     fmpz_mpoly_t Anew, Bnew;
+
+    thread_limit = FLINT_MIN(A->length, B->length)/256;
 
     if (fmpz_mpoly_is_zero(A, ctx))
     {
@@ -1288,36 +1289,10 @@ int fmpz_mpoly_gcd_cofactors_threaded(
 
     if (A->bits <= FLINT_BITS && B->bits <= FLINT_BITS)
     {
-        /* usual gcd's go right down here */
-
-        /* get workers */
-        handles = NULL;
-        num_handles = 0;
-        if (global_thread_pool_initialized)
-        {
-            slong max_num_handles = thread_pool_get_size(global_thread_pool);
-            max_num_handles = FLINT_MIN(thread_limit - 1, max_num_handles);
-            if (max_num_handles > 0)
-            {
-                handles = (thread_pool_handle *) flint_malloc(
-                                   max_num_handles*sizeof(thread_pool_handle));
-                num_handles = thread_pool_request(global_thread_pool,
-                                                     handles, max_num_handles);
-            }
-        }
-
-        success = _fmpz_mpoly_gcd_cofactors(G, Gbits,
-                Abar, A->bits, Bbar, B->bits, A, B, ctx, handles, num_handles);
-
-        for (i = 0; i < num_handles; i++)
-        {
-            thread_pool_give_back(global_thread_pool, handles[i]);
-        }
-        if (handles)
-        {
-            flint_free(handles);
-        }
-
+        num_handles = flint_request_threads(&handles, thread_limit);
+        success = _fmpz_mpoly_gcd_cofactors(G, Gbits, Abar, A->bits,
+                               Bbar, B->bits, A, B, ctx, handles, num_handles);
+        flint_give_back_threads(handles, num_handles);
         return success;
     }
 
@@ -1372,9 +1347,12 @@ int fmpz_mpoly_gcd_cofactors_threaded(
             Buse = Bnew;
         }
 
+        num_handles = flint_request_threads(&handles, thread_limit);
         Gbits = FLINT_MIN(Ause->bits, Buse->bits);
         success = _fmpz_mpoly_gcd_cofactors(G, Gbits, Abar, Ause->bits,
-                                   Bbar, Buse->bits, Ause, Buse, ctx, NULL, 0);
+                      Bbar, Buse->bits, Ause, Buse, ctx, handles, num_handles);
+        flint_give_back_threads(handles, num_handles);
+
         goto cleanup;
 
 could_not_repack:
@@ -1415,9 +1393,12 @@ could_not_repack:
                 goto deflate_cleanup;
         }
 
+        num_handles = flint_request_threads(&handles, thread_limit);
         Gbits = FLINT_MIN(Anew->bits, Bnew->bits);
         success = _fmpz_mpoly_gcd_cofactors(G, Gbits, Abar, Anew->bits,
-                                   Bbar, Bnew->bits, Anew, Bnew, ctx, NULL, 0);
+                      Bbar, Bnew->bits, Anew, Bnew, ctx, handles, num_handles);
+        flint_give_back_threads(handles, num_handles);
+
         if (!success)
             goto deflate_cleanup;
 
@@ -1460,18 +1441,5 @@ cleanup:
     fmpz_mpoly_clear(Bnew, ctx);
 
     return success;
-
-}
-
-int fmpz_mpoly_gcd_cofactors(
-    fmpz_mpoly_t G,
-    fmpz_mpoly_t Abar,
-    fmpz_mpoly_t Bbar,
-    const fmpz_mpoly_t A,
-    const fmpz_mpoly_t B,
-    const fmpz_mpoly_ctx_t ctx)
-{
-    return fmpz_mpoly_gcd_cofactors_threaded(G, Abar, Bbar, A, B,
-                                              ctx, MPOLY_DEFAULT_THREAD_LIMIT);
 }
 

--- a/fmpz_mpoly/mul.c
+++ b/fmpz_mpoly/mul.c
@@ -220,21 +220,21 @@ void fmpz_mpoly_mul(
 
     if (ctx->minfo->ord == ORD_LEX)
     {
-        success = (num_handles == 0)
-                ? _fmpz_mpoly_mul_array_LEX(
-                                    A, B, maxBfields, C, maxCfields, ctx)
-                : _fmpz_mpoly_mul_array_threaded_LEX(
+        success = (num_handles > 0)
+                ? _fmpz_mpoly_mul_array_threaded_LEX(
                                     A, B, maxBfields, C, maxCfields, ctx,
-                                                         handles, num_handles);
+                                                         handles, num_handles)
+                : _fmpz_mpoly_mul_array_LEX(
+                                    A, B, maxBfields, C, maxCfields, ctx);
     }
     else if (ctx->minfo->ord == ORD_DEGLEX || ctx->minfo->ord == ORD_DEGREVLEX)
     {
-        success = (num_handles == 0)
-                ? _fmpz_mpoly_mul_array_DEG(
-                                    A, B, maxBfields, C, maxCfields, ctx)
-                : _fmpz_mpoly_mul_array_threaded_DEG(
+        success = (num_handles > 0)
+                ? _fmpz_mpoly_mul_array_threaded_DEG(
                                     A, B, maxBfields, C, maxCfields, ctx,
-                                                         handles, num_handles);
+                                                         handles, num_handles)
+                : _fmpz_mpoly_mul_array_DEG(
+                                    A, B, maxBfields, C, maxCfields, ctx);
     }
 
     if (success)
@@ -244,14 +244,14 @@ void fmpz_mpoly_mul(
 
 do_heap:
 
-    if (num_handles == 0)
-    {
-        _fmpz_mpoly_mul_johnson_maxfields(A, B, maxBfields, C, maxCfields, ctx);
-    }
-    else
+    if (num_handles > 0)
     {
         _fmpz_mpoly_mul_heap_threaded_maxfields(A,
                       B, maxBfields, C, maxCfields, ctx, handles, num_handles);
+    }
+    else
+    {
+        _fmpz_mpoly_mul_johnson_maxfields(A, B, maxBfields, C, maxCfields, ctx);
     }
 
 cleanup_threads:

--- a/fmpz_mpoly/mul.c
+++ b/fmpz_mpoly/mul.c
@@ -15,6 +15,7 @@
 static int _try_dense(int try_array, slong * Bdegs, slong * Cdegs,
                                            slong Blen, slong Clen, slong nvars)
 {
+    const int max_bit_size = FLINT_MIN(FLINT_BITS/3 + 16, FLINT_BITS - 3);
     slong i, product_count, dense_size;
     ulong hi;
 
@@ -30,7 +31,7 @@ static int _try_dense(int try_array, slong * Bdegs, slong * Cdegs,
             return 0;
     }
 
-    if (dense_size > WORD(5000000))
+    if (dense_size >= WORD(1) << max_bit_size)
         return 0;
 
     umul_ppmm(hi, product_count, Blen, Clen);
@@ -71,8 +72,8 @@ static int _try_array_LEX(slong * Bdegs, slong * Cdegs,
             return 0;
     }
 
-    return dense_size <= WORD(50000000)
-            && dense_size/Blen/Clen < WORD(10);
+    return dense_size <= WORD(50000000) &&
+           dense_size/Blen/Clen < WORD(10);
 }
 
 
@@ -102,17 +103,16 @@ static int _try_array_DEG(slong Btotaldeg, slong Ctotaldeg,
         dense_size /= i + 1;
     }
 
-    return dense_size <= WORD(5000000)
-            && dense_size/Blen/Clen < WORD(10);
+    return dense_size <= WORD(5000000) &&
+           dense_size/Blen/Clen < WORD(10);
 }
 
 
-void fmpz_mpoly_mul_threaded(
+void fmpz_mpoly_mul(
     fmpz_mpoly_t A,
     const fmpz_mpoly_t B,
     const fmpz_mpoly_t C,
-    const fmpz_mpoly_ctx_t ctx,
-    slong thread_limit)
+    const fmpz_mpoly_ctx_t ctx)
 {
     slong i;
     slong nvars = ctx->minfo->nvars;
@@ -121,6 +121,8 @@ void fmpz_mpoly_mul_threaded(
     fmpz * maxBfields, * maxCfields;
     thread_pool_handle * handles;
     slong num_handles;
+    slong min_length, max_length;
+    slong thread_limit;
     TMP_INIT;
 
     if (B->length == 0 || C->length == 0)
@@ -145,33 +147,18 @@ void fmpz_mpoly_mul_threaded(
     mpoly_max_fields_fmpz(maxBfields, B->exps, B->length, B->bits, ctx->minfo);
     mpoly_max_fields_fmpz(maxCfields, C->exps, C->length, C->bits, ctx->minfo);
 
-    handles = NULL;
-    num_handles = 0;
-    if (global_thread_pool_initialized)
-    {
-        slong max_num_handles;
-        max_num_handles = thread_pool_get_size(global_thread_pool);
-        max_num_handles = FLINT_MIN(thread_limit - 1, max_num_handles);
-        if (max_num_handles > 0)
-        {
-            handles = (thread_pool_handle *) flint_malloc(
-                                   max_num_handles*sizeof(thread_pool_handle));
-            num_handles = thread_pool_request(global_thread_pool,
-                                                     handles, max_num_handles);
-        }
-    }
+    min_length = FLINT_MIN(B->length, C->length);
+    max_length = FLINT_MAX(B->length, C->length);
+    thread_limit = min_length/512;
 
     /*
         If one polynomial is tiny or if both polynomials are small,
         heap method with operational complexity O(B->length*C->length) is fine.
     */
-    if (   B->length < 20
-        || C->length < 20
-        || (B->length < 50 && C->length < 50)
-       )
+    if (min_length < 20 || max_length < 50)
     {
         _fmpz_mpoly_mul_johnson_maxfields(A, B, maxBfields, C, maxCfields, ctx);
-        goto done;
+        goto cleanup;
     }
 
     /*
@@ -179,6 +166,7 @@ void fmpz_mpoly_mul_threaded(
     */
     if (B->bits > FLINT_BITS || C->bits > FLINT_BITS)
     {
+        num_handles = flint_request_threads(&handles, thread_limit);
         goto do_heap;
     }
 
@@ -196,11 +184,10 @@ void fmpz_mpoly_mul_threaded(
         If so, it should be about 4x faster than heap.
     */
     try_array = 0;
-    if (   nvars > WORD(1)
-        && nvars < WORD(8)
-        && 1 == mpoly_words_per_exp(B->bits, ctx->minfo)
-        && 1 == mpoly_words_per_exp(C->bits, ctx->minfo)
-       )
+    if (nvars > WORD(1) &&
+        nvars < WORD(8) &&
+        1 == mpoly_words_per_exp(B->bits, ctx->minfo) &&
+        1 == mpoly_words_per_exp(C->bits, ctx->minfo))
     {
         if (ctx->minfo->ord == ORD_LEX)
         {
@@ -220,9 +207,11 @@ void fmpz_mpoly_mul_threaded(
         success = _fmpz_mpoly_mul_dense(A, B, maxBfields, C, maxCfields, ctx);
         if (success)
         {
-            goto done;
+            goto cleanup;
         }
     }
+
+    num_handles = flint_request_threads(&handles, thread_limit);
 
     if (!try_array)
     {
@@ -250,7 +239,7 @@ void fmpz_mpoly_mul_threaded(
 
     if (success)
     {
-        goto done;
+        goto cleanup_threads;
     }
 
 do_heap:
@@ -265,16 +254,11 @@ do_heap:
                       B, maxBfields, C, maxCfields, ctx, handles, num_handles);
     }
 
-done:
+cleanup_threads:
 
-    for (i = 0; i < num_handles; i++)
-    {
-        thread_pool_give_back(global_thread_pool, handles[i]);
-    }
-    if (handles)
-    {
-        flint_free(handles);
-    }
+    flint_give_back_threads(handles, num_handles);
+
+cleanup:
 
     for (i = 0; i < ctx->minfo->nfields; i++)
     {
@@ -285,11 +269,3 @@ done:
     TMP_END;
 }
 
-void fmpz_mpoly_mul(
-    fmpz_mpoly_t A,
-    const fmpz_mpoly_t B,
-    const fmpz_mpoly_t C,
-    const fmpz_mpoly_ctx_t ctx)
-{
-    fmpz_mpoly_mul_threaded(A, B, C, ctx, MPOLY_DEFAULT_THREAD_LIMIT);
-}

--- a/fmpz_mpoly/test/t-gcd.c
+++ b/fmpz_mpoly/test/t-gcd.c
@@ -183,6 +183,8 @@ main(void)
 
         gcd_check(g, a, b, t, ctx, i, 0, "dense examples");
 
+        flint_set_num_threads(n_randint(state, max_threads) + 1);
+
         fmpz_mpoly_clear(a, ctx);
         fmpz_mpoly_clear(b, ctx);
         fmpz_mpoly_clear(g, ctx);

--- a/fmpz_mpoly/test/t-gcd_cofactors.c
+++ b/fmpz_mpoly/test/t-gcd_cofactors.c
@@ -289,6 +289,8 @@ main(void)
 
         gcd_check(g, abar, bbar, a, b, t, ctx, i, 0, "dense examples");
 
+        flint_set_num_threads(n_randint(state, max_threads) + 1);
+
         fmpz_mpoly_clear(a, ctx);
         fmpz_mpoly_clear(b, ctx);
         fmpz_mpoly_clear(g, ctx);

--- a/mpoly.h
+++ b/mpoly.h
@@ -1066,7 +1066,7 @@ FLINT_DLL void mpoly_degrees_si(slong * user_degs, const ulong * poly_exps,
 
 FLINT_DLL void mpoly_degrees_si_threaded(slong * user_degs, const ulong * poly_exps,
                          slong len,  flint_bitcnt_t bits, const mpoly_ctx_t mctx,
-                              thread_pool_handle * handles, slong num_handles);
+                        const thread_pool_handle * handles, slong num_handles);
 
 FLINT_DLL void mpoly_degrees_ffmpz(fmpz * user_degs, const ulong * poly_exps,
                           slong len, flint_bitcnt_t bits, const mpoly_ctx_t mctx);

--- a/mpoly/degrees.c
+++ b/mpoly/degrees.c
@@ -70,7 +70,7 @@ void mpoly_degrees_si_threaded(
     slong len,
     flint_bitcnt_t bits,
     const mpoly_ctx_t mctx,
-    thread_pool_handle * handles,
+    const thread_pool_handle * handles,
     slong num_handles)
 {
     slong i, j;

--- a/nmod_mpoly.h
+++ b/nmod_mpoly.h
@@ -936,9 +936,9 @@ FLINT_DLL int nmod_mpoly_pow_ui(nmod_mpoly_t A, const nmod_mpoly_t B,
 FLINT_DLL int nmod_mpoly_divides(nmod_mpoly_t Q,
        const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx);
 
-FLINT_DLL int nmod_mpoly_divides_threaded(nmod_mpoly_t Q,
+FLINT_DLL int _nmod_mpoly_divides(nmod_mpoly_t Q,
        const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx,
-                                                           slong thread_limit);
+                        const thread_pool_handle * handles, slong num_handles);
 
 FLINT_DLL int nmod_mpoly_divides_monagan_pearce(nmod_mpoly_t Q,
        const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx);
@@ -949,7 +949,7 @@ FLINT_DLL int nmod_mpoly_divides_heap_threaded(nmod_mpoly_t Q,
 
 FLINT_DLL int _nmod_mpoly_divides_heap_threaded(nmod_mpoly_t Q,
        const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx,
-                              thread_pool_handle * handles, slong num_handles);
+                        const thread_pool_handle * handles, slong num_handles);
 
 FLINT_DLL int nmod_mpoly_divides_dense(nmod_mpoly_t Q,
        const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx);

--- a/nmod_mpoly.h
+++ b/nmod_mpoly.h
@@ -865,10 +865,6 @@ FLINT_DLL void nmod_mpoly_compose_nmod_mpoly_gen(nmod_mpoly_t A,
 FLINT_DLL void nmod_mpoly_mul(nmod_mpoly_t A,
        const nmod_mpoly_t B, const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx);
 
-FLINT_DLL void nmod_mpoly_mul_threaded(nmod_mpoly_t A,
-       const nmod_mpoly_t B, const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx,
-                                                           slong thread_limit);
-
 FLINT_DLL void nmod_mpoly_mul_johnson(nmod_mpoly_t A,
        const nmod_mpoly_t B, const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx);
 

--- a/nmod_mpoly.h
+++ b/nmod_mpoly.h
@@ -1004,10 +1004,6 @@ FLINT_DLL void nmod_mpoly_term_content(nmod_mpoly_t M, const nmod_mpoly_t A,
 FLINT_DLL int nmod_mpoly_gcd(nmod_mpoly_t G,
        const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx);
 
-FLINT_DLL int nmod_mpoly_gcd_threaded(nmod_mpoly_t G,
-       const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx,
-                                                           slong thread_limit);
-
 FLINT_DLL int _nmod_mpoly_gcd(nmod_mpoly_t G, flint_bitcnt_t Gbits,
        const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx,
                         const thread_pool_handle * handles, slong num_handles);
@@ -1015,10 +1011,6 @@ FLINT_DLL int _nmod_mpoly_gcd(nmod_mpoly_t G, flint_bitcnt_t Gbits,
 FLINT_DLL int nmod_mpoly_gcd_cofactors(nmod_mpoly_t G,
                 nmod_mpoly_t Abar, nmod_mpoly_t Bbar, const nmod_mpoly_t A,
                              const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx);
-
-FLINT_DLL int nmod_mpoly_gcd_cofactors_threaded(nmod_mpoly_t G,
-                 nmod_mpoly_t Abar, nmod_mpoly_t Bbar, const nmod_mpoly_t A,
-         const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx, slong thread_limit);
 
 FLINT_DLL int _nmod_mpoly_gcd_cofactors(nmod_mpoly_t G, flint_bitcnt_t Gbits,
                                    nmod_mpoly_t Abar, flint_bitcnt_t Abarbits,

--- a/nmod_mpoly/divides_heap_threaded.c
+++ b/nmod_mpoly/divides_heap_threaded.c
@@ -1706,7 +1706,7 @@ int _nmod_mpoly_divides_heap_threaded(
     const nmod_mpoly_t A,
     const nmod_mpoly_t B,
     const nmod_mpoly_ctx_t ctx,
-    thread_pool_handle * handles,
+    const thread_pool_handle * handles,
     slong num_handles)
 {
     ulong mask;

--- a/nmod_mpoly/gcd.c
+++ b/nmod_mpoly/gcd.c
@@ -1102,18 +1102,19 @@ cleanup:
 }
 
 
-int nmod_mpoly_gcd_threaded(
+int nmod_mpoly_gcd(
     nmod_mpoly_t G,
     const nmod_mpoly_t A,
     const nmod_mpoly_t B,
-    const nmod_mpoly_ctx_t ctx,
-    slong thread_limit)
+    const nmod_mpoly_ctx_t ctx)
 {
-    slong i;
     flint_bitcnt_t Gbits;
     int success;
     thread_pool_handle * handles;
     slong num_handles;
+    slong thread_limit;
+
+    thread_limit = FLINT_MIN(A->length, B->length)/256;
 
     if (nmod_mpoly_is_zero(A, ctx))
     {
@@ -1134,35 +1135,9 @@ int nmod_mpoly_gcd_threaded(
 
     if (A->bits <= FLINT_BITS && B->bits <= FLINT_BITS)
     {
-        /* usual gcd's go right down here */
-
-        /* get workers */
-        handles = NULL;
-        num_handles = 0;
-        if (global_thread_pool_initialized)
-        {
-            slong max_num_handles = thread_pool_get_size(global_thread_pool);
-            max_num_handles = FLINT_MIN(thread_limit - 1, max_num_handles);
-            if (max_num_handles > 0)
-            {
-                handles = (thread_pool_handle *) flint_malloc(
-                                   max_num_handles*sizeof(thread_pool_handle));
-                num_handles = thread_pool_request(global_thread_pool,
-                                                     handles, max_num_handles);
-            }
-        }
-
+        num_handles = flint_request_threads(&handles, thread_limit);
         success = _nmod_mpoly_gcd(G, Gbits, A, B, ctx, handles, num_handles);
-
-        for (i = 0; i < num_handles; i++)
-        {
-            thread_pool_give_back(global_thread_pool, handles[i]);
-        }
-        if (handles)
-        {
-            flint_free(handles);
-        }
-
+        flint_give_back_threads(handles, num_handles);
         return success;
     }
 
@@ -1187,34 +1162,38 @@ int nmod_mpoly_gcd_threaded(
         */
 
         int success;
-        int useAnew = 0;
-        int useBnew = 0;
         slong k;
         fmpz * Ashift, * Astride;
         fmpz * Bshift, * Bstride;
         fmpz * Gshift, * Gstride;
-        nmod_mpoly_t Anew;
-        nmod_mpoly_t Bnew;
+        nmod_mpoly_t Anew, Bnew;
+        const nmod_mpoly_struct * Ause, * Buse;
 
         nmod_mpoly_init(Anew, ctx);
         nmod_mpoly_init(Bnew, ctx);
 
+        Ause = A;
         if (A->bits > FLINT_BITS)
         {
-            useAnew = nmod_mpoly_repack_bits(Anew, A, FLINT_BITS, ctx);
-            if (!useAnew)
+            if (!nmod_mpoly_repack_bits(Anew, A, FLINT_BITS, ctx))
                 goto could_not_repack;
+            Ause = Anew;
         }
 
+        Buse = B;
         if (B->bits > FLINT_BITS)
         {
-            useBnew = nmod_mpoly_repack_bits(Bnew, B, FLINT_BITS, ctx);
-            if (!useBnew)
+            if (!nmod_mpoly_repack_bits(Bnew, B, FLINT_BITS, ctx))
                 goto could_not_repack;
+            Buse = Bnew;
         }
 
-        success = _nmod_mpoly_gcd(G, FLINT_BITS, useAnew ? Anew : A,
-                                             useBnew ? Bnew : B, ctx, NULL, 0);
+        num_handles = flint_request_threads(&handles, thread_limit);
+        Gbits = FLINT_MIN(Ause->bits, Buse->bits);
+        success = _nmod_mpoly_gcd(G, Gbits, Ause, Buse, ctx,
+                                                         handles, num_handles);
+        flint_give_back_threads(handles, num_handles);
+
         goto cleanup;
 
 could_not_repack:
@@ -1255,7 +1234,12 @@ could_not_repack:
                 goto deflate_cleanup;
         }
 
-        success = _nmod_mpoly_gcd(G, FLINT_BITS, Anew, Bnew, ctx, NULL, 0);
+
+        num_handles = flint_request_threads(&handles, thread_limit);
+        Gbits = FLINT_MIN(Anew->bits, Bnew->bits);
+        success = _nmod_mpoly_gcd(G, Gbits, Anew, Bnew, ctx,
+                                                         handles, num_handles);
+        flint_give_back_threads(handles, num_handles);
 
         if (success)
         {
@@ -1280,14 +1264,4 @@ cleanup:
         return success;
     }
 }
-
-int nmod_mpoly_gcd(
-    nmod_mpoly_t G,
-    const nmod_mpoly_t A,
-    const nmod_mpoly_t B,
-    const nmod_mpoly_ctx_t ctx)
-{
-    return nmod_mpoly_gcd_threaded(G, A, B, ctx, MPOLY_DEFAULT_THREAD_LIMIT);
-}
-
 

--- a/nmod_mpoly/gcd.c
+++ b/nmod_mpoly/gcd.c
@@ -546,21 +546,23 @@ static int _try_divides(
     nmod_mpoly_t G,
     const nmod_mpoly_t A, int try_a,
     const nmod_mpoly_t B, int try_b,
-    const nmod_mpoly_ctx_t ctx)
+    const nmod_mpoly_ctx_t ctx,
+    const thread_pool_handle * handles,
+    slong num_handles)
 {
     int success;
     nmod_mpoly_t Q;
 
     nmod_mpoly_init(Q, ctx);
 
-    if (try_b && nmod_mpoly_divides_threaded(Q, A, B, ctx, 1))
+    if (try_b && _nmod_mpoly_divides(Q, A, B, ctx, handles, num_handles))
     {
         nmod_mpoly_set(G, B, ctx);
         success = 1;
         goto cleanup;
     }
 
-    if (try_a && nmod_mpoly_divides_threaded(Q, B, A, ctx, 1))
+    if (try_a && _nmod_mpoly_divides(Q, B, A, ctx, handles, num_handles))
     {
         nmod_mpoly_set(G, A, ctx);
         success = 1;
@@ -1057,8 +1059,11 @@ calculate_trivial_gcd:
         if (gcd_is_trivial)
             goto calculate_trivial_gcd;
 
-        if ((try_a || try_b) && _try_divides(G, A, try_a, B, try_b, ctx))
+        if ((try_a || try_b) &&
+            _try_divides(G, A, try_a, B, try_b, ctx, handles, num_handles))
+        {
             goto successful;
+        }
     }
 
     mpoly_gcd_info_measure_brown(I, A->length, B->length, ctx->minfo);

--- a/nmod_mpoly/gcd_cofactors.c
+++ b/nmod_mpoly/gcd_cofactors.c
@@ -940,9 +940,9 @@ cleanup:
         }
 
 #if WANT_ASSERT
-        nmod_mpoly_mul_threaded(T, G, Abar, ctx, 0);
+        nmod_mpoly_mul(T, G, Abar, ctx);
         FLINT_ASSERT(nmod_mpoly_equal(T, Asave, ctx));
-        nmod_mpoly_mul_threaded(T, G, Bbar, ctx, 0);
+        nmod_mpoly_mul(T, G, Bbar, ctx);
         FLINT_ASSERT(nmod_mpoly_equal(T, Bsave, ctx));
 #endif
     }

--- a/nmod_mpoly/mul.c
+++ b/nmod_mpoly/mul.c
@@ -14,6 +14,7 @@
 static int _try_dense(int try_array, slong * Bdegs, slong * Cdegs,
                                            slong Blen, slong Clen, slong nvars)
 {
+    const int max_bit_size = FLINT_MIN(FLINT_BITS/3 + 16, FLINT_BITS - 3);
     slong i, product_count, dense_size;
     ulong hi;
 
@@ -29,7 +30,7 @@ static int _try_dense(int try_array, slong * Bdegs, slong * Cdegs,
             return 0;
     }
 
-    if (dense_size > WORD(5000000))
+    if (dense_size >= WORD(1) << max_bit_size)
         return 0;
 
     umul_ppmm(hi, product_count, Blen, Clen);
@@ -70,8 +71,8 @@ static int _try_array_LEX(slong * Bdegs, slong * Cdegs,
             return 0;
     }
 
-    return dense_size <= WORD(50000000)
-            && dense_size/Blen/Clen < WORD(10);
+    return dense_size <= WORD(50000000) &&
+           dense_size/Blen/Clen < WORD(10);
 }
 
 
@@ -101,17 +102,16 @@ static int _try_array_DEG(slong Btotaldeg, slong Ctotaldeg,
         dense_size /= i + 1;
     }
 
-    return dense_size <= WORD(5000000)
-            && dense_size/Blen/Clen < WORD(10);
+    return dense_size <= WORD(5000000) &&
+           dense_size/Blen/Clen < WORD(10);
 }
 
 
-void nmod_mpoly_mul_threaded(
+void nmod_mpoly_mul(
     nmod_mpoly_t A,
     const nmod_mpoly_t B,
     const nmod_mpoly_t C,
-    const nmod_mpoly_ctx_t ctx,
-    slong thread_limit)
+    const nmod_mpoly_ctx_t ctx)
 {
     slong i;
     slong nvars = ctx->minfo->nvars;
@@ -120,6 +120,8 @@ void nmod_mpoly_mul_threaded(
     fmpz * maxBfields, * maxCfields;
     thread_pool_handle * handles;
     slong num_handles;
+    slong min_length, max_length;
+    slong thread_limit;
     TMP_INIT;
 
     if (B->length == 0 || C->length == 0)
@@ -144,33 +146,18 @@ void nmod_mpoly_mul_threaded(
     mpoly_max_fields_fmpz(maxBfields, B->exps, B->length, B->bits, ctx->minfo);
     mpoly_max_fields_fmpz(maxCfields, C->exps, C->length, C->bits, ctx->minfo);
 
-    handles = NULL;
-    num_handles = 0;
-    if (global_thread_pool_initialized)
-    {
-        slong max_num_handles;
-        max_num_handles = thread_pool_get_size(global_thread_pool);
-        max_num_handles = FLINT_MIN(thread_limit - 1, max_num_handles);
-        if (max_num_handles > 0)
-        {
-            handles = (thread_pool_handle *) flint_malloc(
-                                   max_num_handles*sizeof(thread_pool_handle));
-            num_handles = thread_pool_request(global_thread_pool,
-                                                     handles, max_num_handles);
-        }
-    }
+    min_length = FLINT_MIN(B->length, C->length);
+    max_length = FLINT_MAX(B->length, C->length);
+    thread_limit = min_length/512;
 
     /*
         If one polynomial is tiny or if both polynomials are small,
         heap method with operational complexity O(B->length*C->length) is fine.
     */
-    if (   B->length < 20
-        || C->length < 20
-        || (B->length < 50 && C->length < 50)
-       )
+    if (min_length < 20 || max_length < 50)
     {
         _nmod_mpoly_mul_johnson_maxfields(A, B, maxBfields, C, maxCfields, ctx);
-        goto done;
+        goto cleanup;
     }
 
     /*
@@ -178,6 +165,7 @@ void nmod_mpoly_mul_threaded(
     */
     if (B->bits > FLINT_BITS || C->bits > FLINT_BITS)
     {
+        num_handles = flint_request_threads(&handles, thread_limit);
         goto do_heap;
     }
 
@@ -195,11 +183,10 @@ void nmod_mpoly_mul_threaded(
         If so, it should be about 4x faster than heap.
     */
     try_array = 0;
-    if (   nvars > WORD(1)
-        && nvars < WORD(8)
-        && 1 == mpoly_words_per_exp(B->bits, ctx->minfo)
-        && 1 == mpoly_words_per_exp(C->bits, ctx->minfo)
-       )
+    if (nvars > WORD(1) &&
+        nvars < WORD(8) &&
+        1 == mpoly_words_per_exp(B->bits, ctx->minfo) &&
+        1 == mpoly_words_per_exp(C->bits, ctx->minfo))
     {
         if (ctx->minfo->ord == ORD_LEX)
         {
@@ -219,9 +206,11 @@ void nmod_mpoly_mul_threaded(
         success = _nmod_mpoly_mul_dense(A, B, maxBfields, C, maxCfields, ctx);
         if (success)
         {
-            goto done;
+            goto cleanup;
         }
     }
+
+    num_handles = flint_request_threads(&handles, thread_limit);
 
     if (!try_array)
     {
@@ -249,7 +238,7 @@ void nmod_mpoly_mul_threaded(
 
     if (success)
     {
-        goto done;
+        goto cleanup_threads;
     }
 
 do_heap:
@@ -264,16 +253,11 @@ do_heap:
         _nmod_mpoly_mul_johnson_maxfields(A, B, maxBfields, C, maxCfields, ctx);
     }
 
-done:
+cleanup_threads:
 
-    for (i = 0; i < num_handles; i++)
-    {
-        thread_pool_give_back(global_thread_pool, handles[i]);
-    }
-    if (handles)
-    {
-        flint_free(handles);
-    }
+    flint_give_back_threads(handles, num_handles);
+
+cleanup:
 
     for (i = 0; i < ctx->minfo->nfields; i++)
     {
@@ -284,12 +268,3 @@ done:
     TMP_END;
 }
 
-
-void nmod_mpoly_mul(
-    nmod_mpoly_t A,
-    const nmod_mpoly_t B,
-    const nmod_mpoly_t C,
-    const nmod_mpoly_ctx_t ctx)
-{
-    nmod_mpoly_mul_threaded(A, B, C, ctx, MPOLY_DEFAULT_THREAD_LIMIT);
-}

--- a/nmod_mpoly/test/t-gcd.c
+++ b/nmod_mpoly/test/t-gcd.c
@@ -188,6 +188,8 @@ main(void)
 
         gcd_check(g, a, b, ctx, i, 0, "dense examples");
 
+        flint_set_num_threads(n_randint(state, max_threads) + 1);
+
         nmod_mpoly_clear(a, ctx);
         nmod_mpoly_clear(b, ctx);
         nmod_mpoly_clear(g, ctx);

--- a/nmod_mpoly/test/t-gcd_cofactors.c
+++ b/nmod_mpoly/test/t-gcd_cofactors.c
@@ -251,7 +251,7 @@ main(void)
     flint_printf("gcd_cofactors....");
     fflush(stdout);
 
-    if (0) {
+    {
         nmod_mpoly_ctx_t ctx;
         nmod_mpoly_t g, abar, bbar, a, b, t;
         const char * vars[] = {"t" ,"x", "y", "z"};
@@ -318,6 +318,8 @@ main(void)
         nmod_mpoly_set(t, g, ctx);
 
         gcd_check(g, abar, bbar, a, b, t, ctx, i, 0, "dense examples");
+
+        flint_set_num_threads(n_randint(state, max_threads) + 1);
 
         nmod_mpoly_clear(a, ctx);
         nmod_mpoly_clear(b, ctx);

--- a/thread_support.c
+++ b/thread_support.c
@@ -85,7 +85,7 @@ slong flint_request_threads(thread_pool_handle ** handles, slong thread_limit)
 
     *handles = NULL;
 
-    if (global_thread_pool_initialized)
+    if (global_thread_pool_initialized && thread_limit > 1)
     {
         slong max_num_handles;
         max_num_handles = thread_pool_get_size(global_thread_pool);


### PR DESCRIPTION
I just wanted to make sure this is the desired interface for mul/divides/gcd before copying these changes to nmod. There are still the more specialize functions like fmpz_mpoly_mul_heap_threaded that take an explicit thread limit, but I doubt anyone is ever going to use these.