### PR TITLE
Speedup for rref of matrices with <= 1 rows

### DIFF
--- a/fq_mat_templates/rref.c
+++ b/fq_mat_templates/rref.c
@@ -29,6 +29,36 @@ TEMPLATE(T, mat_rref) (TEMPLATE(T, mat_t) A, const TEMPLATE(T, ctx_t) ctx)
     TEMPLATE(T, struct) * e;
     TEMPLATE(T, mat_t) U, V;
 
+    if (TEMPLATE(T, mat_is_zero)(A, ctx))
+        return 0;
+
+    if (A->r == 1)
+    {
+        TEMPLATE(T, struct) * c;
+        slong i, j;
+        slong r = 0;
+
+        for (i = 0; i < A->c; i++)
+        {
+            c = TEMPLATE(T, mat_entry)(A, 0, i);
+            if (!TEMPLATE(T, is_zero)(c, ctx))
+            {
+                r = 1;
+                if (TEMPLATE(T, is_one)(c, ctx))
+                    break;
+
+                TEMPLATE(T, inv)(c, c, ctx);
+                for (j = i + 1;j < A->c; j++)
+                {
+                    TEMPLATE(T, mul)(TEMPLATE(T, mat_entry)(A, 0, j), TEMPLATE(T, mat_entry)(A, 0, j), c, ctx);
+                }
+                TEMPLATE(T, one)(c, ctx);
+                break;
+            }
+        }
+        return r;
+    }
+
     n = A->c;
 
     P = _perm_init(TEMPLATE(T, mat_nrows) (A, ctx));

--- a/nmod_mat/rref.c
+++ b/nmod_mat/rref.c
@@ -109,6 +109,37 @@ slong
 nmod_mat_rref(nmod_mat_t A)
 {
     slong rank, * pivots_nonpivots, * P;
+
+    if (nmod_mat_is_empty(A))
+        return 0;
+
+    if (A->r == 1)
+    {
+        mp_limb_t c, cinv;
+        slong i, j;
+        slong r = 0;
+
+        for (i = 0; i < A->c; i++)
+        {
+            c = nmod_mat_entry(A, 0, i);
+            if (c != 0)
+            {
+                r = 1;
+                if (c == 1)
+                    break;
+
+                cinv = nmod_inv(c, A->mod);
+                nmod_mat_set_entry(A, 0, i, 1);
+                for (j = i + 1;j < A->c; j++)
+                {
+                    nmod_mat_set_entry(A, 0, j, nmod_mul(nmod_mat_get_entry(A, 0, j), cinv, A->mod));
+                }
+                break;
+            }
+        }
+        return r;
+    }
+
     pivots_nonpivots = flint_malloc(sizeof(slong) * A->c);
     P = _perm_init(nmod_mat_nrows(A));
 


### PR DESCRIPTION
Gave me a nice speepd up (at least twice as fast) for matrices with <= 1 rows.