### PR TITLE
Ecm memleak

### DIFF
--- a/fmpz_factor/ecm.c
+++ b/fmpz_factor/ecm.c
@@ -59,16 +59,16 @@ fmpz_factor_ecm(fmpz_t f, mp_limb_t curves, mp_limb_t B1, mp_limb_t B2,
     const mp_limb_t *prime_array;
     n_size = fmpz_size(n_in);
 
-    fmpz_factor_ecm_init(ecm_inf, n_size);
-
-    TMP_START;
-    
     if (n_size == 1)
     {
         ret = n_factor_ecm(&P, curves, B1, B2, state, fmpz_get_ui(n_in));
         fmpz_set_ui(f, P);
         return ret;
     }
+
+    fmpz_factor_ecm_init(ecm_inf, n_size);
+
+    TMP_START;
 
     n      = TMP_ALLOC(n_size * sizeof(mp_limb_t));
     mpsig  = TMP_ALLOC(n_size * sizeof(mp_limb_t));


### PR DESCRIPTION
This fixes a small memleak in fmpz_factor_ecm caused by the ecm info object being inited but not cleared when n==1.