### PR TITLE
improve fmpz_is_probabprime (issue #291)

### DIFF
--- a/fmpz/is_prime.c
+++ b/fmpz/is_prime.c
@@ -22,12 +22,7 @@
 #include "fmpz.h"
 #include "fmpz_vec.h"
 #include "aprcl.h"
-
-#if FLINT_BITS == 64
-#define ODD_PRIMORIAL UWORD(16294579238595022365)
-#else
-#define ODD_PRIMORIAL UWORD(3234846615)
-#endif
+#include "mpn_extras.h"
 
 int fmpz_is_prime(const fmpz_t n)
 {
@@ -47,8 +42,11 @@ int fmpz_is_prime(const fmpz_t n)
    if (fmpz_abs_fits_ui(n))
       return n_is_prime(fmpz_get_ui(n));
 
-   if (fmpz_is_even(n) || n_gcd(ODD_PRIMORIAL, fmpz_fdiv_ui(n, ODD_PRIMORIAL)) != 1)
+   if (fmpz_is_even(n))
       return 0;
+
+   if (flint_mpn_factor_trial(COEFF_TO_PTR(*n)->_mp_d, COEFF_TO_PTR(*n)->_mp_size, 1, fmpz_bits(n)))
+        return 0;
 
    /* todo: use fmpz_is_perfect_power? */
    if (fmpz_is_square(n))


### PR DESCRIPTION
This improves fmpz_is_probabprime by doing some trial division followed by a BPSW test instead of doing 25 Miller-Rabin rounds. This should both be faster and more reliable.

Time for fmpz_is_probabprime with 10000 random n-bit integers as input:

    n / old / new
    80 / 0.000988 / 0.000599
    160 / 0.0245 / 0.0131
    320 / 0.0581 / 0.0296
    640 / 0.222 / 0.119
    1280 / 1.065 / 0.645
    2560 / 5.336 / 3.758

Time for fmpz_is_probabprime with 1000 random n-bit primes as input:

    n / old / new
    80 / 0.0427 / 0.0196
    160 / 0.154 / 0.0612
    320 / 0.676 / 0.162
    640 / 3.461 / 0.642
    1280 / 23.41 / 3.554

This is with GMP 6.1.2; GMP 6.2 changed its probable prime test to do trial division and a BPSW test plus n-24 Miller-Rabin rounds, so with GMP 6.2 performance should be almost unchanged.

In this patch, I also changed fmpz_is_prime to do more trial division, mainly for consistency with fmpz_is_probabprime. It's hard to measure the performance impact of this change because the average running time fmpz_is_prime seems to be dominated by outliers where the primality test is very slow; in other cases, the performance looks to be roughly the same as before.

While testing this, I also considered improving flint_mpn_factor_trial using something like the following code:

    #if FLINT_BITS == 64
    #define ODD_PRIMORIAL UWORD(16294579238595022365)
    #define NUM_ODD_PRIMES 15
    #else
    #define ODD_PRIMORIAL UWORD(3234846615)
    #define NUM_ODD_PRIMES 9
    #endif

    int flint_mpn_factor_trial(mp_srcptr x, mp_size_t xsize, slong start, slong stop)
    {
        slong i, j, k;
        const mp_limb_t * primes;
        mp_limb_t prod, hi, lo, rem, quot;

        if (start <= NUM_ODD_PRIMES)
        {
            /* This case is useless because the return value is
               indistinguishable from no factor found, but this is the
               documented interface... */
            if (start == 0 && (x[0] % 2 == 0))
                return 0;

            rem = mpn_mod_1(x, xsize, ODD_PRIMORIAL);

            if (start <= 1 && rem % 3 == 0) return 1;
            if (start <= 2 && rem % 5 == 0) return 2;
            if (start <= 3 && rem % 7 == 0) return 3;
            if (start <= 4 && rem % 11 == 0) return 4;
            if (start <= 5 && rem % 13 == 0) return 5;
            if (start <= 6 && rem % 17 == 0) return 6;
            if (start <= 7 && rem % 19 == 0) return 7;
            if (start <= 8 && rem % 23 == 0) return 8;
            if (start <= 9 && rem % 29 == 0) return 9;
            if (start <= 10 && rem % 31 == 0) return 10;
            if (start <= 11 && rem % 37 == 0) return 11;
            if (start <= 12 && rem % 41 == 0) return 12;
            if (start <= 13 && rem % 43 == 0) return 13;
            if (start <= 14 && rem % 47 == 0) return 14;
            if (start <= 15 && rem % 53 == 0) return 15;

            start = NUM_ODD_PRIMES + 1;
        }

        if (start < stop)
            primes = n_primes_arr_readonly(stop);

        for (i = start; i < stop; )
        {
            prod = primes[i];

            for (j = i + 1; j < stop; j++)
            {
                umul_ppmm(hi, lo, prod, primes[j]);
                if (hi != 0)
                    break;
                else
                    prod = lo;
            }

            rem = mpn_mod_1(x, xsize, prod);

            for ( ; i < j; i++)
            {
                if (rem % primes[i] == 0)
                    return i;
            }
        }

        return 0;
    }

I did not notice a significant improvement with this code, so I did not include it in this patch (it's more complex and I didn't test it), but it might be faster on some systems, especially where we use fallback code in mpn_extras. Someone else might want to benchmark that. The GCD trick could also be useful, of course.