### PR TITLE
Add more checks for truncated input in _fmpq_poly_set_str

### DIFF
--- a/fmpq_poly/set_str.c
+++ b/fmpq_poly/set_str.c
@@ -63,7 +63,7 @@ _fmpq_poly_set_str(fmpz * poly, fmpz_t den, const char * str, slong len)
         ans = mpq_set_str(a[i], w, 10);
 
         /* If the format is not correct, clear up and return -1 */
-        if (ans)
+        if (ans || (i + 1 < len && *str == '\0'))
         {
             int j;
             for (j = 0; j <= i; j++)
@@ -102,7 +102,7 @@ fmpq_poly_set_str(fmpq_poly_t poly, const char * str)
     }
     errno = 0;
     len = strtol(str, &endptr, 10);
-    if (errno || len < 0)
+    if (errno || len < 0 || (len > 0 && *endptr == '\0'))
     {
         fmpq_poly_zero(poly);
         return -1;


### PR DESCRIPTION
The tests for bad input in fmpq_poly/test/t-get_set_str sometimes run off the end of the input, bypassing the null terminator and reading bytes beyond the string.  The change to line 66 detects the case when len says there are more entries, but we are looking at the end of the string.  The change to line 105 detects the case when len says there are entries, but the string contains only a length.