### PR TITLE
Remove redundant declarations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - export LOCAL=$(pwd)/local
   - export LDFLAGS="-Wl,-rpath,$LOCAL/lib"
   - ./.build_dependencies
-  - ./configure --with-mpir=${LOCAL} --with-mpfr=${LOCAL} --prefix=${LOCAL}
+  - ./configure CFLAGS="-Wredundant-decls" --with-mpir=${LOCAL} --with-mpfr=${LOCAL} --prefix=${LOCAL}
   - ${MAKE}
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then otool -L libflint.dylib; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/fmpq_poly.h
+++ b/fmpq_poly.h
@@ -851,19 +851,6 @@ int fmpq_poly_read(fmpq_poly_t poly)
     return fmpq_poly_fread(stdin, poly);
 }
 
-/* Inlines *******************************************************************/
-
-FLINT_DLL void fmpq_poly_add_si(fmpq_poly_t res, const fmpq_poly_t poly, slong c);
-FLINT_DLL void fmpq_poly_sub_si(fmpq_poly_t res, const fmpq_poly_t poly, slong c);
-FLINT_DLL void fmpq_poly_si_sub(fmpq_poly_t res, slong c, const fmpq_poly_t poly);
-FLINT_DLL void fmpq_poly_add_fmpz(fmpq_poly_t res, const fmpq_poly_t poly, const fmpz_t c);
-FLINT_DLL void fmpq_poly_sub_fmpz(fmpq_poly_t res, const fmpq_poly_t poly, const fmpz_t c);
-FLINT_DLL void fmpq_poly_fmpz_sub(fmpq_poly_t res, const fmpz_t c, const fmpq_poly_t poly);
-FLINT_DLL void fmpq_poly_add_fmpq(fmpq_poly_t res, const fmpq_poly_t poly, const fmpq_t c);
-FLINT_DLL void fmpq_poly_sub_fmpq(fmpq_poly_t res, const fmpq_poly_t poly, const fmpq_t c);
-FLINT_DLL void fmpq_poly_fmpq_sub(fmpq_poly_t res, const fmpq_t c, const fmpq_poly_t poly);
-FLINT_DLL void fmpq_poly_get_coeff_fmpz(fmpz_t x, const fmpq_poly_t poly, slong n);
-
 #ifdef __cplusplus
 }
 #endif

--- a/fmpq_poly/test/t-print_read.c
+++ b/fmpq_poly/test/t-print_read.c
@@ -24,13 +24,6 @@
 
 #if (!defined (__WIN32) || defined(__CYGWIN__)) && !defined(_MSC_VER)
 
-/*
-    The function fdopen is declared in stdio.h.  It is POSIX.1 compliant, 
-    but not ANSI compliant.  The following line enables compilation with 
-    the "-ansi" flag.
- */
-extern FILE * fdopen(int fildes, const char *mode);
-
 int main(void)
 {
     int i, j, n = 1000, result;

--- a/fmpz/test/t-out_inp_raw.c
+++ b/fmpz/test/t-out_inp_raw.c
@@ -28,13 +28,6 @@
 
 #if (!defined (__WIN32) || defined(__CYGWIN__)) && !defined(_MSC_VER) 
 
-/*
-    The function fdopen is declared in stdio.h.  It is POSIX.1 compliant, 
-    but not ANSI compliant.  The following line enables compilation with 
-    the "-ansi" flag.
- */
-extern FILE * fdopen(int fildes, const char *mode);
-
 int main(void)
 {
     int i, j, n = 10000, result;

--- a/fmpz/test/t-print_read.c
+++ b/fmpz/test/t-print_read.c
@@ -22,13 +22,6 @@
 
 #if (!defined (__WIN32) || defined(__CYGWIN__)) && !defined(_MSC_VER)
 
-/*
-    The function fdopen is declared in stdio.h.  It is POSIX.1 compliant, 
-    but not ANSI compliant.  The following line enables compilation with 
-    the "-ansi" flag.
- */
-extern FILE * fdopen(int fildes, const char *mode);
-
 int main(void)
 {
     int i, j, n = 10000, result;

--- a/fmpz_mat/test/t-print_read.c
+++ b/fmpz_mat/test/t-print_read.c
@@ -23,13 +23,6 @@
 
 #if (!defined (__WIN32) || defined(__CYGWIN__)) && !defined(_MSC_VER)
 
-/*
-    The function fdopen is declared in stdio.h.  It is POSIX.1 compliant, 
-    but not ANSI compliant.  The following line enables compilation with 
-    the "-ansi" flag.
- */
-extern FILE * fdopen(int fildes, const char *mode);
-
 int main(void)
 {
     int i, j, m, n, k = 1000, result;

--- a/fmpz_mod_mpoly.h
+++ b/fmpz_mod_mpoly.h
@@ -86,9 +86,6 @@ FLINT_DLL void fmpz_mod_mpoly_ctx_clear(fmpz_mod_mpoly_ctx_t ctx);
 FLINT_DLL void fmpz_mod_mpolyn_init(fmpz_mod_mpolyn_t A, flint_bitcnt_t bits,
                                                const fmpz_mod_mpoly_ctx_t ctx);
 
-FLINT_DLL void fmpz_mod_mpolyn_fit_length(fmpz_mod_mpolyn_t A,
-                                 slong length, const fmpz_mod_mpoly_ctx_t ctx);
-
 FMPZ_MOD_MPOLY_INLINE void fmpz_mod_mpolyn_swap(fmpz_mod_mpolyn_t A,
                            fmpz_mod_mpolyn_t B, const fmpz_mod_mpoly_ctx_t ctx)
 {
@@ -116,11 +113,6 @@ FMPZ_MOD_MPOLY_INLINE fmpz_mod_poly_struct * fmpz_mod_mpolyn_leadcoeff_poly(
     return A->coeffs + 0;
 }
 
-
-FLINT_DLL void fmpz_mod_mpolyn_divexact_poly(
-    fmpz_mod_mpolyn_t A,
-    const fmpz_mod_poly_t b,
-    const fmpz_mod_mpoly_ctx_t ctx);
 
 FLINT_DLL void fmpz_mod_mpolyn_fit_length(fmpz_mod_mpolyn_t A,
                                  slong length, const fmpz_mod_mpoly_ctx_t ctx);

--- a/fmpz_mod_poly.h
+++ b/fmpz_mod_poly.h
@@ -404,9 +404,6 @@ FLINT_DLL void fmpz_mod_poly_add_series(fmpz_mod_poly_t res,
                    const fmpz_mod_poly_t poly1, const fmpz_mod_poly_t poly2,
                                             slong n, const fmpz_mod_ctx_t ctx);
 
-FLINT_DLL void _fmpz_mod_poly_sub(fmpz *res, const fmpz *poly1, slong len1, 
-                                const fmpz *poly2, slong len2, const fmpz_t p);
-
 FLINT_DLL void fmpz_mod_poly_sub(fmpz_mod_poly_t res, const fmpz_mod_poly_t poly1,
                         const fmpz_mod_poly_t poly2, const fmpz_mod_ctx_t ctx);
 
@@ -416,9 +413,6 @@ FLINT_DLL void _fmpz_mod_poly_neg(fmpz *res, const fmpz *poly, slong len,
 FLINT_DLL void fmpz_mod_poly_sub_series(fmpz_mod_poly_t res, 
                    const fmpz_mod_poly_t poly1, const fmpz_mod_poly_t poly2,
                                             slong n, const fmpz_mod_ctx_t ctx);
-
-FLINT_DLL void _fmpz_mod_poly_neg(fmpz *res, const fmpz *poly, slong len,
-                                                               const fmpz_t p);
 
 FLINT_DLL void fmpz_mod_poly_neg(fmpz_mod_poly_t res,
                          const fmpz_mod_poly_t poly, const fmpz_mod_ctx_t ctx);
@@ -709,23 +703,6 @@ void fmpz_mod_poly_rem_f(fmpz_t f, fmpz_mod_poly_t R, const fmpz_mod_poly_t A,
     fmpz_mod_poly_divrem_f(f, Q, R, A, B, ctx);
     fmpz_mod_poly_clear(Q, ctx);
 }
-
-FLINT_DLL void _fmpz_mod_poly_div_newton_n_preinv (fmpz *Q, const fmpz* A, slong lenA,
-                                         const fmpz* B, slong lenB, const fmpz* Binv,
-                                         slong lenBinv, const fmpz_t p);
-
-FLINT_DLL void fmpz_mod_poly_div_newton_n_preinv (fmpz_mod_poly_t Q,
-                          const fmpz_mod_poly_t A, const fmpz_mod_poly_t B,
-                          const fmpz_mod_poly_t Binv,const fmpz_mod_ctx_t ctx);
-
-
-FLINT_DLL void _fmpz_mod_poly_divrem_newton_n_preinv (fmpz* Q, fmpz* R, const fmpz* A,
-                                            slong lenA, const fmpz* B, slong lenB,
-                                            const fmpz* Binv, slong lenBinv, const fmpz_t p);
-
-FLINT_DLL void fmpz_mod_poly_divrem_newton_n_preinv(fmpz_mod_poly_t Q,
-           fmpz_mod_poly_t R, const fmpz_mod_poly_t A, const fmpz_mod_poly_t B,
-                         const fmpz_mod_poly_t Binv, const fmpz_mod_ctx_t ctx);
 
 /*  Power series inversion ***************************************************/
 

--- a/fmpz_mod_poly/test/t-print_read.c
+++ b/fmpz_mod_poly/test/t-print_read.c
@@ -23,13 +23,6 @@
 
 #if (!defined (__WIN32) || defined(__CYGWIN__)) && !defined(_MSC_VER)
 
-/*
-    The function fdopen is declared in stdio.h.  It is POSIX.1 compliant, 
-    but not ANSI compliant.  The following line enables compilation with 
-    the "-ansi" flag.
- */
-extern FILE * fdopen(int fildes, const char *mode);
-
 int main(void)
 {
     int i, j, n, result;

--- a/fmpz_mod_poly_factor.h
+++ b/fmpz_mod_poly_factor.h
@@ -135,9 +135,6 @@ FLINT_DLL void fmpz_mod_poly_factor_distinct_deg_threaded(
                     fmpz_mod_poly_factor_t res, const fmpz_mod_poly_t poly,
                                slong * const * degs, const fmpz_mod_ctx_t ctx);
 
-FLINT_DLL void fmpz_mod_poly_factor_squarefree(fmpz_mod_poly_factor_t res,
-                            const fmpz_mod_poly_t f, const fmpz_mod_ctx_t ctx);
-
 FLINT_DLL void fmpz_mod_poly_factor(fmpz_mod_poly_factor_t res,
                             const fmpz_mod_poly_t f, const fmpz_mod_ctx_t ctx);
 

--- a/fmpz_mpoly.h
+++ b/fmpz_mpoly.h
@@ -1530,14 +1530,6 @@ FLINT_DLL void _fmpz_mpoly_submul_array1_fmpz_1(fmpz * poly1,
                           const fmpz_t d, ulong exp2,
                            const fmpz * poly3, const ulong * exp3, slong len3);
 
-FLINT_DLL void mpoly_main_variable_split_LEX(slong * ind, ulong * pexp,
-             const ulong * Aexp,
-             slong l1, slong Alen, const ulong * mults, slong num, slong Abits);
-
-FLINT_DLL void mpoly_main_variable_split_DEG(slong * ind, ulong * pexp,
-             const ulong * Aexp,
-             slong l1, slong Alen, ulong deg, slong num, slong Abits);
-
 FLINT_DLL slong fmpz_mpoly_append_array_sm1_LEX(fmpz_mpoly_t P,
                         slong Plen, ulong * coeff_array,
                   const ulong * mults, slong num, slong array_size, slong top);

--- a/fmpz_poly/taylor_shift_divconquer.c
+++ b/fmpz_poly/taylor_shift_divconquer.c
@@ -26,9 +26,6 @@ typedef struct
 }
 worker_t;
 
-void _fmpz_poly_taylor_shift_divconquer(fmpz * poly,
-                                                    const fmpz_t c, slong len);
-
 static void
 _fmpz_poly_taylor_shift_divconquer_worker(void * arg_ptr)
 {

--- a/fmpz_poly/test/t-print_read.c
+++ b/fmpz_poly/test/t-print_read.c
@@ -23,13 +23,6 @@
 
 #if (!defined (__WIN32) || defined(__CYGWIN__)) && !defined(_MSC_VER)
 
-/*
-    The function fdopen is declared in stdio.h.  It is POSIX.1 compliant, 
-    but not ANSI compliant.  The following line enables compilation with 
-    the "-ansi" flag.
- */
-extern FILE * fdopen(int fildes, const char *mode);
-
 int main(void)
 {
     int i, j, n = 1000, result;

--- a/fmpz_poly/test/t-print_read_pretty.c
+++ b/fmpz_poly/test/t-print_read_pretty.c
@@ -24,13 +24,6 @@
 
 #if (!defined (__WIN32) || defined(__CYGWIN__)) && !defined(_MSC_VER)
 
-/*
-    The function fdopen is declared in stdio.h.  It is POSIX.1 compliant, 
-    but not ANSI compliant.  The following line enables compilation with 
-    the "-ansi" flag.
- */
-extern FILE * fdopen(int fildes, const char *mode);
-
 int main(void)
 {
     int i, j, n = 1000, result;

--- a/fq.h
+++ b/fq.h
@@ -231,15 +231,9 @@ FLINT_DLL void fq_mul_si(fq_t rop, const fq_t op, slong x, const fq_ctx_t ctx);
 
 FLINT_DLL void fq_mul_ui(fq_t rop, const fq_t op, ulong x, const fq_ctx_t ctx);
 
-FLINT_DLL void fq_div(fq_t rop, const fq_t op1,
-		                           const fq_t op2, const fq_ctx_t ctx);
-
 FLINT_DLL void fq_sqr(fq_t rop, const fq_t op, const fq_ctx_t ctx);
 
 FLINT_DLL void fq_inv(fq_t rop, const fq_t op1, const fq_ctx_t ctx);
-
-FLINT_DLL void fq_gcdinv(fq_t rop, fq_t inv,
-		                            const fq_t op, const fq_ctx_t ctx);
 
 FLINT_DLL void _fq_pow(fmpz *rop, const fmpz *op, slong len, const fmpz_t e,
              const fq_ctx_t ctx);
@@ -285,8 +279,6 @@ FQ_INLINE int fq_is_one(const fq_t op, const fq_ctx_t ctx)
 {
     return fmpz_poly_is_one(op);
 }
-
-FLINT_DLL int fq_is_invertible(const fq_t op, const fq_ctx_t ctx);
 
 /* Assignments and conversions ***********************************************/
 

--- a/fq_embed_templates.h
+++ b/fq_embed_templates.h
@@ -35,13 +35,6 @@ FLINT_DLL void _TEMPLATE(T, embed_gens_allombert)(TEMPLATE(T, t) gen_sub,
                                                   const TEMPLATE(T, ctx_t) sup_ctx);
 
 /* Convert to-from column vectors */
-FLINT_DLL void TEMPLATE4(T, get, B, mat)(TEMPLATE(B, mat_t) col,
-                                         const TEMPLATE(T, t) a,
-                                         const TEMPLATE(T, ctx_t) ctx);
-FLINT_DLL void TEMPLATE4(T, set, B, mat)(TEMPLATE(T, t) a,
-                                         const TEMPLATE(B, mat_t) col,
-                                         const TEMPLATE(T, ctx_t) ctx);
-
 FLINT_DLL void TEMPLATE(T, embed_matrices)(TEMPLATE(B, mat_t) embed,
                                            TEMPLATE(B, mat_t) project,
                                            const TEMPLATE(T, t) gen_sub,

--- a/fq_nmod_mpoly_factor.h
+++ b/fq_nmod_mpoly_factor.h
@@ -209,11 +209,6 @@ FLINT_DLL void n_bpoly_fq_set_coeff_fq_nmod(
     const fq_nmod_t c,
     const fq_nmod_ctx_t ctx);
 
-FLINT_DLL void n_bpoly_fq_set_fq_nmod_poly_var0(
-    n_bpoly_t A,
-    const fq_nmod_poly_t B,
-    const fq_nmod_ctx_t ctx);
-
 FLINT_DLL void n_bpoly_fq_set_fq_nmod_poly_var1(
     n_bpoly_t A,
     const fq_nmod_poly_t B,
@@ -278,17 +273,6 @@ FLINT_DLL void n_bpoly_fq_set(
 FLINT_DLL void n_bpoly_fq_make_primitive(
     n_poly_t g,
     n_bpoly_t A,
-    const fq_nmod_ctx_t ctx);
-
-FLINT_DLL void n_bpoly_fq_taylor_shift_var1_fq_nmod(
-    n_bpoly_t A,
-    const n_bpoly_t B,
-    const fq_nmod_t c_,
-    const fq_nmod_ctx_t ctx);
-
-FLINT_DLL void n_bpoly_fq_taylor_shift_var0_fq_nmod(
-    n_bpoly_t A,
-    const fq_nmod_t alpha,
     const fq_nmod_ctx_t ctx);
 
 FLINT_DLL void fq_nmod_mpoly_get_n_bpoly_fq(

--- a/fq_poly_templates.h
+++ b/fq_poly_templates.h
@@ -303,11 +303,6 @@ FLINT_DLL void TEMPLATE3(T, poly_scalar_mul, T)(TEMPLATE(T, poly_t) rop,
                                  const TEMPLATE(T, t) x,
                                  const TEMPLATE(T, ctx_t) ctx);
 
-FLINT_DLL void _TEMPLATE3(T, poly_scalar_addmul, T)(TEMPLATE(T, struct) *rop,
-                                     const TEMPLATE(T, struct) *op, slong len,
-                                     const TEMPLATE(T, t) x,
-                                     const TEMPLATE(T, ctx_t) ctx);
-
 FLINT_DLL void _TEMPLATE3(T, poly_scalar_div, T)(TEMPLATE(T, struct) *rop,
                                   const TEMPLATE(T, struct) *op, slong len,
                                   const TEMPLATE(T, t) x,

--- a/fq_zech_mpoly_factor.h
+++ b/fq_zech_mpoly_factor.h
@@ -128,13 +128,7 @@ int fq_zech_bpoly_is_zero(const fq_zech_bpoly_t A, const fq_zech_ctx_t ctx)
     return A->length == 0;
 }
 
-FLINT_DLL void fq_zech_bpoly_set(fq_zech_bpoly_t A, const fq_zech_bpoly_t B, const fq_zech_ctx_t ctx);
-
 FLINT_DLL int fq_zech_bpoly_equal(const fq_zech_bpoly_t A, const fq_zech_bpoly_t B, const fq_zech_ctx_t ctx);
-
-FLINT_DLL void fq_zech_bpoly_set_coeff_fq_zech(fq_zech_bpoly_t A, slong e0, slong e1, const fq_zech_t c, const fq_zech_ctx_t ctx);
-
-FLINT_DLL void fq_zech_bpoly_derivative(fq_zech_bpoly_t A, const fq_zech_bpoly_t B, const fq_zech_ctx_t ctx);
 
 FQ_ZECH_MPOLY_FACTOR_INLINE
 void fq_zech_bpoly_get_coeff(fq_zech_t c, const fq_zech_bpoly_t A, slong e0, slong e1, const fq_zech_ctx_t ctx)
@@ -161,8 +155,6 @@ FLINT_DLL void fq_zech_bpoly_print_pretty(const fq_zech_bpoly_t A,
                 const char * var0, const char * var1, const fq_zech_ctx_t ctx);
 
 FLINT_DLL int fq_zech_bpoly_is_canonical(const fq_zech_bpoly_t A, const fq_zech_ctx_t ctx);
-
-FLINT_DLL void fq_zech_bpoly_one(fq_zech_bpoly_t A, const fq_zech_ctx_t ctx);
 
 FLINT_DLL int fq_zech_bpoly_fq_equal(
     const fq_zech_bpoly_t A,
@@ -430,12 +422,6 @@ FLINT_DLL int fq_zech_mpoly_get_fq_zech_poly(
     slong var,
     const fq_zech_mpoly_ctx_t ctx);
 
-FLINT_DLL void fq_zech_mpoly_fit_length_set_bits(
-    fq_zech_mpoly_t A,
-    slong len,
-    flint_bitcnt_t bits,
-    const fq_zech_mpoly_ctx_t ctx);
-
 FLINT_DLL void _fq_zech_mpoly_set_fq_zech_poly(
     fq_zech_mpoly_t A,
     flint_bitcnt_t Abits,
@@ -451,13 +437,6 @@ FLINT_DLL void fq_zech_mpoly_set_fq_zech_poly(
     const fq_zech_mpoly_ctx_t ctx);
 
 /*****************************************************************************/
-
-void fq_zech_mpoly_evaluate_one_fq_zech(
-    fq_zech_mpoly_t A,
-    const fq_zech_mpoly_t B,
-    slong var,
-    const fq_zech_t val,
-    const fq_zech_mpoly_ctx_t ctx);
 
 typedef struct {
     fq_zech_t constant;

--- a/n_poly.h
+++ b/n_poly.h
@@ -462,9 +462,6 @@ FLINT_DLL void n_poly_mod_addmul_linear(n_poly_t A, const n_poly_t B,
 FLINT_DLL void n_poly_mod_eval2_pow(mp_limb_t * vp, mp_limb_t * vm,
                               const n_poly_t P, n_poly_t alphapow, nmod_t mod);
 
-FLINT_DLL mp_limb_t n_poly_mod_div_root(n_poly_t Q, 
-                                    const n_poly_t A, mp_limb_t c, nmod_t ctx);
-
 N_POLY_INLINE
 void _n_poly_mod_mul(n_poly_t A, const n_poly_t B, const n_poly_t C, nmod_t mod)
 {
@@ -587,8 +584,6 @@ FLINT_DLL void n_poly_mod_div_series(n_poly_t Q, const n_poly_t A,
                                     const n_poly_t B, slong order, nmod_t ctx);
 
 /*****************************************************************************/
-
-FLINT_DLL void n_fq_print_pretty(const mp_limb_t * a, const fq_nmod_ctx_t ctx);
 
 N_POLY_INLINE
 int _n_fq_is_zero(const mp_limb_t * a, slong d)
@@ -867,11 +862,6 @@ FLINT_DLL void n_poly_fq_set(
     const n_poly_t B,
     const fq_nmod_ctx_t ctx);
 
-FLINT_DLL void n_poly_fq_set_n_fq(
-    n_poly_t A,
-    const mp_limb_t * c,
-    const fq_nmod_ctx_t ctx);
-
 FLINT_DLL void n_poly_fq_randtest(
     n_poly_t A,
     flint_rand_t state,
@@ -1014,11 +1004,6 @@ FLINT_DLL void n_poly_fq_pow(
     n_poly_t A,
     const n_poly_t B,
     ulong e,
-    const fq_nmod_ctx_t ctx);
-
-FLINT_DLL ulong n_poly_fq_remove(
-    n_poly_t f,
-    const n_poly_t g,
     const fq_nmod_ctx_t ctx);
 
 FLINT_DLL void n_poly_fq_divrem_divconquer_(
@@ -1250,11 +1235,6 @@ FLINT_DLL void n_bpoly_fq_set_fq_nmod_poly_var0(
 FLINT_DLL void n_bpoly_fq_set_n_poly_fq_var0(
     n_bpoly_t A,
     const n_poly_t B,
-    const fq_nmod_ctx_t ctx);
-
-FLINT_DLL void n_bpoly_fq_set_fq_nmod_poly_var1(
-    n_bpoly_t A,
-    const fq_nmod_poly_t B,
     const fq_nmod_ctx_t ctx);
 
 FLINT_DLL void n_bpoly_fq_set_n_poly_fq_var1(

--- a/nmod_mat.h
+++ b/nmod_mat.h
@@ -66,7 +66,6 @@ mp_limb_t * nmod_mat_entry_ptr(const nmod_mat_t mat, slong i, slong j)
 }
 
 /* See inlines.c */
-FLINT_DLL void nmod_mat_set_entry(nmod_mat_t mat, slong i, slong j, mp_limb_t x);
 
 NMOD_MAT_INLINE
 slong nmod_mat_nrows(const nmod_mat_t mat)

--- a/nmod_mpoly.h
+++ b/nmod_mpoly.h
@@ -975,11 +975,6 @@ FLINT_DLL void nmod_mpoly_divrem_monagan_pearce(nmod_mpoly_t q, nmod_mpoly_t r,
                   const nmod_mpoly_t poly2, const nmod_mpoly_t poly3,
                                                    const nmod_mpoly_ctx_t ctx);
 
-FLINT_DLL void
-nmod_mpoly_divrem_ideal_monagan_pearce(nmod_mpoly_struct ** Q, nmod_mpoly_t R,
-    const nmod_mpoly_t A, nmod_mpoly_struct * const * B, slong len,
-                                                   const nmod_mpoly_ctx_t ctx);
-
 FLINT_DLL slong
 _nmod_mpoly_divrem_ideal_monagan_pearce(nmod_mpoly_struct ** polyq, 
        ulong ** polyr, ulong ** expr, slong * allocr, const ulong * poly2,
@@ -1286,9 +1281,6 @@ FLINT_DLL void nmod_mpolyd_mul_scalar(nmod_mpolyd_t A, mp_limb_t b,
 
 
 /* GCD ***********************************************************************/
-
-FLINT_DLL void nmod_mpoly_term_content(nmod_mpoly_t poly1,
-                         const nmod_mpoly_t poly2, const nmod_mpoly_ctx_t ctx);
 
 FLINT_DLL void nmod_mpoly_gcd_prs(nmod_mpoly_t poly1, nmod_mpoly_t poly2,
                                nmod_mpoly_t poly3, const nmod_mpoly_ctx_t ctx);

--- a/nmod_mpoly/mpolyun.c
+++ b/nmod_mpoly/mpolyun.c
@@ -720,9 +720,6 @@ void nmod_mpoly_to_mpolyun_perm_deflate(
     TMP_END;
 }
 
-void nmod_mpoly_cvtto_mpolyn(nmod_mpolyn_t A, nmod_mpoly_t B,
-                                         slong var, const nmod_mpoly_ctx_t ctx);
-
 void nmod_mpoly_to_mpolyn_perm_deflate_threaded_pool(
     nmod_mpolyn_t A,
     const nmod_mpoly_ctx_t nctx,

--- a/nmod_mpoly/mul_array.c
+++ b/nmod_mpoly/mul_array.c
@@ -111,10 +111,6 @@ void _nmod_mpoly_addmul_array1_ulong3(ulong * poly1,
 ****************************************************/
 
 
-void mpoly_main_variable_split_LEX(slong * ind, ulong * pexp, const ulong * Aexp,
-             slong l1, slong Alen, const ulong * mults, slong num, slong Abits);
-
-
 #define LEX_UNPACK_MACRO(fxn_name, coeff_decl, nonzero_test, reduce_coeff)     \
 slong fxn_name(nmod_mpoly_t P, slong Plen, coeff_decl,                         \
              const ulong * mults, slong num, slong array_size, slong top,      \
@@ -415,10 +411,6 @@ cleanup:
 /****************************************************
     DEGLEX and DEGREVLEX
 ****************************************************/
-
-void mpoly_main_variable_split_DEG(slong * ind, ulong * pexp, const ulong * Aexp,
-             slong l1, slong Alen, ulong deg, slong num, slong Abits);
-
 
 
 #define DEGLEX_UNPACK_MACRO(fxn_name, coeff_decl, nonzero_test, reduce_coeff)  \

--- a/qadic/exp_balanced.c
+++ b/qadic/exp_balanced.c
@@ -11,8 +11,6 @@
 
 #include "qadic.h"
 
-extern slong _padic_exp_bound(slong v, slong N, const fmpz_t p);
-
 static void 
 _qadic_exp_bsplit_series(fmpz *P, fmpz_t Q, fmpz *T, 
                          const fmpz *x, slong len, slong lo, slong hi, 

--- a/qadic/exp_rectangular.c
+++ b/qadic/exp_rectangular.c
@@ -12,8 +12,6 @@
 #include "fmpz_mod_poly.h"
 #include "qadic.h"
 
-extern slong _padic_exp_bound(slong v, slong N, const fmpz_t p);
-
 void _qadic_exp_rectangular(fmpz *rop, const fmpz *op, slong v, slong len, 
                             const fmpz *a, const slong *j, slong lena, 
                             const fmpz_t p, slong N, const fmpz_t pN)

--- a/qadic/log_balanced.c
+++ b/qadic/log_balanced.c
@@ -12,8 +12,6 @@
 #include "fmpz_mod_poly.h"
 #include "qadic.h"
 
-extern slong _padic_log_bound(slong v, slong N, const fmpz_t p);
-
 /*
     Assumes that P, T are vectors of length 2 d - 1.
 

--- a/qadic/log_rectangular.c
+++ b/qadic/log_rectangular.c
@@ -12,8 +12,6 @@
 #include "fmpz_mod_poly.h"
 #include "qadic.h"
 
-extern slong _padic_log_bound(slong v, slong N, const fmpz_t p);
-
 /*
     Carries out the finite series evaluation for the logarithm 
     \begin{equation*}


### PR DESCRIPTION
The headers contain a lot of redundant declarations. We remove them and check in the CI that there is none.