### PR TITLE
add fmpz_poly_is_cyclotomic

### DIFF
--- a/doc/source/fmpz_poly.rst
+++ b/doc/source/fmpz_poly.rst
@@ -3260,6 +3260,14 @@ Minimal polynomials
     We factor `n` into `n = qs` where `q` is squarefree,
     and compute `\Phi_q(x)`. Then `\Phi_n(x) = \Phi_q(x^s)`.
 
+.. function:: ulong _fmpz_poly_is_cyclotomic(const fmpz * poly, slong len)
+
+.. function:: ulong fmpz_poly_is_cyclotomic(fmpz_poly_t poly)
+
+    If ``poly`` is a cyclotomic polynomial, returns the index `n` of this
+    cyclotomic polynomial. If ``poly`` is not a cyclotomic polynomial,
+    returns 0.
+
 .. function:: void _fmpz_poly_cos_minpoly(fmpz * coeffs, ulong n)
 
 .. function:: void fmpz_poly_cos_minpoly(fmpz_poly_t poly, ulong n)

--- a/fmpz_poly.h
+++ b/fmpz_poly.h
@@ -1365,6 +1365,10 @@ FLINT_DLL void _fmpz_poly_cyclotomic(fmpz * a, ulong n, mp_ptr factors,
                                         slong num_factors, ulong phi);
 FLINT_DLL void fmpz_poly_cyclotomic(fmpz_poly_t poly, ulong n);
 
+FLINT_DLL ulong _fmpz_poly_is_cyclotomic(const fmpz * poly, slong len);
+
+FLINT_DLL ulong fmpz_poly_is_cyclotomic(const fmpz_poly_t poly);
+
 FLINT_DLL void _fmpz_poly_cos_minpoly(fmpz * f, ulong n);
 
 FLINT_DLL void fmpz_poly_cos_minpoly(fmpz_poly_t f, ulong n);

--- a/fmpz_poly/is_cyclotomic.c
+++ b/fmpz_poly/is_cyclotomic.c
@@ -1,0 +1,106 @@
+/*
+    Copyright (C) 2020 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz_poly.h"
+
+ulong
+_fmpz_poly_is_cyclotomic(const fmpz * poly, slong len)
+{
+    ulong * phi;
+    ulong p, q, N1, N2;
+    slong i, d;
+    ulong res;
+    double U;
+    fmpz_poly_t tmp;
+
+    d = len - 1;
+
+    if (d < 1)
+        return 0;
+
+    if (d == 1)
+    {
+        if (fmpz_is_one(poly + 1))
+        {
+            if (fmpz_is_one(poly))
+                return 2;
+            if (fmpz_equal_si(poly, -1))
+                return 1;
+        }
+
+        return 0;
+    }
+
+    if (d % 2 != 0)
+        return 0;
+
+    if (!fmpz_is_one(poly))
+        return 0;
+
+    /* Rule out non-palindromes */
+    for (i = 0; i < d / 2; i++)
+    {
+        if (!fmpz_equal(poly + i, poly + d - i))
+            return 0;
+    }
+
+    /* Compute inverse image of the totient function to find candidate
+       indices of the cyclotomic polynomial */
+
+    /* Determine lower and upper bounds [N1, N2) */
+    U = d;
+    for (p = 2; p <= d; p++)
+        if (d % (p - 1) == 0 && n_is_prime(p))
+            U = (U * p) / (p - 1);
+    N1 = d + 1;
+    N2 = U + 3;   /* +3 as safety for possible floating-point rounding */
+
+    res = 0;
+    phi = flint_malloc(N2 * sizeof(ulong));
+    fmpz_poly_init(tmp);
+
+    for (i = 0; i < N2; i++)
+        phi[i] = i;
+
+    for (p = 2; p < N2; p++)
+    {
+        if (phi[p] == p)
+        {
+            phi[p] = p - 1;
+            for (q = 2 * p; q < N2; q += p)
+                phi[q] = (phi[q] / p) * (p - 1);
+        }
+    }
+
+    for (i = N1; i < N2 && !res; i++)
+    {
+        if (phi[i] == d)
+        {
+            /* todo: we could avoid O(len) overhead by computing the
+               factorisation of phi and calling _fmpz_poly_cyclotomic,
+               checking only the deflated polynomial */
+            fmpz_poly_cyclotomic(tmp, i);
+            if (tmp->length == len && _fmpz_vec_equal(poly, tmp->coeffs, len))
+                res = i;
+        }
+    }
+
+    flint_free(phi);
+    fmpz_poly_clear(tmp);
+
+    return res;
+}
+
+ulong
+fmpz_poly_is_cyclotomic(const fmpz_poly_t poly)
+{
+    return _fmpz_poly_is_cyclotomic(poly->coeffs, poly->length);
+}

--- a/fmpz_poly/test/t-is_cyclotomic.c
+++ b/fmpz_poly/test/t-is_cyclotomic.c
@@ -1,0 +1,105 @@
+/*
+    Copyright (C) 2020 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz_poly.h"
+
+int
+main(void)
+{
+    int i;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("is_cyclotomic....");
+    fflush(stdout);
+
+    /* Check detection of small cyclotomics */
+    for (i = 0; i < 250; i++)
+    {
+        fmpz_poly_t f;
+        ulong n, r;
+
+        n = i;
+
+        fmpz_poly_init(f);
+        fmpz_poly_cyclotomic(f, n);
+        r = fmpz_poly_is_cyclotomic(f);
+
+        if (r != n)
+        {
+            flint_printf("FAIL\n");
+            fmpz_poly_print(f); flint_printf("\n\n");
+            flint_printf("%wu %wu\n\n", n, r);
+            abort();
+        }
+
+        fmpz_poly_clear(f);
+    }
+
+    /* Check detection of large cyclotomics */
+    for (i = 0; i < 10 * flint_test_multiplier(); i++)
+    {
+        fmpz_poly_t f;
+        ulong n, r;
+
+        n = n_randtest(state) % 10000;
+
+        fmpz_poly_init(f);
+        fmpz_poly_cyclotomic(f, n);
+        r = fmpz_poly_is_cyclotomic(f);
+
+        if (r != n)
+        {
+            flint_printf("FAIL\n");
+            fmpz_poly_print(f); flint_printf("\n\n");
+            flint_printf("%wu %wu\n\n", n, r);
+            abort();
+        }
+
+        fmpz_poly_clear(f);
+    }
+
+    /* Check cyclotomic + random polynomial */
+    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
+    {
+        fmpz_poly_t f, g;
+        ulong n;
+
+        fmpz_poly_init(f);
+        fmpz_poly_init(g);
+
+        fmpz_poly_cyclotomic(f, 1 + n_randint(state, 100));
+        fmpz_poly_randtest(g, state, 1 + n_randint(state, 50), 1);
+        fmpz_poly_add(f, f, g);
+
+        n = fmpz_poly_is_cyclotomic(f);
+
+        if (n != 0)
+        {
+            fmpz_poly_cyclotomic(g, n);
+
+            if (!fmpz_poly_equal(f, g))
+            {
+                flint_printf("FAIL\n");
+                fmpz_poly_print(f); flint_printf("\n\n");
+                fmpz_poly_print(g); flint_printf("\n\n");
+                flint_printf("%wu\n\n", n);
+                abort();
+            }
+        }
+
+        fmpz_poly_clear(f);
+        fmpz_poly_clear(g);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+    flint_printf("PASS\n");
+    return 0;
+}


### PR DESCRIPTION
This adds a utility function to detect cyclotomic polynomials. It could be done slightly more efficiently when the input is actually cyclotomic (or when the input is non-cyclotomic but still passes superficial tests), but random polynomials at least get discarded instantly.