### PR TITLE
Add missing aliasing for matrix multiplication

### DIFF
--- a/doc/source/fq_mat.rst
+++ b/doc/source/fq_mat.rst
@@ -260,9 +260,8 @@ Matrix multiplication
 .. function:: void fq_mat_mul(fq_mat_t C, const fq_mat_t A, const fq_mat_t B, const fq_ctx_t ctx)
 
     Sets `C = AB`. Dimensions must be compatible for matrix
-    multiplication.  `C` is not allowed to be aliased with `A` or
-    `B`. This function automatically chooses between classical and
-    KS multiplication.
+    multiplication.  Aliasing is allowed. This function automatically chooses
+    between classical and KS multiplication.
 
 .. function:: void fq_mat_mul_classical(fq_mat_t C, const fq_mat_t A, const fq_mat_t B, const fq_ctx_t ctx)
 

--- a/doc/source/fq_nmod_mat.rst
+++ b/doc/source/fq_nmod_mat.rst
@@ -261,9 +261,8 @@ Matrix multiplication
 .. function:: void fq_nmod_mat_mul(fq_nmod_mat_t C, const fq_nmod_mat_t A, const fq_nmod_mat_t B,  const fq_nmod_ctx_t ctx)
 
     Sets `C = AB`. Dimensions must be compatible for matrix
-    multiplication.  `C` is not allowed to be aliased with `A` or
-    `B`. This function automatically chooses between classical and
-    KS multiplication.
+    multiplication. Aliasing is allowed. This function automatically chooses
+    between classical and KS multiplication.
 
 .. function:: void fq_nmod_mat_mul_classical(fq_nmod_mat_t C, const fq_nmod_mat_t A, const fq_nmod_mat_t B, const fq_nmod_ctx_t ctx)
 

--- a/doc/source/nmod_mat.rst
+++ b/doc/source/nmod_mat.rst
@@ -274,8 +274,8 @@ Matrix multiplication
 .. function:: void nmod_mat_mul(nmod_mat_t C, nmod_mat_t A, nmod_mat_t B)
 
     Sets `C = AB`. Dimensions must be compatible for matrix multiplication.
-    `C` is not allowed to be aliased with `A` or `B`. This function
-    automatically chooses between classical and Strassen multiplication.
+    Aliasing is allowed. This function automatically chooses between classical
+    and Strassen multiplication.
 
 .. function:: void _nmod_mat_mul_classical(nmod_mat_t D, const nmod_mat_t C, const nmod_mat_t A, const nmod_mat_t B, int op)
 

--- a/fq_mat_templates/mul.c
+++ b/fq_mat_templates/mul.c
@@ -18,6 +18,16 @@ TEMPLATE(T, mat_mul) (TEMPLATE(T, mat_t) C,
                       const TEMPLATE(T, mat_t) A,
                       const TEMPLATE(T, mat_t) B, const TEMPLATE(T, ctx_t) ctx)
 {
+    if (C == A || C == B)
+    {
+        TEMPLATE(T, mat_t) TT;
+        TEMPLATE(T, mat_init) (TT, A->r, B->c, ctx);
+        TEMPLATE(T, mat_mul) (TT, A, B, ctx);
+        TEMPLATE(T, mat_swap) (TT, C, ctx);
+        TEMPLATE(T, mat_clear) (TT, ctx);
+        return;
+    }
+
     if (TEMPLATE(CAP_T, MAT_MUL_KS_CUTOFF) (A->r, B->c, ctx))
         TEMPLATE(T, mat_mul_KS) (C, A, B, ctx);
     else

--- a/fq_mat_templates/test/t-mul.c
+++ b/fq_mat_templates/test/t-mul.c
@@ -104,6 +104,17 @@ main(void)
             abort();
         }
 
+        if (n == m)
+        {
+            TEMPLATE(T, mat_mul) (A, A, B, ctx);
+
+            if (!TEMPLATE(T, mat_equal) (A, C, ctx))
+            {
+                flint_printf("FAIL: aliasing failed\n");
+                flint_abort();
+            }
+        }
+
         TEMPLATE(T, mat_clear) (A, ctx);
         TEMPLATE(T, mat_clear) (B, ctx);
         TEMPLATE(T, mat_clear) (C, ctx);

--- a/nmod_mat/mul.c
+++ b/nmod_mat/mul.c
@@ -26,6 +26,16 @@ nmod_mat_mul(nmod_mat_t C, const nmod_mat_t A, const nmod_mat_t B)
     k = A->c;
     n = B->c;
 
+    if (C == A || C == B)
+    {
+        nmod_mat_t T;
+        nmod_mat_init(T, m, n, A->mod.n);
+        nmod_mat_mul(T, A, B);
+        nmod_mat_swap(C, T);
+        nmod_mat_clear(T);
+        return;
+    }
+
     if (FLINT_BITS == 64 && C->mod.n < 2048)
         cutoff = 400;
     else

--- a/nmod_mat/test/t-mul.c
+++ b/nmod_mat/test/t-mul.c
@@ -111,6 +111,17 @@ main(void)
             abort();
         }
 
+        if (n == k)
+        {
+            nmod_mat_mul(A, A, B);
+
+            if (!nmod_mat_equal(A, C))
+            {
+                flint_printf("FAIL: aliasing failed\n");
+                flint_abort();
+            }
+        }
+
         nmod_mat_clear(A);
         nmod_mat_clear(B);
         nmod_mat_clear(C);


### PR DESCRIPTION
I have not run all tests locally, so let's see what travis says.