### PR TITLE
Compute get_str size requirements more strictly to avoid overflow

### DIFF
--- a/fq_zech/get_str.c
+++ b/fq_zech/get_str.c
@@ -14,7 +14,19 @@
 char *
 fq_zech_get_str(const fq_zech_t op, const fq_zech_ctx_t ctx)
 {
-    char *s = flint_malloc(n_clog(op->value, 10) * sizeof(char));
+    slong value = (slong)op->value;
+    size_t len;
+    char *s;
+
+    if (value == 0)
+        len = 2U;
+    else if (value < LONG_MAX)
+        len = n_clog(op->value + 1, 10) + 1U;
+    else if (-value == value)
+        len = n_clog(op->value, 10) + 2U;
+    else
+        len = n_clog(-value + 1, 10) + 2U;
+    s = flint_malloc(len * sizeof(char));
     flint_sprintf(s, "%wd", op->value);
     return s;
 }

--- a/fq_zech/get_str.c
+++ b/fq_zech/get_str.c
@@ -14,19 +14,8 @@
 char *
 fq_zech_get_str(const fq_zech_t op, const fq_zech_ctx_t ctx)
 {
-    slong value = (slong)op->value;
-    size_t len;
-    char *s;
-
-    if (value == 0)
-        len = 2U;
-    else if (value < LONG_MAX)
-        len = n_clog(op->value + 1, 10) + 1U;
-    else if (-value == value)
-        len = n_clog(op->value, 10) + 2U;
-    else
-        len = n_clog(-value + 1, 10) + 2U;
-    s = flint_malloc(len * sizeof(char));
+    slong numchars = op->value == 0 ? 1 : n_clog(op->value + 1, 10);
+    char *s = flint_malloc((num_chars + 1)* sizeof(char));
     flint_sprintf(s, "%wd", op->value);
     return s;
 }

--- a/fq_zech/get_str.c
+++ b/fq_zech/get_str.c
@@ -14,7 +14,7 @@
 char *
 fq_zech_get_str(const fq_zech_t op, const fq_zech_ctx_t ctx)
 {
-    slong numchars = op->value == 0 ? 1 : n_clog(op->value + 1, 10);
+    slong num_chars = op->value == 0 ? 1 : n_clog(op->value + 1, 10);
     char *s = flint_malloc((num_chars + 1)* sizeof(char));
     flint_sprintf(s, "%wd", op->value);
     return s;

--- a/fq_zech/get_str_pretty.c
+++ b/fq_zech/get_str_pretty.c
@@ -15,8 +15,19 @@
 char *
 fq_zech_get_str_pretty(const fq_zech_t op, const fq_zech_ctx_t ctx)
 {
-    char *s = flint_malloc((n_clog(op->value, 10) + strlen(ctx->fq_nmod_ctx->var) + 1) *
-                           sizeof(char));
+    slong value = (slong)op->value;
+    size_t len;
+    char *s;
+
+    if (value == 0)
+        len = 2U;
+    else if (value < LONG_MAX)
+        len = n_clog(op->value + 1, 10) + 1U;
+    else if (-value == value)
+        len = n_clog(op->value, 10) + 2U;
+    else
+        len = n_clog(-value + 1, 10) + 2U;
+    s = flint_malloc((len + strlen(ctx->fq_nmod_ctx->var) + 1U) * sizeof(char));
     flint_sprintf(s, "%s^%wd", ctx->fq_nmod_ctx->var, op->value);
     return s;
 }

--- a/fq_zech/get_str_pretty.c
+++ b/fq_zech/get_str_pretty.c
@@ -15,19 +15,8 @@
 char *
 fq_zech_get_str_pretty(const fq_zech_t op, const fq_zech_ctx_t ctx)
 {
-    slong value = (slong)op->value;
-    size_t len;
-    char *s;
-
-    if (value == 0)
-        len = 2U;
-    else if (value < LONG_MAX)
-        len = n_clog(op->value + 1, 10) + 1U;
-    else if (-value == value)
-        len = n_clog(op->value, 10) + 2U;
-    else
-        len = n_clog(-value + 1, 10) + 2U;
-    s = flint_malloc((len + strlen(ctx->fq_nmod_ctx->var) + 1U) * sizeof(char));
+    slong num_chars = op->value == 0 ? 1 : n_clog(op->value + 1, 10);
+    s = flint_malloc((num_chars + strlen(ctx->fq_nmod_ctx->var) + 2) * sizeof(char));
     flint_sprintf(s, "%s^%wd", ctx->fq_nmod_ctx->var, op->value);
     return s;
 }


### PR DESCRIPTION
The code in fq_zech/get_str{,_pretty}.c fails to compute the correct size:
- It does not add 1 for the terminating null byte
- For exact powers of 10, it produces a value that is 1 smaller than the number of digits
- For negative numbers, it does not account for the minus sign
- For negative numbers, it computes the number of digits in the number's representation as an unsigned (i.e., positive) number, which means that it is too large for negative numbers of small magnitude.