### PR TITLE
Gcd overhead

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -148,7 +148,7 @@ htmlhelp_basename = 'Flintdoc'
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
-    # 'papersize': 'letterpaper',
+    'papersize': 'a4paper',
 
     # The font size ('10pt', '11pt' or '12pt').
     #
@@ -157,6 +157,7 @@ latex_elements = {
     # Additional stuff for the LaTeX preamble.
     #
     # 'preamble': '',
+    'preamble': '\\usepackage{lmodern}\n\\setcounter{tocdepth}{2}\n\\urlstyle{tt}',
 
     # Latex figure (float) alignment
     #

--- a/doc/source/flintxx_functions.rst
+++ b/doc/source/flintxx_functions.rst
@@ -3601,7 +3601,7 @@ Exponential
 .. function:: Padic_expr exp_rectangular(Padic_expr)
 .. function:: Padic_expr exp_balanced(Padic_expr)
 
-    Compute the exponential function. These may raise ``flint_exception``s if the
+    Compute the exponential function. These may raise ``flint_exception`` if the
     series do not converge.
 
 Logarithm
@@ -3612,7 +3612,7 @@ Logarithm
 .. function:: Padic_expr log_balanced(Padic_expr)
 .. function:: Padic_expr log_satoh(Padic_expr)
 
-    Compute the logarithm function. These may raise ``flint_exception``s if the
+    Compute the logarithm function. These may raise ``flint_exception`` if the
     series do not converge.
 
 Special functions
@@ -3743,9 +3743,9 @@ Getting and setting coefficients
 .. function:: void Padic_poly_target::set_coeff(slong i, Padic_expr)
 
 Comparison
-
-    The overloaded ``operator==`` can be used for comparison.
 -------------------------------------------------------------------------------
+
+The overloaded ``operator==`` can be used for comparison.
 
 .. function:: bool Padic_poly_expr::is_zero() const
 .. function:: bool Padic_poly_expr::is_one() const
@@ -4057,7 +4057,7 @@ Exponential
 .. function:: Qadic_expr exp_rectangular(Qadic_expr)
 .. function:: Qadic_expr exp_balanced(Qadic_expr)
 
-    Compute the exponential function. These may raise ``flint_exception``s
+    Compute the exponential function. These may raise ``flint_exception``
     if the series do not converge.
 
 Logarithm
@@ -4066,7 +4066,7 @@ Logarithm
 .. function:: Qadic_expr log(Qadic_expr)
 .. function:: Qadic_expr log_balanced(Qadic_expr)
 
-    Compute the logarithm function. These may raise ``flint_exception``s
+    Compute the logarithm function. These may raise ``flint_exception``
     if the series do not converge.
 
 Special functions

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -144,7 +144,7 @@ Floating-point support code
 C++ Interface
 
 .. toctree::
-   :maxdpth 1
+   :maxdepth: 1
 
    flintxx.rst
    flintxx_functions.rst

--- a/fmpz_mpoly/mul.c
+++ b/fmpz_mpoly/mul.c
@@ -131,6 +131,38 @@ void fmpz_mpoly_mul(
         return;
     }
 
+    if (fmpz_mpoly_is_fmpz(B, ctx))
+    {
+        if (A == B || C == B)
+        {
+            fmpz_t t;
+            fmpz_init_set(t, B->coeffs);
+            fmpz_mpoly_scalar_mul_fmpz(A, C, t, ctx);
+            fmpz_clear(t);
+        }
+        else
+        {
+            fmpz_mpoly_scalar_mul_fmpz(A, C, B->coeffs, ctx);
+        }
+        return;
+    }
+
+    if (fmpz_mpoly_is_fmpz(C, ctx))
+    {
+        if (A == C || B == C)
+        {
+            fmpz_t t;
+            fmpz_init_set(t, C->coeffs);
+            fmpz_mpoly_scalar_mul_fmpz(A, B, t, ctx);
+            fmpz_clear(t);
+        }
+        else
+        {
+            fmpz_mpoly_scalar_mul_fmpz(A, B, C->coeffs, ctx);
+        }
+        return;
+    }
+
     TMP_START;
 
     /*


### PR DESCRIPTION
Avoid overhead in fmpz_mpoly_gcd for constant or length 1 input.

(Minor doc fix in older commit.)