### PR TITLE
Zassenhaus

### DIFF
--- a/fmpz_poly_factor/factor.c
+++ b/fmpz_poly_factor/factor.c
@@ -70,7 +70,7 @@ void fmpz_poly_factor(fmpz_poly_factor_t fac, const fmpz_poly_t G)
 
         /* Factor each square-free part */
         for (j = 0; j < sq_fr_fac->num; j++)
-            _fmpz_poly_factor_zassenhaus(fac, sq_fr_fac->exp[j], sq_fr_fac->p + j, 10, 1);
+            _fmpz_poly_factor_zassenhaus(fac, sq_fr_fac->exp[j], sq_fr_fac->p + j, 8, 1);
 
         fmpz_poly_factor_clear(sq_fr_fac);
     }


### PR DESCRIPTION
This patch makes two changes: the cutoff for Zassenhaus/van Hoeij is lowered from 10 to 8, and zassenhaus_recombination is optimised by using a product tree.

Before:

    fredrik@agm:~/src/flint2$ time build/fmpz_poly_factor/test/t-factor
    factor....PASS

    real	0m6,064s
    user	0m6,058s
    sys	0m0,004s

After:

    fredrik@agm:~/src/flint2$ time build/fmpz_poly_factor/test/t-factor
    factor....PASS

    real	0m2,472s
    user	0m2,467s
    sys	0m0,005s

But don't get too excited. This will neither speed up very easy factorisations, nor very hard ones. It just happens that the test polynomials in t-factor are right in the sweet spot for this optimisation. When running the long test, the time is virtually unchanged. At least nothing should slow down significantly.

The cutoff should probably account for the size of the input and not just be a constant, but I'm too lazy to profile this. The product tree could be used in van Hoeij too, but I figure LLL will usually dominate there.