### PR TITLE
Update FLINT_VERSION in header file

### DIFF
--- a/flint.h
+++ b/flint.h
@@ -55,9 +55,9 @@
 /* flint version number */
 
 #define __FLINT_VERSION 2
-#define __FLINT_VERSION_MINOR 5
-#define __FLINT_VERSION_PATCHLEVEL 3
-#define FLINT_VERSION "2.5.3"
+#define __FLINT_VERSION_MINOR 6
+#define __FLINT_VERSION_PATCHLEVEL 0
+#define FLINT_VERSION "2.6.0"
 #define __FLINT_RELEASE (__FLINT_VERSION * 10000 + \
                          __FLINT_VERSION_MINOR * 100 + \
                          __FLINT_VERSION_PATCHLEVEL)


### PR DESCRIPTION
This isn't the 2.6.0 release yet, but I need a new version number to check for in Arb to handle incompatibilities between flint-2.5 and the current flint trunk.