### PR TITLE
Fix memory leaks

### DIFF
--- a/aprcl/test/t-unity_zp_reduce_cyclotomic.c
+++ b/aprcl/test/t-unity_zp_reduce_cyclotomic.c
@@ -72,6 +72,7 @@ int main(void)
             abort();
         }
 
+        fmpz_clear(n);
         fmpz_mod_poly_clear(cyclo_poly);
         unity_zp_clear(f);
         unity_zp_clear(g);

--- a/fmpq_mpoly/test/t-get_set_term_coeff_fmpq.c
+++ b/fmpq_mpoly/test/t-get_set_term_coeff_fmpq.c
@@ -41,7 +41,12 @@ main(void)
 
         fmpq_mpoly_randtest_bits(f, state, len, coeff_bits, exp_bits, ctx);
         if (fmpq_mpoly_length(f, ctx) == WORD(0))
+        {
+            fmpq_mpoly_clear(f, ctx);
+            fmpq_clear(c);
+            fmpq_clear(d);
             continue;
+        }
 
         for (j = 0; j < 10; j++)
         {

--- a/fmpq_mpoly/test/t-get_set_term_coeff_fmpq.c
+++ b/fmpq_mpoly/test/t-get_set_term_coeff_fmpq.c
@@ -35,18 +35,13 @@ main(void)
         fmpq_mpoly_ctx_init_rand(ctx, state, 20);
         fmpq_mpoly_init(f, ctx);
 
-        len = n_randint(state, 100);
-        exp_bits = n_randint(state, 200) + 1;
-        coeff_bits = n_randint(state, 200);
+        do {
+            len = n_randint(state, 100);
+            exp_bits = n_randint(state, 200) + 1;
+            coeff_bits = n_randint(state, 200);
 
-        fmpq_mpoly_randtest_bits(f, state, len, coeff_bits, exp_bits, ctx);
-        if (fmpq_mpoly_length(f, ctx) == WORD(0))
-        {
-            fmpq_mpoly_clear(f, ctx);
-            fmpq_clear(c);
-            fmpq_clear(d);
-            continue;
-        }
+            fmpq_mpoly_randtest_bits(f, state, len, coeff_bits, exp_bits, ctx);
+        } while (fmpq_mpoly_length(f, ctx) == 0);
 
         for (j = 0; j < 10; j++)
         {

--- a/fmpq_mpoly/test/t-get_set_term_exp_fmpz.c
+++ b/fmpq_mpoly/test/t-get_set_term_exp_fmpz.c
@@ -43,7 +43,10 @@ main(void)
 
         fmpq_mpoly_randtest_bits(f, state, len, coeff_bits, exp_bits, ctx);
         if (fmpq_mpoly_length(f, ctx) == 0)
+        {
+            fmpq_mpoly_clear(f, ctx);
             continue;
+        }
 
         for (j = 0; j < 10; j++)
         {

--- a/fmpq_mpoly/test/t-get_set_term_exp_fmpz.c
+++ b/fmpq_mpoly/test/t-get_set_term_exp_fmpz.c
@@ -37,16 +37,13 @@ main(void)
 
         nvars = fmpq_mpoly_ctx_nvars(ctx);
 
-        len = n_randint(state, 50);
-        exp_bits = n_randint(state, 100) + 1;
-        coeff_bits = n_randint(state, 100);
+        do {
+            len = n_randint(state, 50);
+            exp_bits = n_randint(state, 100) + 1;
+            coeff_bits = n_randint(state, 100);
 
-        fmpq_mpoly_randtest_bits(f, state, len, coeff_bits, exp_bits, ctx);
-        if (fmpq_mpoly_length(f, ctx) == 0)
-        {
-            fmpq_mpoly_clear(f, ctx);
-            continue;
-        }
+            fmpq_mpoly_randtest_bits(f, state, len, coeff_bits, exp_bits, ctx);
+        } while (fmpq_mpoly_length(f, ctx) == 0);
 
         for (j = 0; j < 10; j++)
         {

--- a/fmpz_factor/pollard_brent.c
+++ b/fmpz_factor/pollard_brent.c
@@ -143,6 +143,7 @@ fmpz_factor_pollard_brent(fmpz_t p_factor, flint_rand_t state, fmpz_t n_in,
     fmpz_clear(fa);
     fmpz_clear(fy);
     fmpz_clear(maxa);
+    fmpz_clear(maxy);
 
     TMP_END;
     

--- a/fmpz_factor/test/t-pollard_brent_single.c
+++ b/fmpz_factor/test/t-pollard_brent_single.c
@@ -94,6 +94,10 @@ int main(void)
     fmpz_clear(primeprod);
     fmpz_clear(fac);
     fmpz_clear(modval);
+    fmpz_clear(a);
+    fmpz_clear(y);
+    fmpz_clear(maxa);
+    fmpz_clear(maxy);
 
     flint_printf("PASS\n");
     return 0;

--- a/fmpz_mat/test/t-hnf_minors_transform.c
+++ b/fmpz_mat/test/t-hnf_minors_transform.c
@@ -87,6 +87,8 @@ main(void)
             abort();
         }
 
+        fmpz_mat_clear(UA);
+        fmpz_mat_clear(U);
         fmpz_mat_clear(H2);
         fmpz_mat_clear(H);
         fmpz_mat_clear(A);

--- a/fmpz_mod_poly/compose_mod_brent_kung_vec_preinv.c
+++ b/fmpz_mod_poly/compose_mod_brent_kung_vec_preinv.c
@@ -144,11 +144,7 @@ fmpz_mod_poly_compose_mod_brent_kung_vec_preinv(fmpz_mod_poly_struct * res,
     if (len2 == 1)
     {
         for (i = 0; i < n; i++)
-        {
-            fmpz_mod_poly_clear(res + i);
-            fmpz_mod_poly_init(res + i, &poly->p);
             fmpz_mod_poly_zero(res + i);
-        }
 
         return;
     }
@@ -156,11 +152,7 @@ fmpz_mod_poly_compose_mod_brent_kung_vec_preinv(fmpz_mod_poly_struct * res,
     if (len2 == 2)
     {
         for (i = 0; i < n; i++)
-        {
-            fmpz_mod_poly_clear(res + i);
-            fmpz_mod_poly_init(res + i, &poly->p);
             fmpz_mod_poly_set(res + i, polys + i);
-        }
 
         return;
     }

--- a/fmpz_mod_poly/compose_mod_brent_kung_vec_preinv.c
+++ b/fmpz_mod_poly/compose_mod_brent_kung_vec_preinv.c
@@ -145,6 +145,7 @@ fmpz_mod_poly_compose_mod_brent_kung_vec_preinv(fmpz_mod_poly_struct * res,
     {
         for (i = 0; i < n; i++)
         {
+            fmpz_mod_poly_clear(res + i);
             fmpz_mod_poly_init(res + i, &poly->p);
             fmpz_mod_poly_zero(res + i);
         }
@@ -156,6 +157,7 @@ fmpz_mod_poly_compose_mod_brent_kung_vec_preinv(fmpz_mod_poly_struct * res,
     {
         for (i = 0; i < n; i++)
         {
+            fmpz_mod_poly_clear(res + i);
             fmpz_mod_poly_init(res + i, &poly->p);
             fmpz_mod_poly_set(res + i, polys + i);
         }

--- a/fmpz_mod_poly/test/t-print_read.c
+++ b/fmpz_mod_poly/test/t-print_read.c
@@ -56,7 +56,7 @@ int main(void)
         a = flint_malloc(n * sizeof(fmpz_mod_poly_t));
         for (i = 0; i < n; i++)
         {
-            fmpz_mod_poly_init(a[i],two);
+            fmpz_mod_poly_init(a[i], two);
             fmpz_mod_poly_randtest(a[i], state, n_randint(state, 100));
         }
 
@@ -221,7 +221,7 @@ int main(void)
             i = 0;
             /* Only four junk bytes are sent and our read
                doesn't consume invalid bytes, so eof is never reached */
-            for(i=0; i<500; i++)
+            for(i = 0; i < 500; i++)
             {
                 r = fmpz_mod_poly_fread(in, t);
                 if (r > 0)

--- a/fmpz_mod_poly/test/t-print_read.c
+++ b/fmpz_mod_poly/test/t-print_read.c
@@ -101,6 +101,9 @@ int main(void)
                 }
             }
 
+            for (j = 0; j < n; j++)
+                fmpz_mod_poly_clear(a[j]);
+            flint_free(a);
             fclose(out);
             exit(0);
         }

--- a/fmpz_mod_poly/test/t-product_roots_fmpz_vec.c
+++ b/fmpz_mod_poly/test/t-product_roots_fmpz_vec.c
@@ -80,6 +80,7 @@ main(void)
         fmpz_poly_clear(Q);
         fmpz_poly_clear(tmp);
         _fmpz_vec_clear(x, n);
+        fmpz_clear(mod);
     }
 
     FLINT_TEST_CLEANUP(state);

--- a/fmpz_mpoly/test/t-get_set_term_exp_fmpz.c
+++ b/fmpz_mpoly/test/t-get_set_term_exp_fmpz.c
@@ -45,7 +45,11 @@ main(void)
 
         fmpz_mpoly_randtest_bits(f, state, len, coeff_bits, exp_bits, ctx);
         if (f->length == WORD(0))
+        {
+            fmpz_mpoly_clear(f, ctx);
+            fmpz_mpoly_ctx_clear(ctx);
             continue;
+        }
 
         for (j = 0; j < 10; j++)
         {

--- a/fmpz_mpoly/test/t-get_set_term_exp_fmpz.c
+++ b/fmpz_mpoly/test/t-get_set_term_exp_fmpz.c
@@ -39,17 +39,13 @@ main(void)
 
         nvars = fmpz_mpoly_ctx_nvars(ctx);
 
-        len = n_randint(state, 50);
-        exp_bits = n_randint(state, 100) + 1;
-        coeff_bits = n_randint(state, 100);
+        do {
+            len = n_randint(state, 50);
+            exp_bits = n_randint(state, 100) + 1;
+            coeff_bits = n_randint(state, 100);
 
-        fmpz_mpoly_randtest_bits(f, state, len, coeff_bits, exp_bits, ctx);
-        if (f->length == WORD(0))
-        {
-            fmpz_mpoly_clear(f, ctx);
-            fmpz_mpoly_ctx_clear(ctx);
-            continue;
-        }
+            fmpz_mpoly_randtest_bits(f, state, len, coeff_bits, exp_bits, ctx);
+        } while (f->length == 0);
 
         for (j = 0; j < 10; j++)
         {

--- a/fmpz_poly/div_basecase.c
+++ b/fmpz_poly/div_basecase.c
@@ -56,6 +56,7 @@ _fmpz_poly_div_basecase(fmpz * Q, fmpz * R, const fmpz * A, slong lenA,
         {
             if (exact && !fmpz_is_zero(R + lenA - 1))
             {
+                fmpz_clear(r);
                 if (alloc)
                     _fmpz_vec_clear(R, alloc);
 
@@ -71,8 +72,9 @@ _fmpz_poly_div_basecase(fmpz * Q, fmpz * R, const fmpz * A, slong lenA,
 
                 if (!fmpz_is_zero(r))
                 {
+                    fmpz_clear(r);
                     if (alloc)
-                    _fmpz_vec_clear(R, alloc);
+                        _fmpz_vec_clear(R, alloc);
 
                     return 0;
                 }

--- a/fmpz_poly/div_basecase.c
+++ b/fmpz_poly/div_basecase.c
@@ -73,7 +73,7 @@ _fmpz_poly_div_basecase(fmpz * Q, fmpz * R, const fmpz * A, slong lenA,
                     res = 0;
                     goto cleanup;
                 }
-                
+            } else
                 fmpz_fdiv_q(Q + iQ, R + lenA - 1, leadB);
 
             _fmpz_vec_scalar_submul_fmpz(R + lenA - B1 - 1, B, B1, Q + iQ);

--- a/fmpz_poly/div_basecase.c
+++ b/fmpz_poly/div_basecase.c
@@ -25,6 +25,7 @@ _fmpz_poly_div_basecase(fmpz * Q, fmpz * R, const fmpz * A, slong lenA,
     slong B1, iQ = lenA - lenB;
     slong alloc;
     fmpz_t r;
+    int res = 1;
 
     while (lenA >= lenB && fmpz_cmpabs(A + lenA - 1, leadB) < 0)
     {
@@ -56,11 +57,8 @@ _fmpz_poly_div_basecase(fmpz * Q, fmpz * R, const fmpz * A, slong lenA,
         {
             if (exact && !fmpz_is_zero(R + lenA - 1))
             {
-                fmpz_clear(r);
-                if (alloc)
-                    _fmpz_vec_clear(R, alloc);
-
-                return 0;
+                res = 0;
+                goto cleanup;
             }
 
             fmpz_zero(Q + iQ);
@@ -72,13 +70,10 @@ _fmpz_poly_div_basecase(fmpz * Q, fmpz * R, const fmpz * A, slong lenA,
 
                 if (!fmpz_is_zero(r))
                 {
-                    fmpz_clear(r);
-                    if (alloc)
-                        _fmpz_vec_clear(R, alloc);
-
-                    return 0;
+                    res = 0;
+                    goto cleanup;
                 }
-            } else
+                
                 fmpz_fdiv_q(Q + iQ, R + lenA - 1, leadB);
 
             _fmpz_vec_scalar_submul_fmpz(R + lenA - B1 - 1, B, B1, Q + iQ);
@@ -94,13 +89,15 @@ _fmpz_poly_div_basecase(fmpz * Q, fmpz * R, const fmpz * A, slong lenA,
         iQ--;
     }
 
+cleanup:
+        
     if (exact)
         fmpz_clear(r);
 
     if (alloc)
         _fmpz_vec_clear(R, alloc);
 
-    return 1;
+    return res;
 }
 
 void

--- a/fmpz_poly/div_series_divconquer.c
+++ b/fmpz_poly/div_series_divconquer.c
@@ -27,7 +27,7 @@ _fmpz_poly_div_series_divconquer(fmpz * Q, const fmpz * A, slong Alen,
     if (!_fmpz_poly_div(Q, Arev, 2*n - 1, Brev, n, 1))
     {
         _fmpz_vec_clear(Arev, 2*n - 1);
-        _fmpz_vec_clear(Brev, n - 1);
+        _fmpz_vec_clear(Brev, n);
 
         flint_printf("Not an exact division\n");
         flint_abort();
@@ -36,7 +36,7 @@ _fmpz_poly_div_series_divconquer(fmpz * Q, const fmpz * A, slong Alen,
     _fmpz_poly_reverse(Q, Q, n, n);
 
     _fmpz_vec_clear(Arev, 2*n - 1);
-    _fmpz_vec_clear(Brev, n - 1);
+    _fmpz_vec_clear(Brev, n);
 }
 
 void fmpz_poly_div_series_divconquer(fmpz_poly_t Q, const fmpz_poly_t A,

--- a/fmpz_poly/mullow_SS_precache.c
+++ b/fmpz_poly/mullow_SS_precache.c
@@ -145,6 +145,7 @@ void _fmpz_poly_mullow_SS_precache(fmpz * output, const fmpz * input1,
                                                       len_out, t1, t2, s1, tt);
 
     _fmpz_vec_set_fft(output, trunc, ii, pre->limbs, 1); /* write output */
+    flint_free(ii);
 }
 
 void

--- a/fq_embed_templates/test/t-composition_matrix.c
+++ b/fq_embed_templates/test/t-composition_matrix.c
@@ -39,7 +39,10 @@ main(void)
         TEMPLATE(T, ctx_randtest)(ctx, state);
         d = TEMPLATE(T, ctx_degree)(ctx);
         if (d == 1) 
+        {
+            TEMPLATE(T, ctx_clear)(ctx);
             continue;
+        }
         modulus = TEMPLATE(T, ctx_modulus)(ctx);
 
         TEMPLATE(T, init)(frob, ctx);

--- a/fq_embed_templates/test/t-composition_matrix.c
+++ b/fq_embed_templates/test/t-composition_matrix.c
@@ -39,7 +39,7 @@ main(void)
         do {
             TEMPLATE(T, ctx_randtest)(ctx, state);
             d = TEMPLATE(T, ctx_degree)(ctx);
-        while (d == 1); 
+        } while (d == 1); 
             
         modulus = TEMPLATE(T, ctx_modulus)(ctx);
 

--- a/fq_embed_templates/test/t-composition_matrix.c
+++ b/fq_embed_templates/test/t-composition_matrix.c
@@ -36,13 +36,11 @@ main(void)
         TEMPLATE(B, mat_t) mat_frob, mat_a, mat_aq, res;
         slong d;
 
-        TEMPLATE(T, ctx_randtest)(ctx, state);
-        d = TEMPLATE(T, ctx_degree)(ctx);
-        if (d == 1) 
-        {
-            TEMPLATE(T, ctx_clear)(ctx);
-            continue;
-        }
+        do {
+            TEMPLATE(T, ctx_randtest)(ctx, state);
+            d = TEMPLATE(T, ctx_degree)(ctx);
+        while (d == 1); 
+            
         modulus = TEMPLATE(T, ctx_modulus)(ctx);
 
         TEMPLATE(T, init)(frob, ctx);

--- a/fq_embed_templates/test/t-embed_matrices.c
+++ b/fq_embed_templates/test/t-embed_matrices.c
@@ -81,14 +81,12 @@ main(void)
             TEMPLATE(B, mat_t) embed, project, comp, one;
             slong m, n;
 
-            TEMPLATE(T, ctx_randtest)(ctx1, state);
-            m = TEMPLATE(T, ctx_degree)(ctx1);
+            do {
+                TEMPLATE(T, ctx_randtest)(ctx1, state);
+                m = TEMPLATE(T, ctx_degree)(ctx1);
+            } while (m == 1);
             n = m*j;
-            if (m == 1) {
-                i--;
-                TEMPLATE(T, ctx_clear)(ctx1);
-                continue;
-            }
+
             modulus = TEMPLATE(T, ctx_modulus)(ctx1);
 
             TEMPLATE(B, poly_init)(modulus2, TEMPLATE(B, poly_modulus)(modulus));

--- a/fq_embed_templates/test/t-embed_matrices.c
+++ b/fq_embed_templates/test/t-embed_matrices.c
@@ -86,6 +86,7 @@ main(void)
             n = m*j;
             if (m == 1) {
                 i--;
+                TEMPLATE(T, ctx_clear)(ctx1);
                 continue;
             }
             modulus = TEMPLATE(T, ctx_modulus)(ctx1);

--- a/fq_mat_templates/charpoly_danilevsky.c
+++ b/fq_mat_templates/charpoly_danilevsky.c
@@ -189,6 +189,8 @@ TEMPLATE(T, mat_charpoly_danilevsky) (TEMPLATE(T, poly_t) p,
  
 cleanup:
   
+   TEMPLATE(T, clear) (c, ctx);
+   TEMPLATE(T, clear) (h, ctx);
    TEMPLATE(T, poly_clear) (b, ctx);
    _TEMPLATE(T, vec_clear) (T, A->r, ctx);
    _TEMPLATE(T, vec_clear) (V, A->r, ctx);

--- a/fq_mat_templates/lu_classical.c
+++ b/fq_mat_templates/lu_classical.c
@@ -76,7 +76,10 @@ TEMPLATE(T, mat_lu_classical) (slong * P,
         if (TEMPLATE(T, mat_pivot) (A, P, row, col, ctx) == 0)
         {
             if (rank_check)
-                return 0;
+            {
+                rank = 0;
+                goto cleanup;
+            }
             col++;
             continue;
         }
@@ -105,6 +108,7 @@ TEMPLATE(T, mat_lu_classical) (slong * P,
         col++;
     }
 
+cleanup:
     TEMPLATE(T, clear) (d, ctx);
     TEMPLATE(T, clear) (e, ctx);
     TEMPLATE(T, clear) (neg_e, ctx);

--- a/fq_templates/test/t-multiplicative_order.c
+++ b/fq_templates/test/t-multiplicative_order.c
@@ -71,24 +71,24 @@ main(void)
         fmpz_init(pm1);
         
         TEMPLATE(T, gen)(X, ctx);
-        if (!TEMPLATE(T, is_primitive)(X, ctx))
-            continue;
-
-        fmpz_sub_ui(pm1, TEMPLATE(T, ctx_prime)(ctx), 1);
-        TEMPLATE(T, pow)(a, X, pm1, ctx);
-        result = TEMPLATE(T, multiplicative_order)(ord, a, ctx);
-        fmpz_mul(ord, ord, pm1);
-
-        TEMPLATE(T, ctx_order)(size, ctx);
-        fmpz_sub(size, size, ord);
-
-        if (result && !fmpz_is_one(size))
+        if (TEMPLATE(T, is_primitive)(X, ctx))
         {
-            flint_printf("FAIL:\n\n");
-            flint_printf("a = "), TEMPLATE(T, print_pretty)(a, ctx), flint_printf("\n");
-            flint_printf("ord = "), fmpz_print(ord), flint_printf("\n");
-            TEMPLATE(T, ctx_print)(ctx);
-            abort();
+            fmpz_sub_ui(pm1, TEMPLATE(T, ctx_prime)(ctx), 1);
+            TEMPLATE(T, pow)(a, X, pm1, ctx);
+            result = TEMPLATE(T, multiplicative_order)(ord, a, ctx);
+            fmpz_mul(ord, ord, pm1);
+
+            TEMPLATE(T, ctx_order)(size, ctx);
+            fmpz_sub(size, size, ord);
+
+            if (result && !fmpz_is_one(size))
+            {
+                flint_printf("FAIL:\n\n");
+                flint_printf("a = "), TEMPLATE(T, print_pretty)(a, ctx), flint_printf("\n");
+                flint_printf("ord = "), fmpz_print(ord), flint_printf("\n");
+                TEMPLATE(T, ctx_print)(ctx);
+                abort();
+            }
         }
 
         fmpz_clear(pm1);

--- a/mpn_extras/test/t-mulmod_preinvn.c
+++ b/mpn_extras/test/t-mulmod_preinvn.c
@@ -74,6 +74,11 @@ int main(void)
        while (size_d && r2->_mp_d[size_d - 1] == 0) size_d--;
        r2->_mp_size = size_d;
        r2->_mp_alloc = size_d;
+       if (size_d == 0)
+       {
+          flint_free(r2->_mp_d);
+          r2->_mp_d = NULL;
+       }
 
        mpz_div_2exp(r2, r2, norm);
        mpz_div_2exp(a, a, norm);
@@ -93,7 +98,8 @@ int main(void)
           abort();
        }
 
-       flint_free(r2->_mp_d);
+       if (r2->_mp_d != NULL)
+          flint_free(r2->_mp_d);
        flint_free(dinv);
     }
 

--- a/mpn_extras/test/t-mulmod_preinvn.c
+++ b/mpn_extras/test/t-mulmod_preinvn.c
@@ -92,7 +92,7 @@ int main(void)
           abort();
        }
 
-       if (r2->_mp_d != NULL)
+       if (r2->_mp_alloc)
           flint_free(r2->_mp_d);
        flint_free(dinv);
     }

--- a/mpn_extras/test/t-mulmod_preinvn.c
+++ b/mpn_extras/test/t-mulmod_preinvn.c
@@ -73,12 +73,6 @@ int main(void)
        /* normalise */
        while (size_d && r2->_mp_d[size_d - 1] == 0) size_d--;
        r2->_mp_size = size_d;
-       r2->_mp_alloc = size_d;
-       if (size_d == 0)
-       {
-          flint_free(r2->_mp_d);
-          r2->_mp_d = NULL;
-       }
 
        mpz_div_2exp(r2, r2, norm);
        mpz_div_2exp(a, a, norm);

--- a/nmod_mpoly/test/t-mul_array.c
+++ b/nmod_mpoly/test/t-mul_array.c
@@ -77,6 +77,8 @@ main(void)
         nmod_mpoly_clear(g, ctx);  
         nmod_mpoly_clear(h, ctx);  
         nmod_mpoly_clear(k, ctx);  
+
+        nmod_mpoly_ctx_clear(ctx);
     }
 
     /* Check aliasing first argument */
@@ -129,6 +131,8 @@ main(void)
         nmod_mpoly_clear(f, ctx);  
         nmod_mpoly_clear(g, ctx);  
         nmod_mpoly_clear(h, ctx);  
+
+        nmod_mpoly_ctx_clear(ctx);
     }
 
     /* Check aliasing second argument */
@@ -181,6 +185,8 @@ main(void)
         nmod_mpoly_clear(f, ctx);  
         nmod_mpoly_clear(g, ctx);  
         nmod_mpoly_clear(h, ctx);  
+
+        nmod_mpoly_ctx_clear(ctx);
     }
 
     FLINT_TEST_CLEANUP(state);

--- a/qsieve/test/t-primes_init.c
+++ b/qsieve/test/t-primes_init.c
@@ -52,12 +52,12 @@ int main(void)
 
        fmpz_randtest_unsigned(n, state, 130);
 
-       if (fmpz_is_zero(n) || fmpz_is_one(n)) continue;
+       if (fmpz_is_zero(n) || fmpz_is_one(n)) goto cleanup;
 
        qsieve_init(qs_inf, n);
        small_factor = qsieve_knuth_schroeppel(qs_inf);
 
-       if (small_factor) continue;
+       if (small_factor) goto cleanup;
 
        fmpz_mul_ui(qs_inf->kn, qs_inf->n, qs_inf->k);                      /* haven't calculated earlier */
        small_factor = qsieve_primes_init(qs_inf);
@@ -73,7 +73,7 @@ int main(void)
                flint_printf("\n");
                abort();
            }
-           else continue;
+           else goto cleanup;
        }
 
        for (j = 3; j < qs_inf->num_primes; j++)
@@ -120,7 +120,7 @@ int main(void)
                flint_printf("\n");
                abort();
            }
-           else continue;
+           else goto cleanup;
        }
 
        for (j = k; j < qs_inf->num_primes; j++)
@@ -164,7 +164,7 @@ int main(void)
                flint_printf("\n");
                abort();
            }
-           else continue;
+           else goto cleanup;
        }
 
        for (j = k; j < qs_inf->num_primes; j++)
@@ -208,7 +208,7 @@ int main(void)
                flint_printf("\n");
                abort();
            }
-           else continue;
+           else goto cleanup;
        }
 
        for (j = k; j < qs_inf->num_primes; j++)
@@ -239,6 +239,7 @@ int main(void)
            }
        }
 
+cleanup:
        qsieve_clear(qs_inf);
        fmpz_clear(n);
        fmpz_clear(x);

--- a/qsieve/test/t-primes_init.c
+++ b/qsieve/test/t-primes_init.c
@@ -52,7 +52,7 @@ int main(void)
 
        fmpz_randtest_unsigned(n, state, 130);
 
-       if (fmpz_is_zero(n) || fmpz_is_one(n)) goto cleanup;
+       if (fmpz_is_zero(n) || fmpz_is_one(n)) goto cleanup0;
 
        qsieve_init(qs_inf, n);
        small_factor = qsieve_knuth_schroeppel(qs_inf);
@@ -244,6 +244,7 @@ cleanup2:
        qsieve_primes_clear(qs_inf);
 cleanup1:
        qsieve_clear(qs_inf);
+cleanup0:
        fmpz_clear(n);
        fmpz_clear(x);
        fmpz_clear(y);

--- a/qsieve/test/t-primes_init.c
+++ b/qsieve/test/t-primes_init.c
@@ -52,7 +52,7 @@ int main(void)
 
        fmpz_randtest_unsigned(n, state, 130);
 
-       if (fmpz_is_zero(n) || fmpz_is_one(n)) goto cleanup0;
+       if (fmpz_is_zero(n) || fmpz_is_one(n)) goto cleanup2;
 
        qsieve_init(qs_inf, n);
        small_factor = qsieve_knuth_schroeppel(qs_inf);
@@ -74,7 +74,7 @@ int main(void)
                abort();
            }
            else
-               goto cleanup2;
+               goto cleanup1;
        }
 
        for (j = 3; j < qs_inf->num_primes; j++)
@@ -121,7 +121,7 @@ int main(void)
                flint_printf("\n");
                abort();
            }
-           else goto cleanup2;
+           else goto cleanup1;
        }
 
        for (j = k; j < qs_inf->num_primes; j++)
@@ -165,7 +165,7 @@ int main(void)
                flint_printf("\n");
                abort();
            }
-           else goto cleanup2;
+           else goto cleanup1;
        }
 
        for (j = k; j < qs_inf->num_primes; j++)
@@ -209,7 +209,7 @@ int main(void)
                flint_printf("\n");
                abort();
            }
-           else goto cleanup2;
+           else goto cleanup1;
        }
 
        for (j = k; j < qs_inf->num_primes; j++)
@@ -240,11 +240,9 @@ int main(void)
            }
        }
 
-cleanup2:
-       qsieve_primes_clear(qs_inf);
 cleanup1:
        qsieve_clear(qs_inf);
-cleanup0:
+cleanup2:
        fmpz_clear(n);
        fmpz_clear(x);
        fmpz_clear(y);

--- a/qsieve/test/t-primes_init.c
+++ b/qsieve/test/t-primes_init.c
@@ -57,23 +57,24 @@ int main(void)
        qsieve_init(qs_inf, n);
        small_factor = qsieve_knuth_schroeppel(qs_inf);
 
-       if (small_factor) goto cleanup;
+       if (small_factor) goto cleanup1;
 
        fmpz_mul_ui(qs_inf->kn, qs_inf->n, qs_inf->k);                      /* haven't calculated earlier */
        small_factor = qsieve_primes_init(qs_inf);
 
-       if (small_factor)
+       if (small_factor != 0)
        {
            /* check if factor, if returned by factor base function
               is actually a factor of n */
-           if (fmpz_fdiv_ui(n, small_factor))
+           if (fmpz_fdiv_ui(n, small_factor) != 0)
            {
                flint_printf("%wd is not a factor of ", small_factor);
                fmpz_print(qs_inf->n);
                flint_printf("\n");
                abort();
            }
-           else goto cleanup;
+           else
+               goto cleanup2;
        }
 
        for (j = 3; j < qs_inf->num_primes; j++)
@@ -93,7 +94,7 @@ int main(void)
                abort();
            }
 
-           /* check if inverse of factor base primes are correct*/
+           /* check if inverse of factor base primes are correct */
            fmpz_randtest_unsigned(x, state, FLINT_BITS);
            fmpz_mod_ui(y, x, qs_inf->factor_base[j].p);
            pmod = n_mod2_preinv(fmpz_get_ui(x),
@@ -111,16 +112,16 @@ int main(void)
        k = qs_inf->num_primes;
        small_factor = qsieve_primes_increment(qs_inf, 50);
 
-       if (small_factor)
+       if (small_factor != 0)
        {
-           if (fmpz_fdiv_ui(qs_inf->n, small_factor))
+           if (fmpz_fdiv_ui(qs_inf->n, small_factor) != 0)
            {
                flint_printf("%wd is not a factor of ", small_factor);
                fmpz_print(qs_inf->n);
                flint_printf("\n");
                abort();
            }
-           else goto cleanup;
+           else goto cleanup2;
        }
 
        for (j = k; j < qs_inf->num_primes; j++)
@@ -155,16 +156,16 @@ int main(void)
        k = qs_inf->num_primes;
        small_factor = qsieve_primes_increment(qs_inf, 30);
 
-       if (small_factor)
+       if (small_factor != 0)
        {
-           if (fmpz_fdiv_ui(qs_inf->n, small_factor))
+           if (fmpz_fdiv_ui(qs_inf->n, small_factor) != 0)
            {
                flint_printf("%wd is not a factor of ", small_factor);
                fmpz_print(n);
                flint_printf("\n");
                abort();
            }
-           else goto cleanup;
+           else goto cleanup2;
        }
 
        for (j = k; j < qs_inf->num_primes; j++)
@@ -199,16 +200,16 @@ int main(void)
        k = qs_inf->num_primes;
        small_factor = qsieve_primes_increment(qs_inf, 10);
 
-       if (small_factor)
+       if (small_factor != 0)
        {
-           if (fmpz_fdiv_ui(qs_inf->n, small_factor))
+           if (fmpz_fdiv_ui(qs_inf->n, small_factor) != 0)
            {
                flint_printf("%wd is not a factor of ", small_factor);
                fmpz_print(n);
                flint_printf("\n");
                abort();
            }
-           else goto cleanup;
+           else goto cleanup2;
        }
 
        for (j = k; j < qs_inf->num_primes; j++)
@@ -239,7 +240,9 @@ int main(void)
            }
        }
 
-cleanup:
+cleanup2:
+       qsieve_primes_clear(qs_inf);
+cleanup1:
        qsieve_clear(qs_inf);
        fmpz_clear(n);
        fmpz_clear(x);


### PR DESCRIPTION
I am one of the maintainers of the flint package for the Fedora Linux distribution.  I heard you were working towards a new release, so I did a test build of git head.  Building with -fsanitize=address revealed a number of memory leaks and buffer overruns.  This commit fixes nearly all of the memory leaks, with 2 exceptions:
- There is an occasional leak in the fmpz_mpoly divides code.  The leak report points to fmpz/link/fmpz_single.c line 75, which just means that some fmpz in that block was not freed.  I suspect that a race condition is involved, because if I add instrumentation to help figure out which fmpz is involved, the leak does not happen.  It is intermittent in any case.
- I cannot currently check the flintxx code for leaks due to https://github.com/wbhart/flint2/issues/690.

I think most of the changes are self-explanatory.  These may not be:
- fq_templates/test/t-multiplicative_order.c: this looks like a big change, but it is mostly the addition of whitespace to increase indentation for a block of code, so that the following cleanup code is executed in either case.
- mpn_extras/test/t-mulmod_preinvn.c: if r2->_mp_alloc is zero, then gmp feels free to allocate memory and assign it to r2->_mp_d, overwriting the pointer flint put there.  To avoid a leak here, the pointer has to be freed before gmp sees it.