### PR TITLE
remove deleted dedekind_sum from arithxx

### DIFF
--- a/arithxx.h
+++ b/arithxx.h
@@ -271,10 +271,6 @@ template<> struct outsize<operations::landau_function_vec_op>
 
 ARITHXX_DEFINE_BINOP(dedekind_sum_naive, fmpqxx,
         FMPZXX_COND_S, FMPZXX_COND_S)
-ARITHXX_DEFINE_BINOP(dedekind_sum_coprime_large, fmpqxx,
-        FMPZXX_COND_S, FMPZXX_COND_S)
-ARITHXX_DEFINE_BINOP(dedekind_sum_coprime, fmpqxx,
-        FMPZXX_COND_S, FMPZXX_COND_S)
 ARITHXX_DEFINE_BINOP(dedekind_sum, fmpqxx,
         FMPZXX_COND_S, FMPZXX_COND_S)
 
@@ -311,8 +307,6 @@ inline double bell_number_size(ulong n) {return arith_bell_number_size(n);}
 inline double bernoulli_number_size(ulong n)
     {return arith_bernoulli_number_size(n);}
 inline double euler_number_size(ulong n) {return arith_euler_number_size(n);}
-inline double dedekind_sum_coprime_d(double h, double k)
-    {return arith_dedekind_sum_coprime_d(h, k);}
 
 template<class Fmpz>
 inline typename mp::enable_if<traits::is_fmpzxx<Fmpz>, int>::type moebius_mu(

--- a/flintxx/test/t-arithxx.cpp
+++ b/flintxx/test/t-arithxx.cpp
@@ -166,9 +166,7 @@ test_dedekind()
     fmpzxx k = fmpzxx::randtest_unsigned(state, 10);
     tassert(dedekind_sum_naive(h, k) == dedekind_sum(h, k));
     k /= gcd(h, k);
-    tassert(dedekind_sum_coprime_large(h, k) == dedekind_sum(h, k));
-    tassert(dedekind_sum_coprime(h, k) == dedekind_sum(h, k));
-    // untested: dedekind_sum_coprime_d
+    tassert(dedekind_sum_naive(h, k) == dedekind_sum(h, k));
 }
 
 void


### PR DESCRIPTION
Unfortunately my computer does not have enough memory to compile parts of the flintxx test suit.
I can say that the arithxx passes for me and the new `fmpq_dedekind_sum` is faster than the old version and even faster than direct calls to the internal `fmpq_dedekind_sum_coprime_d` for 20 bit  inputs. In short, doubles should have never been used. :)