### PR TITLE
don't do a temp allocation for each variable in mpoly_get_str_pretty

### DIFF
--- a/fmpq_mpoly/get_str_pretty.c
+++ b/fmpq_mpoly/get_str_pretty.c
@@ -13,6 +13,8 @@
 #include <string.h>
 #include "fmpq_mpoly.h"
 
+#define ALLOC_PER_VAR ((FLINT_BITS+4)/3)
+
 char * fmpq_mpoly_get_str_pretty(const fmpq_mpoly_t A,
                                   const char ** x_in, const fmpq_mpoly_ctx_t qctx)
 {
@@ -21,7 +23,7 @@ char * fmpq_mpoly_get_str_pretty(const fmpq_mpoly_t A,
     fmpz * exponents;
     const fmpz_mpoly_struct * poly = A->zpoly;
     const mpoly_ctx_struct * mctx = qctx->zctx->minfo;
-    char ** x = (char **) x_in;
+    char ** x = (char **) x_in, *xtmp;
     slong len = A->zpoly->length;
     flint_bitcnt_t bits = A->zpoly->bits;
     char * str;
@@ -41,10 +43,11 @@ char * fmpq_mpoly_get_str_pretty(const fmpq_mpoly_t A,
 
     if (x == NULL)
     {
+        xtmp = (char *) TMP_ALLOC(mctx->nvars * ALLOC_PER_VAR * sizeof(char));
         x = (char **) TMP_ALLOC(mctx->nvars*sizeof(char *));
         for (i = 0; i < mctx->nvars; i++)
         {
-            x[i] = (char *) TMP_ALLOC(22*sizeof(char));
+            x[i] = xtmp + i * ALLOC_PER_VAR;
             flint_sprintf(x[i], "x%wd", i + 1);
         }
     }

--- a/fmpz_mpoly/get_str_pretty.c
+++ b/fmpz_mpoly/get_str_pretty.c
@@ -14,11 +14,13 @@
 #include <string.h>
 #include "fmpz_mpoly.h"
 
+#define ALLOC_PER_VAR ((FLINT_BITS+4)/3)
+
 char *
 _fmpz_mpoly_get_str_pretty(const fmpz * coeffs, const ulong * exps, slong len,
                         const char ** x_in, slong bits, const mpoly_ctx_t mctx)
 {
-    char * str, ** x = (char **) x_in;
+    char * str, ** x = (char **) x_in, *xtmp;
     slong i, j, N, bound, off;
     fmpz * exponents;
     int first;
@@ -38,10 +40,11 @@ _fmpz_mpoly_get_str_pretty(const fmpz * coeffs, const ulong * exps, slong len,
 
     if (x == NULL)
     {
+        xtmp = (char *) TMP_ALLOC(mctx->nvars * ALLOC_PER_VAR * sizeof(char));
         x = (char **) TMP_ALLOC(mctx->nvars*sizeof(char *));
         for (i = 0; i < mctx->nvars; i++)
         {
-            x[i] = (char *) TMP_ALLOC(22*sizeof(char));
+            x[i] = xtmp + i * ALLOC_PER_VAR;
             flint_sprintf(x[i], "x%wd", i + 1);
         }
     }

--- a/fq_nmod_mpoly/get_str_pretty.c
+++ b/fq_nmod_mpoly/get_str_pretty.c
@@ -13,12 +13,14 @@
 #include <string.h>
 #include "fq_nmod_mpoly.h"
 
+#define ALLOC_PER_VAR ((FLINT_BITS+4)/3)
+
 char *
 _fq_nmod_mpoly_get_str_pretty(const fq_nmod_struct * coeff, const ulong * exp,
                                   slong len, const char ** x_in, slong bits,
                                                  const fq_nmod_mpoly_ctx_t ctx)
 {
-    char * str, ** x = (char **) x_in;
+    char * str, ** x = (char **) x_in, *xtmp;
     slong i, j, N, bound, off;
     fmpz * exponents;
     int first;
@@ -39,10 +41,11 @@ _fq_nmod_mpoly_get_str_pretty(const fq_nmod_struct * coeff, const ulong * exp,
 
     if (x == NULL)
     {
+        xtmp = (char *) TMP_ALLOC(ctx->minfo->nvars * ALLOC_PER_VAR * sizeof(char));
         x = (char **) TMP_ALLOC(ctx->minfo->nvars*sizeof(char *));
         for (i = 0; i < ctx->minfo->nvars; i++)
         {
-            x[i] = (char *) TMP_ALLOC(((FLINT_BITS+4)/3)*sizeof(char));
+            x[i] = xtmp + i * ALLOC_PER_VAR;
             flint_sprintf(x[i], "x%wd", i + 1);
         }
     }

--- a/nmod_mpoly/get_str_pretty.c
+++ b/nmod_mpoly/get_str_pretty.c
@@ -13,12 +13,14 @@
 #include <string.h>
 #include "nmod_mpoly.h"
 
+#define ALLOC_PER_VAR ((FLINT_BITS+4)/3)
+
 char *
 _nmod_mpoly_get_str_pretty(const mp_limb_t * coeff, const ulong * exp, slong len,
                              const char ** x_in, slong bits,
                                 const mpoly_ctx_t mctx, const nmodf_ctx_t fctx)
 {
-    char * str, ** x = (char **) x_in;
+    char * str, ** x = (char **) x_in, *xtmp;
     slong i, j, N, bound, off;
     fmpz * exponents;
     int first;
@@ -38,10 +40,11 @@ _nmod_mpoly_get_str_pretty(const mp_limb_t * coeff, const ulong * exp, slong len
 
     if (x == NULL)
     {
+        xtmp = (char *) TMP_ALLOC(mctx->nvars * ALLOC_PER_VAR * sizeof(char));
         x = (char **) TMP_ALLOC(mctx->nvars*sizeof(char *));
         for (i = 0; i < mctx->nvars; i++)
         {
-            x[i] = (char *) TMP_ALLOC(((FLINT_BITS+4)/3)*sizeof(char));
+            x[i] = xtmp + i * ALLOC_PER_VAR;
             flint_sprintf(x[i], "x%wd", i + 1);
         }
     }


### PR DESCRIPTION
Fixes crash when printing a polynomial in 10^6 variables.