### PR TITLE
Add fast paths to speed up fmpq arithmetic with word-size operands

### DIFF
--- a/doc/source/fmpq.rst
+++ b/doc/source/fmpq.rst
@@ -365,8 +365,6 @@ Random number generation
 Arithmetic
 --------------------------------------------------------------------------------
 
-
-
 .. function:: void fmpq_add(fmpq_t res, const fmpq_t op1, const fmpq_t op2)
 
 .. function:: void fmpq_sub(fmpq_t res, const fmpq_t op1, const fmpq_t op2)
@@ -419,9 +417,9 @@ Arithmetic
 
 .. function:: void fmpq_sub_ui(fmpq_t res, const fmpq_t op1, ulong c)
                                                                                
-.. function:: void fmpq_add_fmpz(fmpq_t res, const fmpq_t op1, const fmpz_t c);
+.. function:: void fmpq_add_fmpz(fmpq_t res, const fmpq_t op1, const fmpz_t c)
 
-.. function:: void fmpq_sub_fmpz(fmpq_t res, const fmpq_t op1, const fmpz_t c);
+.. function:: void fmpq_sub_fmpz(fmpq_t res, const fmpq_t op1, const fmpz_t c)
 
    Sets ``res`` to the sum or difference respectively, of the fraction 
    ``op1`` and the integer `c`.
@@ -465,9 +463,9 @@ Arithmetic
     Sets ``dest`` to ``1 / src``. The result is placed in canonical
     form, assuming that ``src`` is already in canonical form.
 
-.. function:: void _fmpq_pow_si(fmpz_t rnum, fmpz_t rden, const fmpz_t opnum, const fmpz_t opden, slong e);
+.. function:: void _fmpq_pow_si(fmpz_t rnum, fmpz_t rden, const fmpz_t opnum, const fmpz_t opden, slong e)
 
-.. function:: void fmpq_pow_si(fmpq_t res, const fmpq_t op, slong e);
+.. function:: void fmpq_pow_si(fmpq_t res, const fmpq_t op, slong e)
 
     Sets ``res`` to ``op`` raised to the power~`e`, where~`e` 
     is a ``slong``.  If `e` is `0` and ``op`` is `0`, then 
@@ -509,6 +507,18 @@ Arithmetic
 
     Set ``res`` to the gcd of ``op1`` and ``op2``. See the low
     level function ``_fmpq_gcd`` for our definition of gcd.
+
+.. function:: void _fmpq_add_small(fmpz_t rnum, fmpz_t rden, slong p1, ulong q1, slong p2, ulong q2)
+
+    Sets ``(rnum, rden)`` to the sum of ``(p1, q1)`` and ``(p2, q2)``.
+    Assumes that ``(p1, q1)`` and ``(p2, q2)`` are in canonical form
+    and that all inputs are between ``COEFF_MIN`` and ``COEFF_MAX``.
+
+.. function:: void _fmpq_mul_small(fmpz_t rnum, fmpz_t rden, slong p1, ulong q1, slong p2, ulong q2)
+
+    Sets ``(rnum, rden)`` to the product of ``(p1, q1)`` and ``(p2, q2)``.
+    Assumes that ``(p1, q1)`` and ``(p2, q2)`` are in canonical form
+    and that all inputs are between ``COEFF_MIN`` and ``COEFF_MAX``.
 
 
 Modular reduction and rational reconstruction

--- a/fmpq.h
+++ b/fmpq.h
@@ -222,6 +222,10 @@ FLINT_DLL void _fmpq_randbits(fmpz_t num, fmpz_t den, flint_rand_t state, flint_
 
 FLINT_DLL void fmpq_randbits(fmpq_t res, flint_rand_t state, flint_bitcnt_t bits);
 
+FLINT_DLL void _fmpq_add_small(fmpz_t rnum, fmpz_t rden, slong p1, ulong q1, slong p2, ulong q2);
+
+FLINT_DLL void _fmpq_mul_small(fmpz_t rnum, fmpz_t rden, slong p1, ulong q1, slong p2, ulong q2);
+
 FLINT_DLL void _fmpq_add(fmpz_t rnum, fmpz_t rden, const fmpz_t op1num,
     const fmpz_t op1den, const fmpz_t op2num, const fmpz_t op2den);
 

--- a/fmpq/add.c
+++ b/fmpq/add.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2011, 2020 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -16,6 +16,12 @@ _fmpq_add(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q,
             const fmpz_t r, const fmpz_t s)
 {
     fmpz_t g, a, b, t, u;
+
+    if (!COEFF_IS_MPZ(*p) && !COEFF_IS_MPZ(*q) && !COEFF_IS_MPZ(*r) && !COEFF_IS_MPZ(*s))
+    {
+        _fmpq_add_small(rnum, rden, *p, *q, *r, *s);
+        return;
+    }
 
     /* Same denominator */
     if (fmpz_equal(q, s))

--- a/fmpq/add_fmpz.c
+++ b/fmpq/add_fmpz.c
@@ -18,6 +18,12 @@ _fmpq_add_fmpz(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q,
 {
     fmpz_t u;
 
+    if (!COEFF_IS_MPZ(*p) && !COEFF_IS_MPZ(*q) && !COEFF_IS_MPZ(*r))
+    {
+        _fmpq_add_small(rnum, rden, *p, *q, *r, 1);
+        return;
+    }
+
     /* both are integers */
     if (fmpz_is_one(q))
     {

--- a/fmpq/add_si.c
+++ b/fmpq/add_si.c
@@ -18,6 +18,12 @@ _fmpq_add_si(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q,
 {
     fmpz_t u;
 
+    if (!COEFF_IS_MPZ(*p) && !COEFF_IS_MPZ(*q) && r >= COEFF_MIN && r <= COEFF_MAX)
+    {
+        _fmpq_add_small(rnum, rden, *p, *q, r, 1);
+        return;
+    }
+
     /* both are integers */
     if (fmpz_is_one(q))
     {

--- a/fmpq/add_small.c
+++ b/fmpq/add_small.c
@@ -1,0 +1,225 @@
+/*
+    Copyright (C) 2020 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fmpq.h"
+
+void
+_fmpq_add_small(fmpz_t rnum, fmpz_t rden, slong p1, ulong q1, slong p2, ulong q2)
+{
+    ulong pp, qq, rr, ss;
+    mp_limb_t hi, lo;
+    int s1, s2;
+
+    if (q1 == q2)
+    {
+        p1 += p2;
+
+        if (q1 != 1)
+        {
+            ulong g = n_gcd(FLINT_ABS(p1), q1);
+
+            if (g != 1)
+            {
+                p1 /= (slong) g;
+                q1 /= g;
+            }
+        }
+
+        fmpz_set_si(rnum, p1);
+        _fmpz_demote(rden);
+        *rden = q1;
+        return;
+    }
+
+    if (p1 == 0)
+    {
+        _fmpz_demote(rnum);
+        _fmpz_demote(rden);
+        *rnum = p2;
+        *rden = q2;
+        return;
+    }
+
+    if (p2 == 0)
+    {
+        _fmpz_demote(rnum);
+        _fmpz_demote(rden);
+        *rnum = p1;
+        *rden = q1;
+        return;
+    }
+
+    qq = q1;
+    ss = q2;
+
+    if (p1 >= 0)
+    {
+        s1 = 0;
+        pp = p1;
+    }
+    else
+    {
+        s1 = 1;
+        pp = -p1;
+    }
+
+    if (p2 >= 0)
+    {
+        s2 = 0;
+        rr = p2;
+    }
+    else
+    {
+        s2 = 1;
+        rr = -p2;
+    }
+
+    if (ss == 1)
+    {
+        umul_ppmm(hi, lo, rr, qq);
+        if (s1 == s2)
+        {
+            add_ssaaaa(hi, lo, hi, lo, 0, pp);
+        }
+        else
+        {
+            if (hi || (lo >= pp))
+            {
+                sub_ddmmss(hi, lo, hi, lo, 0, pp);
+                s1 = s2;
+            }
+            else
+            {
+                hi = 0;
+                lo = pp - lo;
+            }
+        }
+
+        _fmpz_demote(rden);
+        *rden = qq;
+    }
+    else if (qq == 1)
+    {
+        umul_ppmm(hi, lo, pp, ss);
+        if (s1 == s2)
+        {
+            add_ssaaaa(hi, lo, hi, lo, 0, rr);
+        }
+        else
+        {
+            if (hi || (lo >= rr))
+            {
+                sub_ddmmss(hi, lo, hi, lo, 0, rr);
+            }
+            else
+            {
+                hi = 0;
+                lo = rr - lo;
+                s1 = s2;
+            }
+        }
+
+        _fmpz_demote(rden);
+        *rden = ss;
+    }
+    else
+    {
+        ulong g, h, a, b, t, u, v, denhi, denlo;
+
+        g = n_gcd(qq, ss);
+
+        if (g == 1)
+        {
+            umul_ppmm(hi, lo, pp, ss);
+            umul_ppmm(t, u, qq, rr);
+            if (s1 == s2)
+            {
+                add_ssaaaa(hi, lo, hi, lo, t, u);
+            }
+            else
+            {
+                if (hi > t || (hi == t && lo >= u))
+                {
+                    sub_ddmmss(hi, lo, hi, lo, t, u);
+                }
+                else
+                {
+                    sub_ddmmss(hi, lo, t, u, hi, lo);
+                    s1 = s2;
+                }
+            }
+
+            umul_ppmm(denhi, denlo, qq, ss);
+        }
+        else
+        {
+            a = qq / g;
+            b = ss / g;
+
+            umul_ppmm(hi, lo, pp, b);
+            umul_ppmm(t, u, rr, a);
+            if (s1 == s2)
+            {
+                add_ssaaaa(hi, lo, hi, lo, t, u);
+            }
+            else
+            {
+                if (hi > t || (hi == t && lo >= u))
+                {
+                    sub_ddmmss(hi, lo, hi, lo, t, u);
+                }
+                else
+                {
+                    sub_ddmmss(hi, lo, t, u, hi, lo);
+                    s1 = s2;
+                }
+            }
+
+            if (hi == 0)
+            {
+                h = n_gcd(lo, g);
+            }
+            else
+            {
+                udiv_qrnnd(t, h, hi % g, lo, g);
+                h = n_gcd(h, g);
+            }
+
+            if (h != 1)
+            {
+                if (hi == 0)
+                {
+                    lo /= h;
+                }
+                else
+                {
+                    t = hi / h;
+                    u = hi - t * h;
+                    udiv_qrnnd(v, u, u, lo, h);
+                    hi = t;
+                    lo = v;
+                }
+
+                qq /= h;
+            }
+
+            umul_ppmm(denhi, denlo, qq, b);
+        }
+
+        fmpz_set_uiui(rden, denhi, denlo);
+    }
+
+    if (s1)
+        fmpz_neg_uiui(rnum, hi, lo);
+    else
+        fmpz_set_uiui(rnum, hi, lo);
+}
+

--- a/fmpq/add_ui.c
+++ b/fmpq/add_ui.c
@@ -18,13 +18,17 @@ _fmpq_add_ui(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q,
 {
     fmpz_t u;
 
+    if (!COEFF_IS_MPZ(*p) && !COEFF_IS_MPZ(*q) && r <= COEFF_MAX)
+    {
+        _fmpq_add_small(rnum, rden, *p, *q, r, 1);
+        return;
+    }
+
     /* both are integers */
     if (fmpz_is_one(q))
     {
         fmpz_add_ui(rnum, p, r);
-
         fmpz_set(rden, q);
-        
         return;
     }
 

--- a/fmpq/div.c
+++ b/fmpq/div.c
@@ -18,6 +18,15 @@ _fmpq_div(fmpz_t rnum, fmpz_t rden, const fmpz_t op1num, const fmpz_t op1den,
 {
     fmpz_t t, u;
 
+    if (!COEFF_IS_MPZ(*op1num) && !COEFF_IS_MPZ(*op1den) && !COEFF_IS_MPZ(*op2num) && !COEFF_IS_MPZ(*op2den))
+    {
+        if (*op2num > 0)
+            _fmpq_mul_small(rnum, rden, *op1num, *op1den, *op2den, *op2num);
+        else
+            _fmpq_mul_small(rnum, rden, *op1num, *op1den, -(*op2den), -(*op2num));
+        return;
+    }
+
     fmpz_init(t);
     fmpz_init(u);
     fmpz_set(t, op2den);

--- a/fmpq/div_fmpz.c
+++ b/fmpq/div_fmpz.c
@@ -15,13 +15,24 @@ void fmpq_div_fmpz(fmpq_t res, const fmpq_t op, const fmpz_t x)
 {
     fmpz_t y;
 
-    fmpz_init(y);
-    fmpz_one(y);
+    if (fmpz_is_zero(x))
+    {
+        flint_printf("Exception (fmpq_div_fmpz). Division by zero.\n");
+        flint_abort();
+    }
 
+    if (!COEFF_IS_MPZ(*fmpq_numref(op)) && !COEFF_IS_MPZ(*fmpq_denref(op)) && !COEFF_IS_MPZ(*x))
+    {
+        if (*x >= 0)
+            _fmpq_mul_small(fmpq_numref(res), fmpq_denref(res), *fmpq_numref(op), *fmpq_denref(op), 1, *x);
+        else
+            _fmpq_mul_small(fmpq_numref(res), fmpq_denref(res), *fmpq_numref(op), *fmpq_denref(op), -WORD(1), -(*x));
+        return;
+    }
+
+    *y = 1;
     _fmpq_mul(fmpq_numref(res), fmpq_denref(res),
               fmpq_numref(op), fmpq_denref(op), y, x);
-
-    fmpz_clear(y);
 
     if (fmpz_sgn(fmpq_denref(res)) < 0)
     {

--- a/fmpq/mul.c
+++ b/fmpq/mul.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2011, 2020 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -15,6 +15,12 @@ void
 _fmpq_mul(fmpz_t rnum, fmpz_t rden, const fmpz_t op1num, const fmpz_t op1den,
             const fmpz_t op2num, const fmpz_t op2den)
 {
+    if (!COEFF_IS_MPZ(*op1num) && !COEFF_IS_MPZ(*op1den) && !COEFF_IS_MPZ(*op2num) && !COEFF_IS_MPZ(*op2den))
+    {
+        _fmpq_mul_small(rnum, rden, *op1num, *op1den, *op2num, *op2den);
+        return;
+    }
+
     /* Common special cases: squaring, same denominator (e.g. both integers) */
     if (((op1num == op2num) && (op1den == op2den)) ||
          fmpz_equal(op1den, op2den))

--- a/fmpq/mul_fmpz.c
+++ b/fmpq/mul_fmpz.c
@@ -14,12 +14,7 @@
 void fmpq_mul_fmpz(fmpq_t res, const fmpq_t op, const fmpz_t x)
 {
     fmpz_t y;
-
-    fmpz_init(y);
-    fmpz_one(y);
-
+    *y = 1;
     _fmpq_mul(fmpq_numref(res), fmpq_denref(res),
               fmpq_numref(op), fmpq_denref(op), x, y);
-
-    fmpz_clear(y);
 }

--- a/fmpq/mul_si.c
+++ b/fmpq/mul_si.c
@@ -17,7 +17,7 @@ static ulong _fmpz_gcd_ui(const fmpz_t g, ulong h)
     if (!COEFF_IS_MPZ(*g))
         return n_gcd(FLINT_ABS(*g), h);
     else
-        return n_gcd(mpz_fdiv_ui(COEFF_TO_PTR(*g), h), h);
+        return n_gcd(flint_mpz_fdiv_ui(COEFF_TO_PTR(*g), h), h);
 }
 
 void

--- a/fmpq/mul_small.c
+++ b/fmpq/mul_small.c
@@ -1,0 +1,81 @@
+/*
+    Copyright (C) 2020 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fmpq.h"
+
+void
+_fmpq_mul_small(fmpz_t rnum, fmpz_t rden, slong op1num, ulong op1den, slong op2num, ulong op2den)
+{
+    mp_limb_t hi, lo, denhi, denlo;
+    int neg;
+
+    if (op1num == 0 || op2num == 0)
+    {
+        fmpz_zero(rnum);
+        fmpz_one(rden);
+        return;
+    }
+
+    neg = 0;
+    if (op1num < 0)
+    {
+        op1num = -op1num;
+        neg = 1;
+    }
+
+    if (op2num < 0)
+    {
+        op2num = -op2num;
+        neg = !neg;
+    }
+
+    if (op1den == op2den)
+    {
+        umul_ppmm(hi, lo, op1num, op2num);
+        umul_ppmm(denhi, denlo, op1den, op2den);
+    }
+    else if (op1den == 1)
+    {
+        ulong t, x;
+        t = n_gcd(op1num, op2den);
+        x = op1num / t;
+        t = op2den / t;
+        umul_ppmm(hi, lo, x, op2num);
+        umul_ppmm(denhi, denlo, op1den, t);
+    }
+    else if (op2den == 1)
+    {
+        ulong t, x;
+        t = n_gcd(op2num, op1den);
+        x = op2num / t;
+        t = op1den / t;
+        umul_ppmm(hi, lo, x, op1num);
+        umul_ppmm(denhi, denlo, op2den, t);
+    }
+    else
+    {
+        ulong t, u, x, y;
+        t = n_gcd(op1num, op2den);
+        u = n_gcd(op1den, op2num);
+        x = op1num / t;
+        y = op2num / u;
+        umul_ppmm(hi, lo, x, y);
+        x = op1den / u;
+        y = op2den / t;
+        umul_ppmm(denhi, denlo, x, y);
+    }
+
+    if (neg)
+        fmpz_neg_uiui(rnum, hi, lo);
+    else
+        fmpz_set_uiui(rnum, hi, lo);
+    fmpz_set_uiui(rden, denhi, denlo);
+}

--- a/fmpq/mul_ui.c
+++ b/fmpq/mul_ui.c
@@ -17,7 +17,7 @@ static ulong _fmpz_gcd_ui(const fmpz_t g, ulong h)
     if (!COEFF_IS_MPZ(*g))
         return n_gcd(FLINT_ABS(*g), h);
     else
-        return n_gcd(mpz_fdiv_ui(COEFF_TO_PTR(*g), h), h);
+        return n_gcd(flint_mpz_fdiv_ui(COEFF_TO_PTR(*g), h), h);
 }
 
 void

--- a/fmpq/mul_ui.c
+++ b/fmpq/mul_ui.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2020 William Hart
+    Copyright (C) 2020 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -11,38 +12,46 @@
 
 #include "fmpq.h"
 
+static ulong _fmpz_gcd_ui(const fmpz_t g, ulong h)
+{
+    if (!COEFF_IS_MPZ(*g))
+        return n_gcd(FLINT_ABS(*g), h);
+    else
+        return n_gcd(mpz_fdiv_ui(COEFF_TO_PTR(*g), h), h);
+}
+
 void
 _fmpq_mul_ui(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q,
             ulong r)
 {
-    fmpz_t u;
-
-    if (r == 0)
+    if (r == 0 || fmpz_is_zero(p))
     {
         fmpz_zero(rnum);
         fmpz_one(rden);
-    } else if (r == 1)
+    }
+    else if (!COEFF_IS_MPZ(*p) && !COEFF_IS_MPZ(*q) && r <= COEFF_MAX)
+    {
+        _fmpq_mul_small(rnum, rden, *p, *q, r, 1);
+    }
+    else if (r == 1)
     {
         fmpz_set(rnum, p);
-	fmpz_set(rden, q);
-    } else
+        fmpz_set(rden, q);
+    }
+    else
     {
-	fmpz_init_set_ui(u, r);
+        ulong g = _fmpz_gcd_ui(q, r);
 
-        fmpz_gcd(u, u, q);
-
-        if (!fmpz_is_one(u))
+        if (g == 1)
         {
-            r /= fmpz_get_ui(u);
-            fmpz_tdiv_q(rden, q, u);
-        } else
             fmpz_set(rden, q);
-
-        fmpz_mul_ui(rnum, p, r);
-
-	fmpz_clear(u);
-
-        return;
+            fmpz_mul_ui(rnum, p, r);
+        }
+        else
+        {
+            fmpz_mul_ui(rnum, p, r / g);
+            fmpz_divexact_ui(rden, q, g);
+        }
     }
 }
 

--- a/fmpq/sub.c
+++ b/fmpq/sub.c
@@ -17,6 +17,12 @@ _fmpq_sub(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q,
 {
     fmpz_t g, a, b, t, u;
 
+    if (!COEFF_IS_MPZ(*p) && !COEFF_IS_MPZ(*q) && !COEFF_IS_MPZ(*r) && !COEFF_IS_MPZ(*s))
+    {
+        _fmpq_add_small(rnum, rden, *p, *q, -(*r), *s);
+        return;
+    }
+
     /* Same denominator */
     if (fmpz_equal(q, s))
     {

--- a/fmpq/sub_fmpz.c
+++ b/fmpq/sub_fmpz.c
@@ -18,14 +18,18 @@ _fmpq_sub_fmpz(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q,
 {
     fmpz_t u;
 
+    if (!COEFF_IS_MPZ(*p) && !COEFF_IS_MPZ(*q) && !COEFF_IS_MPZ(*r))
+    {
+        _fmpq_add_small(rnum, rden, *p, *q, -(*r), 1);
+        return;
+    }
+
     /* both are integers */
     if (fmpz_is_one(q))
     {
         fmpz_sub(rnum, p, r);
-        
         fmpz_set(rden, q);
-        
-        return;
+                return;
     }
 
     /*

--- a/fmpq/sub_si.c
+++ b/fmpq/sub_si.c
@@ -18,6 +18,12 @@ _fmpq_sub_si(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q,
 {
     fmpz_t u;
 
+    if (!COEFF_IS_MPZ(*p) && !COEFF_IS_MPZ(*q) && r >= COEFF_MIN && r <= COEFF_MAX)
+    {
+        _fmpq_add_small(rnum, rden, *p, *q, -r, 1);
+        return;
+    }
+
     /* both are integers */
     if (fmpz_is_one(q))
     {
@@ -27,7 +33,6 @@ _fmpq_sub_si(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q,
            fmpz_add_ui(rnum, p, -r);
 
         fmpz_set(rden, q);
-        
         return;
     }
 

--- a/fmpq/sub_ui.c
+++ b/fmpq/sub_ui.c
@@ -18,13 +18,17 @@ _fmpq_sub_ui(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q,
 {
     fmpz_t u;
 
+    if (!COEFF_IS_MPZ(*p) && !COEFF_IS_MPZ(*q) && r <= COEFF_MAX)
+    {
+        _fmpq_add_small(rnum, rden, *p, *q, -(slong) r, 1);
+        return;
+    }
+
     /* both are integers */
     if (fmpz_is_one(q))
     {
         fmpz_sub_ui(rnum, p, r);
-
         fmpz_set(rden, q);
-        
         return;
     }
 


### PR DESCRIPTION
This makes operations on small fmpqs roughly twice as fast.