### PR TITLE
set proper compiler flags on *BSD

### DIFF
--- a/configure
+++ b/configure
@@ -585,7 +585,6 @@ else
 fi
 
 #defaults for CFLAGS
-
 if [ -z "$CFLAGS" ]; then
    if [ "$OS" = "MINGW64" ]; then
       CFLAGS="-std=c99 -O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG"
@@ -596,10 +595,10 @@ if [ -z "$CFLAGS" ]; then
    elif [ "$MACHINE" = "mips64" ]; then
       CFLAGS="-O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG"
       ANSI_FLAG=""
-   elif [ "$KERNEL" = FreeBSD ]; then
-      CFLAGS="-std=c99 -pedantic -Wall -O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG"
+   elif test "$KERNEL" = "FreeBSD" -o "$OS" = "OpenBSD"; then
+      CFLAGS="-std=c99 -pedantic -Wall -O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG -I/usr/local/include"
       ANSI_FLAG=""
-      CXXFLAGS="-std=c++11 -pedantic -Wall -O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG"
+      CXXFLAGS="-std=c++11 -pedantic -Wall -O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG -I/usr/local/include"
    else
       ANSI_FLAG="-ansi"
       CFLAGS="-pedantic -Wall -O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG"


### PR DESCRIPTION
enable setting std C++ flag on OpenBSD, and also make the FreeBSD handling a bit more sane - 
both need `-I/usr/local/include` in C*FLAGS. 