### PR TITLE
Zero fill empty matrices and windows

### DIFF
--- a/fmpq_mat/clear.c
+++ b/fmpq_mat/clear.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include <string.h>
 #include "fmpq_mat.h"
 
 void fmpq_mat_clear(fmpq_mat_t mat)
@@ -21,6 +22,8 @@ void fmpq_mat_clear(fmpq_mat_t mat)
             fmpq_clear(mat->entries + i);
 
         flint_free(mat->entries);
-        flint_free(mat->rows);
     }
+    if (mat->rows)
+        flint_free(mat->rows);
+    memset(mat, 0, sizeof(*mat));
 }

--- a/fmpq_mat/init.c
+++ b/fmpq_mat/init.c
@@ -10,11 +10,12 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include <string.h>
 #include "fmpq_mat.h"
 
 void fmpq_mat_init(fmpq_mat_t mat, slong rows, slong cols)
 {
-    if (rows != 0 && cols != 0)
+    if (rows > 0 && cols > 0)
     {
         slong i;
         mat->entries = (fmpq *) flint_calloc(flint_mul_sizes(rows, cols), sizeof(fmpq));
@@ -26,10 +27,10 @@ void fmpq_mat_init(fmpq_mat_t mat, slong rows, slong cols)
 
         for (i = 0; i < rows; i++)
             mat->rows[i] = mat->entries + i * cols;
+
+        mat->r = rows;
+        mat->c = cols;
     }
     else
-        mat->entries = NULL;
-
-    mat->r = rows;
-    mat->c = cols;
+        memset(mat, 0, sizeof(*mat));
 }

--- a/fmpq_mat/test/t-mul.c
+++ b/fmpq_mat/test/t-mul.c
@@ -32,9 +32,9 @@ main(void)
 
         slong m, n, k, bits;
 
-        m = n_randint(state, 10);
-        n = n_randint(state, 10);
-        k = n_randint(state, 10);
+        m = n_randint(state, 9) + 1;
+        n = n_randint(state, 9) + 1;
+        k = n_randint(state, 9) + 1;
 
         bits = 1 + n_randint(state, 100);
 

--- a/fmpq_mat/test/t-trace.c
+++ b/fmpq_mat/test/t-trace.c
@@ -35,8 +35,8 @@ main(void)
         fmpq_t trab, trba;
         slong m, n;
 
-        m = n_randint(state, 10);
-        n = n_randint(state, 10);
+        m = n_randint(state, 9) + 1;
+        n = n_randint(state, 9) + 1;
 
         fmpq_mat_init(A, m, n);
         fmpq_mat_init(B, n, m);

--- a/fmpq_mat/window_clear.c
+++ b/fmpq_mat/window_clear.c
@@ -9,11 +9,13 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include <string.h>
 #include "fmpq_mat.h"
 
 void
 fmpq_mat_window_clear(fmpq_mat_t window)
 {
-    if (window->r != 0)
+    if (window->rows)
         flint_free(window->rows);
+    memset(window, 0, sizeof(*window));
 }

--- a/fmpq_mat/window_init.c
+++ b/fmpq_mat/window_init.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include <string.h>
 #include "fmpq_mat.h"
 
 void
@@ -18,15 +19,18 @@ fmpq_mat_window_init(fmpq_mat_t window, const fmpq_mat_t mat, slong r1,
     slong i;
     window->entries = NULL;
 
-    if (r2 > r1)
-        window->rows = (fmpq **) flint_malloc((r2 - r1) * sizeof(fmpq *));
-
-    if (mat->c > 0)
+    if (r2 > r1 && c2 > c1)
     {
-        for (i = 0; i < r2 - r1; i++)
-            window->rows[i] = mat->rows[r1 + i] + c1;
-    }
+        window->rows = (fmpq **) flint_malloc((r2 - r1) * sizeof(fmpq *));
+        window->r = r2 - r1;
+        window->c = c2 - c1;
 
-    window->r = r2 - r1;
-    window->c = c2 - c1;
+        if (mat->c > 0)
+        {
+            for (i = 0; i < r2 - r1; i++)
+                window->rows[i] = mat->rows[r1 + i] + c1;
+        }
+    }
+    else
+        memset(window, 0, sizeof(*window));
 }

--- a/fmpz_mat/clear.c
+++ b/fmpz_mat/clear.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz_mat.h"
+#include <string.h>
 
 void
 fmpz_mat_clear(fmpz_mat_t mat)
@@ -20,6 +21,8 @@ fmpz_mat_clear(fmpz_mat_t mat)
         for (i = 0; i < mat->r * mat->c; i++)
             fmpz_clear(mat->entries + i);   /* Clear all coefficients */
         flint_free(mat->entries);     /* Clean up array of entries */
-        flint_free(mat->rows);        /* Clean up row array */
     }
+    if (mat->rows)
+        flint_free(mat->rows);        /* Clean up row array */
+    memset(mat, 0, sizeof(*mat));
 }

--- a/fmpz_mat/init.c
+++ b/fmpz_mat/init.c
@@ -9,12 +9,13 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include <string.h>
 #include "fmpz_mat.h"
 
 void
 fmpz_mat_init(fmpz_mat_t mat, slong rows, slong cols)
 {
-    if (rows != 0 && cols != 0)       /* Allocate space for r*c small entries */
+    if (rows > 0 && cols > 0)       /* Allocate space for r*c small entries */
     {
         slong i;
         mat->entries = (fmpz *) flint_calloc(flint_mul_sizes(rows, cols), sizeof(fmpz));
@@ -22,10 +23,9 @@ fmpz_mat_init(fmpz_mat_t mat, slong rows, slong cols)
 
         for (i = 0; i < rows; i++)
             mat->rows[i] = mat->entries + i * cols;
+        mat->r = rows;
+        mat->c = cols;
     }
     else
-        mat->entries = NULL;
-
-    mat->r = rows;
-    mat->c = cols;
+        memset(mat, 0, sizeof(*mat));
 }

--- a/fmpz_mat/test/t-equal.c
+++ b/fmpz_mat/test/t-equal.c
@@ -33,8 +33,8 @@ main(void)
         fmpz_mat_t A, B, C, D, E;
         slong m, n, j;
 
-        m = n_randint(state, 20);
-        n = n_randint(state, 20);
+        m = n_randint(state, 19) + 1;
+        n = n_randint(state, 19) + 1;
 
         fmpz_mat_init(A, m, n);
         fmpz_mat_init(B, m, n);

--- a/fmpz_mat/test/t-gram.c
+++ b/fmpz_mat/test/t-gram.c
@@ -26,8 +26,8 @@ int main(void)
     {
         slong m, n;
 
-        m = n_randint(state, 50);
-        n = n_randint(state, 50);
+        m = n_randint(state, 49) + 1;
+        n = n_randint(state, 49) + 1;
 
         fmpz_mat_init(A, m, n);
         fmpz_mat_init(B, n, m);

--- a/fmpz_mat/test/t-is_square.c
+++ b/fmpz_mat/test/t-is_square.c
@@ -30,8 +30,8 @@ main(void)
     for (i = 0; i < 1000 * flint_test_multiplier(); i++)
     {
         fmpz_mat_t A;
-        slong rows = n_randint(state, 10);
-        slong cols = n_randint(state, 10);
+        slong rows = n_randint(state, 9) + 1;
+        slong cols = n_randint(state, 9) + 1;
 
         fmpz_mat_init(A, rows, cols);
 

--- a/fmpz_mat/test/t-mul_multi_mod.c
+++ b/fmpz_mat/test/t-mul_multi_mod.c
@@ -31,9 +31,9 @@ int main(void)
     {
         slong m, n, k;
 
-        m = n_randint(state, 50);
-        n = n_randint(state, 50);
-        k = n_randint(state, 50);
+        m = n_randint(state, 49) + 1;
+        n = n_randint(state, 49) + 1;
+        k = n_randint(state, 49) + 1;
 
         fmpz_mat_init(A, m, n);
         fmpz_mat_init(B, n, k);
@@ -65,9 +65,9 @@ int main(void)
     {
         slong m, n, k;
 
-        m = n_randint(state, 3);
-        n = n_randint(state, 3);
-        k = n_randint(state, 3);
+        m = n_randint(state, 2) + 1;
+        n = n_randint(state, 2) + 1;
+        k = n_randint(state, 2) + 1;
 
         fmpz_mat_init(A, m, n);
         fmpz_mat_init(B, n, k);

--- a/fmpz_mat/test/t-nullspace.c
+++ b/fmpz_mat/test/t-nullspace.c
@@ -33,8 +33,8 @@ main(void)
     /* small dimension */
     for (i = 0; i < 1000 * flint_test_multiplier(); i++)
     {
-        m = n_randint(state, 10);
-        n = n_randint(state, 10);
+        m = n_randint(state, 9) + 1;
+        n = n_randint(state, 9) + 1;
 
         for (r = 0; r <= FLINT_MIN(m,n); r++)
         {

--- a/fmpz_mat/window_clear.c
+++ b/fmpz_mat/window_clear.c
@@ -9,11 +9,13 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include <string.h>
 #include "fmpz_mat.h"
 
 void
 fmpz_mat_window_clear(fmpz_mat_t window)
 {
-    if (window->r != 0)
+    if (window->rows)
         flint_free(window->rows);
+    memset(window, 0, sizeof(*window));
 }

--- a/fmpz_mat/window_init.c
+++ b/fmpz_mat/window_init.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include <string.h>
 #include "fmpz_mat.h"
 
 void
@@ -18,15 +19,18 @@ fmpz_mat_window_init(fmpz_mat_t window, const fmpz_mat_t mat, slong r1,
     slong i;
     window->entries = NULL;
 
-    if (r2 > r1)
-        window->rows = (fmpz **) flint_malloc((r2 - r1) * sizeof(fmpz *));
-
-    if (mat->c > 0)
+    if (r2 > r1 && c2 > c1)
     {
-        for (i = 0; i < r2 - r1; i++)
-            window->rows[i] = mat->rows[r1 + i] + c1;
-    }
+        window->rows = (fmpz **) flint_malloc((r2 - r1) * sizeof(fmpz *));
+        window->r = r2 - r1;
+        window->c = c2 - c1;
 
-    window->r = r2 - r1;
-    window->c = c2 - c1;
+        if (mat->c > 0)
+        {
+            for (i = 0; i < r2 - r1; i++)
+                window->rows[i] = mat->rows[r1 + i] + c1;
+        }
+    }
+    else
+        memset(window, 0, sizeof(*window));
 }

--- a/fmpz_mod_poly/compose_mod_brent_kung_precomp_preinv.c
+++ b/fmpz_mod_poly/compose_mod_brent_kung_precomp_preinv.c
@@ -85,18 +85,18 @@ fmpz_mod_poly_precompute_matrix(fmpz_mat_t A, const fmpz_mod_poly_t poly1,
         flint_abort();
     }
 
-    if (A->r != m || A->c != len)
-    {
-        flint_printf("Exception (fmpz_mod_poly_precompute_matrix)."
-                     " Wrong dimensions.\n");
-        flint_abort();
-    }
-
     if (len2 == 1)
     {
         fmpz_mat_zero(A);
 
         return;
+    }
+
+    if (A->r != m || A->c != len)
+    {
+        flint_printf("Exception (fmpz_mod_poly_precompute_matrix)."
+                     " Wrong dimensions.\n");
+        flint_abort();
     }
 
     ptr = _fmpz_vec_init(vec_len);

--- a/fmpz_poly_mat/clear.c
+++ b/fmpz_poly_mat/clear.c
@@ -10,6 +10,7 @@
 */
 
 #include <stdlib.h>
+#include <string.h>
 #include "flint.h"
 #include "fmpz_poly.h"
 #include "fmpz_poly_mat.h"
@@ -25,6 +26,8 @@ fmpz_poly_mat_clear(fmpz_poly_mat_t A)
             fmpz_poly_clear(A->entries + i);
 
         flint_free(A->entries);
-        flint_free(A->rows);
     }
+    if (A->rows)
+        flint_free(A->rows);
+    memset(A, 0, sizeof(*A));
 }

--- a/fmpz_poly_mat/init.c
+++ b/fmpz_poly_mat/init.c
@@ -9,7 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
-#include <stdlib.h>
+#include <string.h>
 #include "flint.h"
 #include "fmpz_poly.h"
 #include "fmpz_poly_mat.h"
@@ -17,7 +17,7 @@
 void
 fmpz_poly_mat_init(fmpz_poly_mat_t A, slong rows, slong cols)
 {
-    if (rows != 0 && cols != 0)
+    if (rows > 0 && cols > 0)
     {
         slong i;
 
@@ -29,10 +29,10 @@ fmpz_poly_mat_init(fmpz_poly_mat_t A, slong rows, slong cols)
 
         for (i = 0; i < rows; i++)
             A->rows[i] = A->entries + i * cols;
+
+        A->r = rows;
+        A->c = cols;
     }
     else
-        A->entries = NULL;
-
-    A->r = rows;
-    A->c = cols;
+        memset(A, 0, sizeof(*A));
 }

--- a/fmpz_poly_mat/test/t-nullspace.c
+++ b/fmpz_poly_mat/test/t-nullspace.c
@@ -34,8 +34,8 @@ main(void)
         slong n, m, bits, deg, rank, nullity;
         float density;
 
-        m = n_randint(state, 13);
-        n = n_randint(state, 13);
+        m = n_randint(state, 12) + 1;
+        n = n_randint(state, 12) + 1;
         deg = 1 + n_randint(state, 5);
         bits = 1 + n_randint(state, 100);
         density = n_randint(state, 100) * 0.01;

--- a/fmpz_poly_mat/window_clear.c
+++ b/fmpz_poly_mat/window_clear.c
@@ -10,11 +10,13 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include <string.h>
 #include "fmpz_poly_mat.h"
 
 void
 fmpz_poly_mat_window_clear(fmpz_poly_mat_t window)
 {
-    if (window->r != 0)
+    if (window->rows)
         flint_free(window->rows);
+    memset(window, 0, sizeof(window));
 }

--- a/fmpz_poly_mat/window_init.c
+++ b/fmpz_poly_mat/window_init.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include <string.h>
 #include "fmpz_poly_mat.h"
 
 void
@@ -19,16 +20,15 @@ fmpz_poly_mat_window_init(fmpz_poly_mat_t window, const fmpz_poly_mat_t mat, slo
     slong i;
     window->entries = NULL;
 
-    if (r2 > r1)
+    if (r2 > r1 && c2 > c1)
+    {
         window->rows = (fmpz_poly_struct **) flint_malloc((r2 - r1)
                                                   * sizeof(fmpz_poly_struct *));
-
-    if (c2 > c1)
-    {
         for (i = 0; i < r2 - r1; i++)
             window->rows[i] = mat->rows[r1 + i] + c1;
+        window->r = r2 - r1;
+        window->c = c2 - c1;
     }
-
-    window->r = r2 - r1;
-    window->c = c2 - c1;
+    else
+        memset(window, 0, sizeof(*window));
 }

--- a/fq_mat_templates/clear.c
+++ b/fq_mat_templates/clear.c
@@ -13,6 +13,7 @@
 
 #ifdef T
 
+#include <string.h>
 #include "templates.h"
 
 void
@@ -24,8 +25,10 @@ TEMPLATE(T, mat_clear) (TEMPLATE(T, mat_t) mat, const TEMPLATE(T, ctx_t) ctx)
         for (i = 0; i < mat->r * mat->c; i++)
             TEMPLATE(T, clear) (mat->entries + i, ctx); /* Clear all coefficients */
         flint_free(mat->entries);   /* Clean up array of entries */
-        flint_free(mat->rows);  /* Clean up row array */
     }
+    if (mat->rows)
+        flint_free(mat->rows);  /* Clean up row array */
+    memset(mat, 0, sizeof(*mat));
 }
 
 

--- a/fq_mat_templates/init.c
+++ b/fq_mat_templates/init.c
@@ -12,13 +12,14 @@
 
 #ifdef T
 
+#include <string.h>
 #include "templates.h"
 
 void
 TEMPLATE(T, mat_init) (TEMPLATE(T, mat_t) mat, slong rows, slong cols,
                        const TEMPLATE(T, ctx_t) ctx)
 {
-    if (rows != 0 && cols != 0)       /* Allocate space for r*c small entries */
+    if (rows > 0 && cols > 0)       /* Allocate space for r*c small entries */
     {
         slong i, j;
         mat->entries = (TEMPLATE(T, struct) *) flint_malloc(flint_mul_sizes(rows, cols)
@@ -34,12 +35,12 @@ TEMPLATE(T, mat_init) (TEMPLATE(T, mat_t) mat, slong rows, slong cols,
                 TEMPLATE(T, init) (mat->rows[i] + j, ctx);
             }
         }
+
+        mat->r = rows;
+        mat->c = cols;
     }
     else
-        mat->entries = NULL;
-
-    mat->r = rows;
-    mat->c = cols;
+        memset(mat, 0, sizeof(*mat));
 }
 
 

--- a/fq_mat_templates/test/t-concat_horizontal.c
+++ b/fq_mat_templates/test/t-concat_horizontal.c
@@ -37,7 +37,7 @@ main(void)
 
         TEMPLATE(T, ctx_randtest) (ctx, state);
 
-        c1 = n_randint(state, 10);
+        c1 = n_randint(state, 9) + 1;
         c2 = n_randint(state, 10);
         r1 = n_randint(state, 10);
 

--- a/fq_mat_templates/test/t-concat_vertical.c
+++ b/fq_mat_templates/test/t-concat_vertical.c
@@ -38,7 +38,7 @@ main(void)
 
         TEMPLATE(T, ctx_randtest) (ctx, state);
 
-        r1 = n_randint(state, 10);
+        r1 = n_randint(state, 9) + 1;
         r2 = n_randint(state, 10);
         c1 = n_randint(state, 10);
 

--- a/fq_mat_templates/test/t-equal.c
+++ b/fq_mat_templates/test/t-equal.c
@@ -41,8 +41,8 @@ main(void)
 
         TEMPLATE(T, init) (x, ctx);
 
-        m = n_randint(state, 20);
-        n = n_randint(state, 20);
+        m = n_randint(state, 19) + 1;
+        n = n_randint(state, 19) + 1;
 
         TEMPLATE(T, mat_init) (A, m, n, ctx);
         TEMPLATE(T, mat_init) (B, m, n, ctx);

--- a/fq_mat_templates/test/t-nullspace.c
+++ b/fq_mat_templates/test/t-nullspace.c
@@ -30,8 +30,8 @@ main(void)
         TEMPLATE(T, mat_t) A, B, ker;
         slong m, n, d, r, nullity, nulrank;
 
-        m = n_randint(state, 30);
-        n = n_randint(state, 30);
+        m = n_randint(state, 29) + 1;
+        n = n_randint(state, 29) + 1;
 
         for (r = 0; r <= FLINT_MIN(m, n); r++)
         {

--- a/fq_mat_templates/test/t-window_init_clear.c
+++ b/fq_mat_templates/test/t-window_init_clear.c
@@ -35,8 +35,8 @@ main(void)
 
     	TEMPLATE(T, mat_t) a, w;
         slong j, r1, r2, c1, c2;
-        slong rows = n_randint(state, 10);
-        slong cols = n_randint(state, 10);
+        slong rows = n_randint(state, 9) + 1;
+        slong cols = n_randint(state, 9) + 1;
 
         TEMPLATE(T, ctx_randtest) (ctx, state);
 
@@ -44,15 +44,12 @@ main(void)
         TEMPLATE(T, mat_randtest) (a, state, ctx);
 
         r2 = n_randint(state, rows + 1);
-        c2 = n_randint(state, cols + 1);
+        c2 = n_randint(state, cols) + 1;
         if (r2)
             r1 = n_randint(state, r2);
         else
             r1 = 0;
-        if (c2)
-            c1 = n_randint(state, c2);
-        else
-            c1 = 0;
+        c1 = n_randint(state, c2);
 
         TEMPLATE(T, mat_window_init) (w, a, r1, c1, r2, c2, ctx);
 

--- a/fq_mat_templates/window_clear.c
+++ b/fq_mat_templates/window_clear.c
@@ -15,14 +15,16 @@
 
 #ifdef T
 
+#include <string.h>
 #include "templates.h"
 
 void
 TEMPLATE(T, mat_window_clear) (TEMPLATE(T, mat_t) window,
                                const TEMPLATE(T, ctx_t) ctx)
 {
-    if (window->r != 0)
+    if (window->rows)
         flint_free(window->rows);
+    memset(window, 0, sizeof(*window));
 }
 
 

--- a/fq_mat_templates/window_init.c
+++ b/fq_mat_templates/window_init.c
@@ -15,6 +15,7 @@
 
 #ifdef T
 
+#include <string.h>
 #include "templates.h"
 
 void
@@ -26,18 +27,21 @@ TEMPLATE(T, mat_window_init) (TEMPLATE(T, mat_t) window,
     slong i;
     window->entries = NULL;
 
-    if (r2 > r1)
+    if (r2 > r1 && c2 > c1)
+    {
         window->rows = (TEMPLATE(T, struct) **) flint_malloc((r2 - r1)
                                               * sizeof(TEMPLATE(T, struct) *));
+        window->r = r2 - r1;
+        window->c = c2 - c1;
 
-    if (mat->c > 0)
-    {
-        for (i = 0; i < r2 - r1; i++)
-            window->rows[i] = mat->rows[r1 + i] + c1;
+        if (mat->c > 0)
+        {
+            for (i = 0; i < r2 - r1; i++)
+                window->rows[i] = mat->rows[r1 + i] + c1;
+        }
     }
-
-    window->r = r2 - r1;
-    window->c = c2 - c1;
+    else
+        memset(window, 0, sizeof(*window));
 }
 
 

--- a/fq_poly_templates/compose_mod_brent_kung_precomp_preinv.c
+++ b/fq_poly_templates/compose_mod_brent_kung_precomp_preinv.c
@@ -84,17 +84,17 @@ TEMPLATE(T, poly_precompute_matrix) (TEMPLATE(T, mat_t) A,
         flint_abort();
     }
 
+    if (len2 == 1)
+    {
+        TEMPLATE(T, mat_zero) (A, ctx);
+        return;
+    }
+
     if (A->r != m || A->c != len)
     {
         flint_printf
             ("Exception (nmod_poly_compose_mod_brent_kung). Wrong dimensions.\n");
         flint_abort();
-    }
-
-    if (len2 == 1)
-    {
-        TEMPLATE(T, mat_zero) (A, ctx);
-        return;
     }
 
     ptr1 = _TEMPLATE(T, vec_init) (len, ctx);

--- a/nmod_mat/clear.c
+++ b/nmod_mat/clear.c
@@ -11,6 +11,7 @@
 */
 
 #include <stdlib.h>
+#include <string.h>
 #include <gmp.h>
 #include "flint.h"
 #include "nmod_mat.h"
@@ -19,8 +20,8 @@ void
 nmod_mat_clear(nmod_mat_t mat)
 {
     if (mat->entries)
-    {
         flint_free(mat->entries);
+    if (mat->rows)
         flint_free(mat->rows);
-    }
+    memset(mat, 0, sizeof(*mat));
 }

--- a/nmod_mat/init.c
+++ b/nmod_mat/init.c
@@ -10,7 +10,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
-#include <stdlib.h>
+#include <string.h>
 #include <gmp.h>
 #include "flint.h"
 #include "nmod_mat.h"
@@ -19,7 +19,7 @@
 void
 nmod_mat_init(nmod_mat_t mat, slong rows, slong cols, mp_limb_t n)
 {
-    if (rows != 0 && cols != 0)
+    if (rows > 0 && cols > 0)
     {
         slong i;
         mat->entries = (mp_limb_t *) flint_calloc(flint_mul_sizes(rows, cols), sizeof(mp_limb_t));
@@ -27,12 +27,12 @@ nmod_mat_init(nmod_mat_t mat, slong rows, slong cols, mp_limb_t n)
 
         for (i = 0; i < rows; i++)
             mat->rows[i] = mat->entries + i * cols;
+
+        mat->r = rows;
+        mat->c = cols;
     }
     else
-        mat->entries = NULL;
-
-    mat->r = rows;
-    mat->c = cols;
+        memset(mat, 0, sizeof(*mat));
 
     _nmod_mat_set_mod(mat, n);
 }

--- a/nmod_mat/init_set.c
+++ b/nmod_mat/init_set.c
@@ -10,7 +10,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
-#include <stdlib.h>
+#include <string.h>
 #include <gmp.h>
 #include "flint.h"
 #include "nmod_mat.h"
@@ -21,7 +21,7 @@ nmod_mat_init_set(nmod_mat_t mat, const nmod_mat_t src)
     slong rows = src->r;
     slong cols = src->c;
 
-    if ((rows) && (cols))
+    if (rows > 0 && cols > 0)
     {
         slong i;
         mat->entries = flint_malloc(flint_mul_sizes(rows, cols) * sizeof(mp_limb_t));
@@ -32,12 +32,12 @@ nmod_mat_init_set(nmod_mat_t mat, const nmod_mat_t src)
             mat->rows[i] = mat->entries + i * cols;
             flint_mpn_copyi(mat->rows[i], src->rows[i], cols);
         }
+
+        mat->r = rows;
+        mat->c = cols;
     }
     else
-        mat->entries = NULL;
-
-    mat->r = rows;
-    mat->c = cols;
+        memset(mat, 0, sizeof(*mat));
 
     mat->mod = src->mod;
 }

--- a/nmod_mat/test/t-concat_horizontal.c
+++ b/nmod_mat/test/t-concat_horizontal.c
@@ -32,7 +32,7 @@ int main(void)
     {
         slong c1, c2, r1, n;
 
-        c1 = n_randint(state, 50);
+        c1 = n_randint(state, 49) + 1;
         c2 = n_randint(state, 50);
         r1 = n_randint(state, 50);
         n = n_randint(state, 50) + 1;

--- a/nmod_mat/test/t-concat_vertical.c
+++ b/nmod_mat/test/t-concat_vertical.c
@@ -32,7 +32,7 @@ int main(void)
     {
         slong r1, r2, c1, n;
 
-        r1 = n_randint(state, 50);
+        r1 = n_randint(state, 49) + 1;
         r2 = n_randint(state, 50);
         c1 = n_randint(state, 50);
         n = n_randint(state, 50) + 1;

--- a/nmod_mat/test/t-nullspace.c
+++ b/nmod_mat/test/t-nullspace.c
@@ -34,8 +34,8 @@ main(void)
         mp_limb_t mod;
         slong m, n, d, r, nullity, nulrank;
 
-        m = n_randint(state, 30);
-        n = n_randint(state, 30);
+        m = n_randint(state, 29) + 1;
+        n = n_randint(state, 29) + 1;
 
         for (r = 0; r <= FLINT_MIN(m,n); r++)
         {

--- a/nmod_mat/window_clear.c
+++ b/nmod_mat/window_clear.c
@@ -12,7 +12,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
-#include <stdlib.h>
+#include <string.h>
 #include <gmp.h>
 #include "flint.h"
 #include "nmod_mat.h"
@@ -20,6 +20,7 @@
 void
 nmod_mat_window_clear(nmod_mat_t window)
 {
-    if (window->r > 0)
+    if (window->rows)
         flint_free(window->rows);
+    memset(window, 0, sizeof(*window));
 }

--- a/nmod_mat/window_init.c
+++ b/nmod_mat/window_init.c
@@ -12,7 +12,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
-#include <stdlib.h>
+#include <string.h>
 #include <gmp.h>
 #include "flint.h"
 #include "nmod_mat.h"
@@ -24,16 +24,20 @@ nmod_mat_window_init(nmod_mat_t window, const nmod_mat_t mat,
     slong i;
     window->entries = NULL;
 
-    if (r2 > r1)
-        window->rows = (mp_limb_t **) flint_malloc((r2 - r1) * sizeof(mp_limb_t *));
-
-    if (mat->c > 0)
+    if (r2 > r1 && c2 > c1)
     {
-        for (i = 0; i < r2 - r1; i++)
-            window->rows[i] = mat->rows[r1 + i] + c1;
-    }
+        window->rows = (mp_limb_t **) flint_malloc((r2 - r1) * sizeof(mp_limb_t *));
+        window->r = r2 - r1;
+        window->c = c2 - c1;
 
-    window->r = r2 - r1;
-    window->c = c2 - c1;
+        if (mat->c > 0)
+        {
+            for (i = 0; i < r2 - r1; i++)
+                window->rows[i] = mat->rows[r1 + i] + c1;
+        }
+    }
+    else
+        memset(window, 0, sizeof(*window));
+
     window->mod = mat->mod;
 }

--- a/nmod_poly/compose_mod_brent_kung_precomp_preinv.c
+++ b/nmod_poly/compose_mod_brent_kung_precomp_preinv.c
@@ -72,16 +72,16 @@ nmod_poly_precompute_matrix(nmod_mat_t A, const nmod_poly_t poly1,
         flint_abort();
     }
 
-    if (A->r != m || A->c != len)
-    {
-        flint_printf("Exception (nmod_poly_precompute_matrix). Wrong dimensions.\n");
-        flint_abort();
-    }
-
     if (len2 == 1)
     {
         nmod_mat_zero(A);
         return;
+    }
+
+    if (A->r != m || A->c != len)
+    {
+        flint_printf("Exception (nmod_poly_precompute_matrix). Wrong dimensions.\n");
+        flint_abort();
     }
 
     ptr1 = _nmod_vec_init(len);

--- a/nmod_poly_mat/clear.c
+++ b/nmod_poly_mat/clear.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include <string.h>
 #include "flint.h"
 #include "nmod_poly.h"
 #include "nmod_poly_mat.h"
@@ -24,6 +25,8 @@ nmod_poly_mat_clear(nmod_poly_mat_t A)
             nmod_poly_clear(A->entries + i);
 
         flint_free(A->entries);
-        flint_free(A->rows);
     }
+    if (A->rows)
+        flint_free(A->rows);
+    memset(A, 0, sizeof(*A));
 }

--- a/nmod_poly_mat/init.c
+++ b/nmod_poly_mat/init.c
@@ -9,7 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
-#include <stdlib.h>
+#include <string.h>
 #include "flint.h"
 #include "nmod_poly.h"
 #include "nmod_poly_mat.h"
@@ -17,7 +17,7 @@
 void
 nmod_poly_mat_init(nmod_poly_mat_t A, slong rows, slong cols, mp_limb_t n)
 {
-    if (rows && cols)
+    if (rows > 0 && cols > 0)
     {
         slong i;
 
@@ -29,11 +29,11 @@ nmod_poly_mat_init(nmod_poly_mat_t A, slong rows, slong cols, mp_limb_t n)
 
         for (i = 0; i < rows; i++)
             A->rows[i] = A->entries + i * cols;
+
+        A->r = rows;
+        A->c = cols;
+        A->modulus = n;
     }
     else
-        A->entries = NULL;
-
-    A->modulus = n;
-    A->r = rows;
-    A->c = cols;
+        memset(A, 0, sizeof(*A));
 }

--- a/nmod_poly_mat/test/t-nullspace.c
+++ b/nmod_poly_mat/test/t-nullspace.c
@@ -34,8 +34,8 @@ main(void)
         mp_limb_t mod;
 
         mod = n_randtest_prime(state, 0);
-        m = n_randint(state, 13);
-        n = n_randint(state, 13);
+        m = n_randint(state, 12) + 1;
+        n = n_randint(state, 12) + 1;
         deg = 1 + n_randint(state, 5);
         density = n_randint(state, 100) * 0.01;
 

--- a/nmod_poly_mat/window_clear.c
+++ b/nmod_poly_mat/window_clear.c
@@ -9,14 +9,15 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include <string.h>
 #include "nmod_poly_mat.h"
 
 void
 nmod_poly_mat_window_clear(nmod_poly_mat_t window)
 {
-    if (window->r != 0)
+    if (window->rows)
     {
         flint_free(window->rows);
     }
-
+    memset(window, 0, sizeof(*window));
 }

--- a/nmod_poly_mat/window_init.c
+++ b/nmod_poly_mat/window_init.c
@@ -9,21 +9,24 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include <string.h>
 #include "nmod_poly_mat.h"
 
 void
 nmod_poly_mat_window_init(nmod_poly_mat_t window, const nmod_poly_mat_t mat, slong r1,
                      slong c1, slong r2, slong c2)
 {
-    slong i;
-    window->entries = NULL;
-
-    if (r2 - r1)
+    if (r2 > r1 && c2 > c1)
+    {
+        slong i;
+        window->entries = NULL;
         window->rows = flint_malloc((r2 - r1) * sizeof(nmod_poly_t));
+        window->r = r2 - r1;
+        window->c = c2 - c1;
 
-    for (i = 0; i < r2 - r1; i++)
-        window->rows[i] = mat->rows[r1 + i] + c1;
-
-    window->r = r2 - r1;
-    window->c = c2 - c1;
+        for (i = 0; i < r2 - r1; i++)
+            window->rows[i] = mat->rows[r1 + i] + c1;
+    }
+    else
+        memset(window, 0, sizeof(*window));
 }


### PR DESCRIPTION
In addition, adjust code that expects empty matrices to have:
- Either nonzero rows or nonzero columns
- Non-null entries pointer
- Non-null rows pointer

This is the last pull request for now.  I left this one for last because I expect that you are not going to like some aspects of it.  The impetus is address sanitizer reports like this one:
```
scalar_smod....=================================================================
==27773==ERROR: AddressSanitizer: heap-use-after-free on address 0x604000000150 at pc 0x7f2756b9b254 bp 0x7ffd20f84cf0 sp 0x7ffd20f84ce0
READ of size 8 at 0x604000000150 thread T0
    #0 0x7f2756b9b253 in fmpz_mat_scalar_smod /builddir/build/BUILD/flint2/fmpz_mat/scalar_smod.c:20
    #1 0x401486 in main test/t-scalar_smod.c:52
    #2 0x7f2753c0d041 in __libc_start_main (/lib64/libc.so.6+0x27041)
    #3 0x4019ad in _start (/builddir/build/BUILD/flint2/build/fmpz_mat/test/t-scalar_smod+0x4019ad)

0x604000000150 is located 0 bytes inside of 40-byte region [0x604000000150,0x604000000178)
freed by thread T0 here:
    #0 0x7f27574f3307 in __interceptor_free (/lib64/libasan.so.6+0xb0307)
    #1 0x4015ea in main test/t-scalar_smod.c:73
    #2 0x7f2753c0d041 in __libc_start_main (/lib64/libc.so.6+0x27041)
    #3 0x4019ad in _start (/builddir/build/BUILD/flint2/build/fmpz_mat/test/t-scalar_smod+0x4019ad)

previously allocated by thread T0 here:
    #0 0x7f27574f3667 in __interceptor_malloc (/lib64/libasan.so.6+0xb0667)
    #1 0x7f2756a896e9 in flint_malloc /builddir/build/BUILD/flint2/memory_manager.c:91
    #2 0x7f2756b7e0e9 in fmpz_mat_init /builddir/build/BUILD/flint2/fmpz_mat/init.c:21
    #3 0x4013e6 in main test/t-scalar_smod.c:40
    #4 0x7f2753c0d041 in __libc_start_main (/lib64/libc.so.6+0x27041)
    #5 0x4019ad in _start (/builddir/build/BUILD/flint2/build/fmpz_mat/test/t-scalar_smod+0x4019ad)

SUMMARY: AddressSanitizer: heap-use-after-free /builddir/build/BUILD/flint2/fmpz_mat/scalar_smod.c:20 in fmpz_mat_scalar_smod
Shadow bytes around the buggy address:
  0x0c087fff7fd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c087fff7fe0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c087fff7ff0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c087fff8000: fa fa fd fd fd fd fd fa fa fa fd fd fd fd fd fa
  0x0c087fff8010: fa fa fd fd fd fd fd fd fa fa fd fd fd fd fd fd
=>0x0c087fff8020: fa fa fd fd fd fd fd fa fa fa[fd]fd fd fd fd fa
  0x0c087fff8030: fa fa fd fd fd fd fd fa fa fa fd fd fd fd fd fa
  0x0c087fff8040: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c087fff8050: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c087fff8060: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c087fff8070: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==27773==ABORTING
```
The test suite produces quite a few reports like that.  There are a handful of interacting issues here:
- The various matrix and window init functions do not fully initialize the objects when they are empty.  For example, fmpz_mat_init does not write a NULL pointer into mat->rows in that case.
- The matrix and window init functions set the r and c fields to the passed in rows and cols values, even if the matrix or window is empty.  This means that a 0 x 5 matrix differs from a 0 x 4 matrix.
- Code that accesses the rows field does not always check that the c field is nonzero, meaning that the rows pointer is sometimes dereferenced even if it does not point to valid storage.
- The matrix and window clear functions do not zero out the rows and entries pointers.  Combined with the first issue, this means that a reused object can contain a pointer to freed space.  Combined with the previous issue, this means that code sometimes dereferences a pointer to freed space.  This is a segfault waiting to happen.

Some of the tests actually depend on being able to dereference a rows or entries pointer from a previous iteration of the testing loop, in the case that an empty matrix was generated for the current iteration (such as with the case shown above).  For some tests, it appears to me that the computations involved are not correct (or cannot logically be done) with an empty matrix, so I adjusted the random number expressions to preclude the possibility of generating zero.  In those cases, I made sure that the largest random number that could be generated did not change; i.e., I shrunk the range by 1.  This may not be what you want.  Perhaps you want the size of the range to stay the same, but be shifted up by one.

Some of the init functions check that rows and/or cols is nonzero before executing code for the nonempty case.  However, the parameters are of signed type.  To catch the case where negative numbers are passed in, I changed those to checks for positive values.

I will not be surprised if you want lots of changes to this, or more explanations.  Let me know.