### PR TITLE
Retry ECM in factor_smooth with same parameters if factor found

### DIFF
--- a/fmpz_factor/factor_smooth.c
+++ b/fmpz_factor/factor_smooth.c
@@ -57,7 +57,7 @@ int fmpz_factor_smooth(fmpz_factor_t factor, const fmpz_t n,
     slong found;
     slong trial_stop;
     slong * idx;
-    slong i, b, bits2;
+    slong i, b, bits2, istride;
     const mp_limb_t * primes;
     int ret = 0;
 
@@ -204,8 +204,10 @@ int fmpz_factor_smooth(fmpz_factor_t factor, const fmpz_t n,
                 bits = FLINT_MIN(bits, 100);
                 bits2 = (bits + 1)/2;
 
-                /* tuning is in increments of 2 bits, start with 16 bits */
-                for (i = 9 + (bits2 % 3); i <= bits2; i += 3)
+                /* tuning is in increments of 2 bits */
+                istride = 3;
+                /* start with 18-22 bits, advance by 6 bits at a time */
+                for (i = 9 + (bits2 % 3); i <= bits2; i += istride)
                 {
                     found = fmpz_factor_ecm(f, ecm_tuning[i][2],
                             ecm_tuning[i][1], ecm_tuning[i][1]*100, state, n2);
@@ -235,7 +237,7 @@ int fmpz_factor_smooth(fmpz_factor_t factor, const fmpz_t n,
                             break;
                         }
 
-                        i--; /* redo with the same parameters if factor found */
+                        i -= istride; /* redo with the same parameters if factor found */
                     }
                 }    
 


### PR DESCRIPTION
The original code in fmpz_factor_smooth performed several attempts to factor with ECM in a progressive manner. When an attempt fails the next set of parameters is chosen, advancing by 6 bits (`i += 3`, in the loop). If such attempt succeeds the set of parameters should be preserved to try factoring further. But in the current implementation another set of parameters is chosen instead (`i--` and later `i += 3` in the loop), increasing the number of bits by 4. This behavior does not agree with the comment in the code 

> redo with the same parameters if factor found

since the parameters obviously change.

I'm not sure if this was intended or was a result of adjusting loop iteration step without correcting the `i--` statement upon successful factoring. My PR is aimed to fix this inconsistency. The fix also speeds up a bit several test cases that I've performed (mostly factoring products of primes of the same size), but I'm not sure that it would be better in general.
