### PR TITLE
Changes to CMake files to allow MPIR replacement and require C11/C++11 standard

### DIFF
--- a/CMake/FindGMP.cmake
+++ b/CMake/FindGMP.cmake
@@ -1,23 +1,22 @@
-# Try to find the GMP library
-# https://gmplib.org/
+# Try to find the GNU Multiple Precision Arithmetic Library (GMP)
+# See http://gmplib.org/
 #
 # This module supports requiring a minimum version, e.g. you can do
-#   find_package(GMP 6.0.0)
-# to require version 6.0.0 to newer of GMP.
+#   find_package(GMP 6.1.0)
+# to require version 6.1.0 to newer of GMP.
 #
 # Once done this will define
 #
-#  GMP_FOUND - system has GMP lib with correct version
-#  GMP_INCLUDE_DIRS - the GMP include directory
-#  GMP_LIBRARIES - the GMP library
-#  GMP_VERSION - GMP version
-#
+#  GMP_FOUND             - system has GMP lib
+#  GMP_INCLUDE_DIRS      - the GMP include directory
+#  GMP_LIBRARIES         - Libraries needed to use GMP
+#  GMP_VERSION           - GMP version
+
 # Copyright (c) 2016 Jack Poulson, <jack.poulson@gmail.com>
+# Copyright (c) 2020, Mahrud Sayrafi, <mahrud@umn.edu>
 # Redistribution and use is allowed according to the terms of the BSD license.
 
-find_path(GMP_INCLUDE_DIRS NAMES gmp.h PATHS $ENV{GMPDIR} ${INCLUDE_INSTALL_DIR})
-
-# Set GMP_FIND_VERSION to 5.1.0 if no minimum version is specified
+# Set GMP_FIND_VERSION to 1.0.0 if no minimum version is specified
 if(NOT GMP_FIND_VERSION)
   if(NOT GMP_FIND_VERSION_MAJOR)
     set(GMP_FIND_VERSION_MAJOR 5)
@@ -32,11 +31,10 @@ if(NOT GMP_FIND_VERSION)
     "${GMP_FIND_VERSION_MAJOR}.${GMP_FIND_VERSION_MINOR}.${GMP_FIND_VERSION_PATCH}")
 endif()
 
-if(GMP_INCLUDE_DIRS)
+macro(_gmp_check_version)
   # Since the GMP version macros may be in a file included by gmp.h of the form
   # gmp-.*[_]?.*.h (e.g., gmp-x86_64.h), we search each of them.
-  file(GLOB GMP_HEADERS "${GMP_INCLUDE_DIRS}/gmp.h" "${GMP_INCLUDE_DIRS}/gmp-*.h"
-	  "${GMP_INCLUDE_DIRS}/x86*/gmp.h")
+  file(GLOB GMP_HEADERS "${GMP_INCLUDE_DIRS}/gmp.h" "${GMP_INCLUDE_DIRS}/gmp-*.h")
   foreach(gmp_header_filename ${GMP_HEADERS})
     file(READ "${gmp_header_filename}" _gmp_version_header)
     string(REGEX MATCH
@@ -55,6 +53,9 @@ if(GMP_INCLUDE_DIRS)
     endif()
   endforeach()
 
+  set(GMP_VERSION
+    ${GMP_MAJOR_VERSION}.${GMP_MINOR_VERSION}.${GMP_PATCHLEVEL_VERSION})
+
   # Check whether found version exists and exceeds the minimum requirement
   if(NOT GMP_VERSION)
     set(GMP_VERSION_OK FALSE)
@@ -66,11 +67,38 @@ if(GMP_INCLUDE_DIRS)
   else()
     set(GMP_VERSION_OK TRUE)
   endif()
+endmacro(_gmp_check_version)
+
+if(NOT GMP_VERSION_OK)
+  set(GMP_INCLUDE_DIRS NOTFOUND)
+  set(GMP_LIBRARIES NOTFOUND)
+
+  # search first if an GMPConfig.cmake is available in the system,
+  # if successful this would set GMP_INCLUDE_DIRS and the rest of
+  # the script will work as usual
+  find_package(GMP ${GMP_FIND_VERSION} NO_MODULE QUIET)
+
+  if(NOT GMP_INCLUDE_DIRS)
+    find_path(GMP_INCLUDE_DIRS NAMES gmp.h
+      HINTS ENV GMPDIR ENV GMPDIR
+      PATHS ${INCLUDE_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX}/include
+      )
+  endif()
+
+  if(GMP_INCLUDE_DIRS)
+    _GMP_check_version()
+  endif()
+
+  if(NOT GMP_LIBRARIES)
+    find_library(GMP_LIBRARIES NAMES gmp
+      HINTS ENV GMPDIR ENV GMPDIR
+      PATHS ${LIB_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX}/lib
+      )
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(GMP DEFAULT_MSG GMP_INCLUDE_DIRS GMP_LIBRARIES GMP_VERSION_OK)
+
+  mark_as_advanced(GMP_INCLUDE_DIRS GMP_LIBRARIES)
+
 endif()
-
-find_library(GMP_LIBRARIES gmp PATHS $ENV{GMPDIR} ${LIB_INSTALL_DIR})
-
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(GMP DEFAULT_MSG
-                                  GMP_INCLUDE_DIRS GMP_LIBRARIES GMP_VERSION_OK)
-mark_as_advanced(GMP_INCLUDE_DIRS GMP_LIBRARIES)

--- a/CMake/FindMPIR.cmake
+++ b/CMake/FindMPIR.cmake
@@ -1,0 +1,92 @@
+# Try to find the MPIR libraries
+# See http://www.mpir.org/
+#
+# This module supports requiring a minimum version, e.g. you can do
+#   find_package(MPIR 3.0.0)
+# to require version 3.0.0 to newer of MPIR.
+#
+# Once done this will define
+#
+#  MPIR_FOUND             - system has MPIR lib
+#  MPIR_INCLUDE_DIRS      - the MPIR include directory
+#  MPIR_LIBRARIES         - Libraries needed to use MPIR
+#  MPIR_VERSION           - MPIR version
+
+# Copyright (c) 2020, Mahrud Sayrafi, <mahrud@umn.edu>
+# Redistribution and use is allowed according to the terms of the BSD license.
+
+# Set MPIR_FIND_VERSION to 1.0.0 if no minimum version is specified
+if(NOT MPIR_FIND_VERSION)
+  if(NOT MPIR_FIND_VERSION_MAJOR)
+    set(MPIR_FIND_VERSION_MAJOR 1)
+  endif()
+  if(NOT MPIR_FIND_VERSION_MINOR)
+    set(MPIR_FIND_VERSION_MINOR 0)
+  endif()
+  if(NOT MPIR_FIND_VERSION_PATCH)
+    set(MPIR_FIND_VERSION_PATCH 0)
+  endif()
+  set(MPIR_FIND_VERSION
+    "${MPIR_FIND_VERSION_MAJOR}.${MPIR_FIND_VERSION_MINOR}.${MPIR_FIND_VERSION_PATCH}")
+endif()
+
+macro(_mpir_check_version)
+  # Query MPIR_VERSION
+  file(READ "${MPIR_INCLUDE_DIRS}/mpir.h" _mpir_version_header)
+
+  string(REGEX MATCH "define[ \t]+__MPIR_VERSION[ \t]+([0-9]+)"
+    _mpir_major_version_match "${_mpir_version_header}")
+  set(MPIR_MAJOR_VERSION "${CMAKE_MATCH_1}")
+  string(REGEX MATCH "define[ \t]+__MPIR_VERSION_MINOR[ \t]+([0-9]+)"
+    _mpir_minor_version_match "${_mpir_version_header}")
+  set(MPIR_MINOR_VERSION "${CMAKE_MATCH_1}")
+  string(REGEX MATCH "define[ \t]+__MPIR_VERSION_PATCHLEVEL[ \t]+([0-9]+)"
+    _mpir_patchlevel_version_match "${_mpir_version_header}")
+  set(MPIR_PATCHLEVEL_VERSION "${CMAKE_MATCH_1}")
+
+  set(MPIR_VERSION
+    ${MPIR_MAJOR_VERSION}.${MPIR_MINOR_VERSION}.${MPIR_PATCHLEVEL_VERSION})
+
+  # Check whether found version exceeds minimum required
+  if(${MPIR_VERSION} VERSION_LESS ${MPIR_FIND_VERSION})
+    set(MPIR_VERSION_OK FALSE)
+    message(STATUS "MPIR version ${MPIR_VERSION} found in ${MPIR_INCLUDE_DIRS}, "
+                   "but at least version ${MPIR_FIND_VERSION} is required")
+  else()
+    set(MPIR_VERSION_OK TRUE)
+  endif()
+endmacro(_mpir_check_version)
+
+if(NOT MPIR_VERSION_OK)
+  set(MPIR_INCLUDE_DIRS NOTFOUND)
+  set(MPIR_LIBRARIES NOTFOUND)
+
+  # search first if an MPIRConfig.cmake is available in the system,
+  # if successful this would set MPIR_INCLUDE_DIRS and the rest of
+  # the script will work as usual
+  find_package(MPIR ${MPIR_FIND_VERSION} NO_MODULE QUIET)
+
+  if(NOT MPIR_INCLUDE_DIRS)
+    find_path(MPIR_INCLUDE_DIRS NAMES mpir.h
+      HINTS ENV MPIRDIR ENV GMPDIR
+      PATHS ${INCLUDE_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX}/include
+      )
+  endif()
+
+  if(MPIR_INCLUDE_DIRS)
+    _MPIR_check_version()
+  endif()
+
+  if(NOT MPIR_LIBRARIES)
+    find_library(MPIR_LIBRARIES NAMES mpir
+      HINTS ENV MPIRDIR ENV GMPDIR
+      PATHS ${LIB_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX}/lib
+      )
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(MPIR DEFAULT_MSG MPIR_INCLUDE_DIRS MPIR_LIBRARIES MPIR_VERSION_OK)
+
+  mark_as_advanced(MPIR_INCLUDE_DIRS MPIR_LIBRARIES)
+
+endif()

--- a/CMake/FindNTL.cmake
+++ b/CMake/FindNTL.cmake
@@ -1,25 +1,94 @@
-# Locate NTL
-# This module defines
-# NTL_LIBRARY
-# NTL_FOUND, if false, do not try to link to OpenAL 
-# NTL_INCLUDE_DIR, where to find the headers
+# Try to find the NTL libraries
+# See https://www.shoup.net/ntl/
 #
-# Created by Tai Chi Minh Ralph Eastwood <tcmreastwood@gmail.com>
+# This module supports requiring a minimum version, e.g. you can do
+#   find_package(NTL 10.5.0)
+# to require version 10.5.0 to newer of NTL.
+#
+# Once done this will define
+#
+#  NTL_FOUND		- system has the NTL library with correct version
+#  NTL_INCLUDE_DIR	- the NTL include directory
+#  NTL_LIBRARIES	- the NTL library
+#  NTL_VERSION		- NTL version
 
-FIND_PATH(NTL_INCLUDE_DIR NTL/RR.h
-  HINTS
-  $ENV{NTLDIR}
-)
+# Copyright (c) 2020, Mahrud Sayrafi, <mahrud@umn.edu>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
 
-FIND_LIBRARY(NTL_LIBRARY
-  NAMES ntl
-  HINTS
-  $ENV{NTLDIR}
-)
+# Set NTL_FIND_VERSION to 1.0.0 if no minimum version is specified
+if(NOT NTL_FIND_VERSION)
+  if(NOT NTL_FIND_VERSION_MAJOR)
+    set(NTL_FIND_VERSION_MAJOR 1)
+  endif()
+  if(NOT NTL_FIND_VERSION_MINOR)
+    set(NTL_FIND_VERSION_MINOR 0)
+  endif()
+  if(NOT NTL_FIND_VERSION_PATCH)
+    set(NTL_FIND_VERSION_PATCH 0)
+  endif()
 
-# handle the QUIETLY and REQUIRED arguments and set NTL_FOUND to TRUE if
-# all listed variables are TRUE
-INCLUDE(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(NTL DEFAULT_MSG  NTL_LIBRARY NTL_INCLUDE_DIR)
+  set(NTL_FIND_VERSION "${NTL_FIND_VERSION_MAJOR}.${NTL_FIND_VERSION_MINOR}.${NTL_FIND_VERSION_PATCH}")
+endif()
 
-MARK_AS_ADVANCED(NTL_LIBRARY NTL_INCLUDE_DIR)
+macro(_NTL_check_version)
+  # Query NTL_VERSION
+  file(READ "${NTL_INCLUDE_DIR}/NTL/version.h" _NTL_version_header)
+
+  string(REGEX MATCH "define[ \t]+NTL_MAJOR_VERSION[ \t]+\\(([0-9]+)\\)"
+    _NTL_major_version_match "${_NTL_version_header}")
+  set(NTL_MAJOR_VERSION "${CMAKE_MATCH_1}")
+  string(REGEX MATCH "define[ \t]+NTL_MINOR_VERSION[ \t]+\\(([0-9]+)\\)"
+    _NTL_minor_version_match "${_NTL_version_header}")
+  set(NTL_MINOR_VERSION "${CMAKE_MATCH_1}")
+  string(REGEX MATCH "define[ \t]+NTL_REVISION[ \t]+\\(([0-9]+)\\)"
+    _NTL_patchlevel_version_match "${_NTL_version_header}")
+  set(NTL_PATCHLEVEL_VERSION "${CMAKE_MATCH_1}")
+
+  set(NTL_VERSION
+    ${NTL_MAJOR_VERSION}.${NTL_MINOR_VERSION}.${NTL_PATCHLEVEL_VERSION})
+
+  # Check whether found version exceeds minimum required
+  if(${NTL_VERSION} VERSION_LESS ${NTL_FIND_VERSION})
+    set(NTL_VERSION_OK FALSE)
+    message(STATUS "NTL version ${NTL_VERSION} found in ${NTL_INCLUDE_DIR}, "
+                   "but at least version ${NTL_FIND_VERSION} is required")
+  else()
+    set(NTL_VERSION_OK TRUE)
+  endif()
+endmacro(_NTL_check_version)
+
+if(NOT NTL_FOUND)
+  set(NTL_INCLUDE_DIR NOTFOUND)
+  set(NTL_LIBRARIES NOTFOUND)
+
+  # search first if an NTLConfig.cmake is available in the system,
+  # if successful this would set NTL_INCLUDE_DIR and the rest of
+  # the script will work as usual
+  find_package(NTL ${NTL_FIND_VERSION} NO_MODULE QUIET)
+
+  if(NOT NTL_INCLUDE_DIR)
+    find_path(NTL_INCLUDE_DIR NAMES NTL/version.h
+      HINTS ENV NTLDIR
+      PATHS ${INCLUDE_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX}/include
+      PATH_SUFFIXES NTL
+      )
+  endif()
+
+  if(NTL_INCLUDE_DIR)
+    _NTL_check_version()
+  endif()
+
+  if(NOT NTL_LIBRARIES)
+    find_library(NTL_LIBRARIES NAMES ntl
+      HINTS ENV NTLDIR
+      PATHS ${LIB_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX}/lib
+      )
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(NTL DEFAULT_MSG NTL_INCLUDE_DIR NTL_LIBRARIES NTL_VERSION_OK)
+
+  mark_as_advanced(NTL_INCLUDE_DIR NTL_LIBRARIES)
+
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ include(CheckCCompilerFlag)
 include(CheckLibraryExists)
 include(TestBigEndian)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_C_STANDARD 11)
+
 project(flint LANGUAGES C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 option(BUILD_SHARED_LIBS "Build shared libs" on)
+option(WITH_MPIR "Build with MPIR or not" off)
 option(WITH_NTL "Build with NTL or not" off)
 
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/configure" CONFIGURE_CONTENTS)
@@ -33,6 +34,8 @@ set(FLINT_PATCH ${CMAKE_MATCH_1})
 
 if(WITH_MPIR)
   find_package(MPIR 3.0.0 REQUIRED)
+  set(GMP_LIBRARIES ${MPIR_LIBRARIES})
+  set(GMP_INCLUDE_DIRS ${MPIR_INCLUDE_DIRS})
 else()
   find_package(GMP 6.0.0 REQUIRED)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,10 +31,14 @@ set(FLINT_MINOR ${CMAKE_MATCH_1})
 string(REGEX MATCH "FLINT_PATCH=([0-9]*)" _ ${CONFIGURE_CONTENTS})
 set(FLINT_PATCH ${CMAKE_MATCH_1})
 
-find_package(GMP REQUIRED)
-find_package(MPFR REQUIRED)
-if (WITH_NTL)
-    find_package(NTL REQUIRED)
+if(WITH_MPIR)
+  find_package(MPIR 3.0.0 REQUIRED)
+else()
+  find_package(GMP 6.0.0 REQUIRED)
+endif()
+find_package(MPFR 4.0.1 REQUIRED)
+if(WITH_NTL)
+    find_package(NTL 10.5.0 REQUIRED)
 endif()
 find_package(PythonInterp REQUIRED)
 
@@ -229,7 +233,7 @@ list(APPEND HEADERS ${TEMP})
 
 add_library(flint ${SOURCES})
 target_link_libraries(flint PUBLIC
-    ${NTL_LIBRARY} ${MPFR_LIBRARIES} ${GMP_LIBRARIES} ${PThreads_LIBRARIES}
+    ${NTL_LIBRARIES} ${MPFR_LIBRARIES} ${GMP_LIBRARIES} ${PThreads_LIBRARIES}
 )
 
 # Include directories


### PR DESCRIPTION
These changes are limited to CMakeLists.txt and the CMake directory. I'm not sure if they were considered and rejected or not, but I thought I'd submit the PR as a suggestion just in case.

cc: @isuruf, @deinst.