### PR TITLE
fix bug in fq_nmod_mpoly_divrem_ideal

### DIFF
--- a/fq_nmod_mpoly/divrem_ideal_monagan_pearce.c
+++ b/fq_nmod_mpoly/divrem_ideal_monagan_pearce.c
@@ -179,7 +179,7 @@ slong _fq_nmod_mpoly_divrem_ideal_monagan_pearce(fq_nmod_mpoly_struct ** polyq,
                     x->p = p;
                     x->next = NULL;
                     hinds[p][x->i] = 2*(x->j + 1) + 0;
-                    mpoly_monomial_add(exp_list[exp_next], exp3[x->p] + x->i*N,
+                    mpoly_monomial_add_mp(exp_list[exp_next], exp3[x->p] + x->i*N,
                                                 polyq[x->p]->exps + x->j*N, N);
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);

--- a/fq_nmod_mpoly/test/t-divrem_ideal_monagan_pearce.c
+++ b/fq_nmod_mpoly/test/t-divrem_ideal_monagan_pearce.c
@@ -24,12 +24,12 @@ main(void)
     fflush(stdout);
 
     /* Check f*g/g = f */
-    for (i = 0; i < 10 * flint_test_multiplier(); i++)
+    for (i = 0; i < 30 * flint_test_multiplier(); i++)
     {
         fq_nmod_mpoly_ctx_t ctx;
         fq_nmod_mpoly_t f, g, h, k, r;
-        slong len, len1, len2, exp_bound, exp_bound1, exp_bound2;
-        slong exp_bits, exp_bits1, exp_bits2;
+        slong len, len1, len2;
+        flint_bitcnt_t exp_bits, exp_bits1, exp_bits2;
         fq_nmod_mpoly_struct * qarr[1], * darr[1];
 
         fq_nmod_mpoly_ctx_init_rand(ctx, state, 10, FLINT_BITS, 5);
@@ -40,27 +40,23 @@ main(void)
         fq_nmod_mpoly_init(k, ctx);
         fq_nmod_mpoly_init(r, ctx);
 
-        len = n_randint(state, 50);
-        len1 = n_randint(state, 50);
-        len2 = n_randint(state, 50) + 1;
+        len = n_randint(state, 30);
+        len1 = n_randint(state, 30);
+        len2 = n_randint(state, 30) + 1;
 
         exp_bits = n_randint(state, 200) + 1;
         exp_bits1 = n_randint(state, 200) + 1;
         exp_bits2 = n_randint(state, 200) + 1;
 
-        exp_bound = n_randbits(state, exp_bits);
-        exp_bound1 = n_randbits(state, exp_bits1);
-        exp_bound2 = n_randbits(state, exp_bits2);
-
         for (j = 0; j < 4; j++)
         {
-            fq_nmod_mpoly_randtest_bound(f, state, len1, exp_bound1, ctx);
+            fq_nmod_mpoly_randtest_bits(f, state, len1, exp_bits1, ctx);
             do {
-                fq_nmod_mpoly_randtest_bound(g, state, len2, exp_bound2 + 1, ctx);
+                fq_nmod_mpoly_randtest_bits(g, state, len2, exp_bits2 + 1, ctx);
             } while (g->length == 0);
-            fq_nmod_mpoly_randtest_bound(h, state, len, exp_bound, ctx);
-            fq_nmod_mpoly_randtest_bound(k, state, len, exp_bound, ctx);
-            fq_nmod_mpoly_randtest_bound(r, state, len, exp_bound, ctx);
+            fq_nmod_mpoly_randtest_bits(h, state, len, exp_bits, ctx);
+            fq_nmod_mpoly_randtest_bits(k, state, len, exp_bits, ctx);
+            fq_nmod_mpoly_randtest_bits(r, state, len, exp_bits, ctx);
 
             fq_nmod_mpoly_mul_johnson(h, f, g, ctx);
 


### PR DESCRIPTION
This fixes two of my bugs, which had a self-canceling effect on the final test code. The only reason @isuruf found it is that n_randbits invokes UB if the bit count is out of range. Maybe this could be in the documentation for n_randbits. should fix #669