### PR TITLE
Makefile.in [macos]: Do not make $(DESTDIR) part of install_name

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -214,7 +214,7 @@ install: library
 	cp flintxx/*.h "$(DESTDIR)$(PREFIX)/include/flint/flintxx"
 	cp *xx.h "$(DESTDIR)$(PREFIX)/include/flint"
 	$(AT)if [ "$(OS)" = "Darwin" ] && [ "$(FLINT_SHARED)" -eq "1" ]; then \
-		install_name_tool -id "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(FLINT_LIB)" "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(FLINT_LIBNAME)"; \
+		install_name_tool -id "$(PREFIX)/$(LIBDIR)/$(FLINT_LIB)" "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(FLINT_LIBNAME)"; \
 	fi
 
 build:


### PR DESCRIPTION
Fixes an installation problem on macOS when DESTDIR is used, see https://trac.sagemath.org/ticket/29719#comment:41