### PR TITLE
add ctx object to fmpz_mod_polyxx

### DIFF
--- a/flintxx/doc/flintxx.txt
+++ b/flintxx/doc/flintxx.txt
@@ -3514,7 +3514,30 @@ Ltuple<bool, nmod_poly_matxx, nmod_polyxx>_expr solve_fflu_precomp(
 
     fmpz\_mod\_polyxx
 
+    The type \code{fmpz_mod_polyxx} wraps \code{fmpz_mod_poly}.
+    Every instance of \code{fmpz_mod_poly} contains a reference to a context
+    \code{fmpz_mod_ctx}. The only polynomial operation that can change the
+    context object is \code{read}.
+
 *******************************************************************************
+
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    Context
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+fmpz_modxx_ctx::fmpz_modxx_ctx(Fmpz_src n)
+fmpz_modxx_ctx::fmpz_modxx_ctx(ulong n)
+
+    Initialize a context for the integers modulo \code{n}.
+
+fmpz_modxx_ctx::set_modulus(Fmpz_src n)
+fmpz_modxx_ctx::set_modulus(ulong n)
+
+    Change the modulus of the context.
+
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    Operations
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Fmpz_mod_poly_expr::unary operation() const
 
@@ -3571,8 +3594,8 @@ read(FILE*, Fmpz_mod_poly_target)
     Memory management
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-fmpz_mod_polyxx::fmpz_mod_polyxx(Fmpz_expr n)
-fmpz_mod_polyxx::fmpz_mod_polyxx(Fmpz_expr n, slong alloc)
+fmpz_mod_polyxx::fmpz_mod_polyxx(fmpz_modxx_ctx_srcref)
+fmpz_mod_polyxx::fmpz_mod_polyxx(fmpz_modxx_ctx_srcref, slong alloc)
 
 void Fmpz_mod_poly_target realloc(slong alloc)
 void Fmpz_mod_poly_target::fit_length(slong len)
@@ -3802,7 +3825,7 @@ bool Fmpz_mod_poly_expr::is_irreducible_ddf() const
 bool Fmpz_mod_poly_expr::is_irreducible_rabin() const
 slong Fmpz_mod_poly_target::remove(Fmpz_mod_poly_expr)
 
-fmpz_mod_poly_factorxx::nmod_poly_factorxx()
+fmpz_mod_poly_factorxx::fmpz_poly_factorxx(fmpz_modxx_ctx_srcref)
 
     Initialise an empty factorisation.
 
@@ -3823,7 +3846,6 @@ slong& fmpz_mod_poly_factorxx::exp(slong i)
 
     Obtain the exponent of the ith factor.
 
-fmpz_mod_polyxx_srcref nmod_poly_factorxx::p(slong i) const
 fmpz_mod_polyxx_ref nmod_poly_factorxx::p(slong i)
 
     Obtain the ith factor.

--- a/flintxx/test/t-fmpz_mod_polyxx.cpp
+++ b/flintxx/test/t-fmpz_mod_polyxx.cpp
@@ -342,6 +342,7 @@ test_printing()
     frandxx state;
     fmpz_modxx_ctx M(7);
     fmpz_mod_polyxx f = fmpz_mod_polyxx::randtest(M, state, 4);
+    test_print_read(f);
     f.set_zero();
     f.set_coeff(0, 3);
     f.set_coeff(1, 1);

--- a/flintxx/test/t-fmpz_mod_polyxx.cpp
+++ b/flintxx/test/t-fmpz_mod_polyxx.cpp
@@ -22,18 +22,19 @@ using namespace flint;
 void
 test_init()
 {
-    fmpz_mod_polyxx p(fmpzxx(2003));
+    fmpz_modxx_ctx M(2003);
+    fmpz_mod_polyxx p(M);
     tassert(p.length() == 0);
     tassert(p.modulus() == 2003);
-    tassert(fmpz_mod_polyxx::zero(fmpzxx(2003)).is_zero());
+    tassert(fmpz_mod_polyxx::zero(M).is_zero());
 }
 
 void
 test_manipulation()
 {
-    fmpzxx M(1031);
+    fmpz_modxx_ctx M(1031);
     fmpz_mod_polyxx p(M), q(M);
-    p.set_coeff(5, 17u + M);
+    p.set_coeff(5, 17u + M.modulus());
     tassert(p.degree() == 5);
     q.set_coeff(5, fmpzxx(16) + fmpzxx(1));
     tassert((q + fmpz_mod_polyxx(M)).get_coeff(5) == 17);
@@ -55,7 +56,7 @@ test_manipulation()
 void
 test_assignment()
 {
-    fmpzxx M(31);
+    fmpz_modxx_ctx M(31);
     fmpz_mod_polyxx p(M), q(M);
     p.set_coeff(0, 1);
     tassert(p != q);
@@ -66,31 +67,31 @@ test_assignment()
 void
 test_conversion()
 {
-    fmpzxx M(1031);
+    fmpz_modxx_ctx M(1031);
     fmpz_mod_polyxx p(M);
 
     p = 4u + 1031;
     tassert(p.length() == 1 && p.get_coeff(0) == 4);
 
-    p = fmpzxx(5) + M;
+    p = fmpzxx(5) + M.modulus();
     tassert(p.length() == 1 && p.get_coeff(0) == 5);
 
     frandxx rand;
     fmpz_polyxx P = fmpz_polyxx::randtest(rand, 10, 20);
     p = P;
     for(slong i = 0;i < P.length();++i)
-        tassert(P.get_coeff(i) % M == p.get_coeff(i));
+        tassert(P.get_coeff(i) % M.modulus() == p.get_coeff(i));
     fmpz_polyxx Pp = p.to<fmpz_polyxx>();
     for(slong i = 0;i < P.length();++i)
-        tassert(P.get_coeff(i) % M == Pp.get_coeff(i));
+        tassert(P.get_coeff(i) % M.modulus() == Pp.get_coeff(i));
 }
 
 void
 test_arithmetic()
 {
-    fmpzxx M(1031);
+    fmpz_modxx_ctx M(1031);
     fmpz_mod_polyxx g(M), h(M);
-    g.set_coeff(0, 17); h.set_coeff(0, 15u + M);
+    g.set_coeff(0, 17); h.set_coeff(0, 15u + M.modulus());
     tassert((g + h).get_coeff(0) == 15 + 17);
 
     frandxx state;
@@ -101,7 +102,7 @@ test_arithmetic()
     tassert(g - h == g + (-h));
 
     tassert(g*fmpzxx(3) == g + g + g);
-    tassert(g.make_monic() == g*g.lead().invmod(M));
+    tassert(g.make_monic() == g*g.lead().invmod(M.modulus()));
 
     fmpz_mod_polyxx f(M);f = 15u;
     tassert(f*g == fmpzxx(15)*g);
@@ -132,7 +133,7 @@ test_arithmetic()
 void
 test_functions()
 {
-    fmpzxx M(1031);
+    fmpz_modxx_ctx M(1031);
     fmpz_mod_polyxx g(M), res(M);
 
     g.set_coeff(5, 15);
@@ -156,7 +157,6 @@ test_functions()
     g.set_coeff(15, 1);
     g.zero_coeffs(14, 15);
     tassert(g.get_coeff(14) == 0);
-
 
     // multiplication, division, modulo tested in arithmetic
 
@@ -219,7 +219,6 @@ test_functions()
     ltupleref(res, R, S) = f.xgcd(g);
     tassert(res == R*f + S*g && res == gcd(f, g));
     tassert(f.xgcd(g) == f.xgcd_euclidean(g));
-
 }
 
 bool equiv_fac(const fmpz_mod_poly_factorxx& fac1,
@@ -248,13 +247,14 @@ bool equiv_fac(const fmpz_mod_poly_factorxx& fac1,
 void
 test_factoring()
 {
-    fmpzxx M(1031);
+    fmpz_modxx_ctx M(fmpzxx(1031));
     fmpz_mod_polyxx f(M), g(M);
     frandxx state;
     f.set_randtest_irreducible(state, 4); f = f.make_monic();
     g.set_randtest_irreducible(state, 5); g = g.make_monic();
 
-    fmpz_mod_poly_factorxx fac = factor(f*f*g);
+    fmpz_mod_poly_factorxx fac(M);
+    fac = factor(f*f*g);
     tassert(fac.size() == 2);
     if(fac.exp(0) == 1)
     {
@@ -267,7 +267,7 @@ test_factoring()
         tassert(fac.p(1) == g && fac.exp(1) == 1);
     }
 
-    fmpz_mod_poly_factorxx fac2;fac2 = fac;fac2.pow(2);
+    fmpz_mod_poly_factorxx fac2(M);fac2 = fac;fac2.pow(2);
     fac.insert(g, 1);
     fac.insert(f, 2);
     tassert(fac == fac2);
@@ -297,7 +297,7 @@ void
 test_randomisation()
 {
     frandxx state, state2;
-    fmpzxx M(1031);
+    fmpz_modxx_ctx M(1031);
     fmpz_mod_polyxx p(M);
 
     p.set_randtest(state, 10);
@@ -311,7 +311,7 @@ test_randomisation()
 void
 test_radix()
 {
-    fmpzxx M(1031);
+    fmpz_modxx_ctx M(1031);
     fmpz_mod_poly_vecxx v1(10, M), v2(10, M);
     v1[0].set_coeff(7, 1);
     tassert(v1 != v2);
@@ -340,8 +340,8 @@ void
 test_printing()
 {
     frandxx state;
-    fmpz_mod_polyxx f = fmpz_mod_polyxx::randtest(fmpzxx(7), state, 4);
-    test_print_read(f);
+    fmpz_modxx_ctx M(7);
+    fmpz_mod_polyxx f = fmpz_mod_polyxx::randtest(M, state, 4);
     f.set_zero();
     f.set_coeff(0, 3);
     f.set_coeff(1, 1);
@@ -351,7 +351,8 @@ test_printing()
 void
 test_unified_access()
 {
-    fmpz_mod_polyxx p(fmpzxx(1031));
+    fmpz_modxx_ctx M(1031);
+    fmpz_mod_polyxx p(M);
     p.set_coeff(0, 1);
     const fmpz_mod_polyxx& q = p;
     tassert(q.lead() == 1);

--- a/flintxx/test/t-fmpz_mod_polyxx.cpp
+++ b/flintxx/test/t-fmpz_mod_polyxx.cpp
@@ -20,9 +20,9 @@
 using namespace flint;
 
 void
-test_init()
+test_init(fmpz_modxx_ctx& M)
 {
-    fmpz_modxx_ctx M(2003);
+    M.set_modulus(2003);
     fmpz_mod_polyxx p(M);
     tassert(p.length() == 0);
     tassert(p.modulus() == 2003);
@@ -30,9 +30,9 @@ test_init()
 }
 
 void
-test_manipulation()
+test_manipulation(fmpz_modxx_ctx& M)
 {
-    fmpz_modxx_ctx M(1031);
+    M.set_modulus(1031);
     fmpz_mod_polyxx p(M), q(M);
     p.set_coeff(5, 17u + M.modulus());
     tassert(p.degree() == 5);
@@ -54,9 +54,9 @@ test_manipulation()
 }
 
 void
-test_assignment()
+test_assignment(fmpz_modxx_ctx& M)
 {
-    fmpz_modxx_ctx M(31);
+    M.set_modulus(31);
     fmpz_mod_polyxx p(M), q(M);
     p.set_coeff(0, 1);
     tassert(p != q);
@@ -65,9 +65,9 @@ test_assignment()
 }
 
 void
-test_conversion()
+test_conversion(fmpz_modxx_ctx& M)
 {
-    fmpz_modxx_ctx M(1031);
+    M.set_modulus(1031);
     fmpz_mod_polyxx p(M);
 
     p = 4u + 1031;
@@ -87,9 +87,9 @@ test_conversion()
 }
 
 void
-test_arithmetic()
+test_arithmetic(fmpz_modxx_ctx& M)
 {
-    fmpz_modxx_ctx M(1031);
+    M.set_modulus(1031);
     fmpz_mod_polyxx g(M), h(M);
     g.set_coeff(0, 17); h.set_coeff(0, 15u + M.modulus());
     tassert((g + h).get_coeff(0) == 15 + 17);
@@ -131,9 +131,9 @@ test_arithmetic()
 }
 
 void
-test_functions()
+test_functions(fmpz_modxx_ctx& M)
 {
-    fmpz_modxx_ctx M(1031);
+    M.set_modulus(1031);
     fmpz_mod_polyxx g(M), res(M);
 
     g.set_coeff(5, 15);
@@ -245,9 +245,9 @@ bool equiv_fac(const fmpz_mod_poly_factorxx& fac1,
             && fac1.p(1) == fac2.p(0);
 }
 void
-test_factoring()
+test_factoring(fmpz_modxx_ctx& M)
 {
-    fmpz_modxx_ctx M(fmpzxx(1031));
+    M.set_modulus(1031);
     fmpz_mod_polyxx f(M), g(M);
     frandxx state;
     f.set_randtest_irreducible(state, 4); f = f.make_monic();
@@ -294,10 +294,10 @@ test_factoring()
 }
 
 void
-test_randomisation()
+test_randomisation(fmpz_modxx_ctx& M)
 {
     frandxx state, state2;
-    fmpz_modxx_ctx M(1031);
+    M.set_modulus(1031);
     fmpz_mod_polyxx p(M);
 
     p.set_randtest(state, 10);
@@ -309,9 +309,9 @@ test_randomisation()
 }
 
 void
-test_radix()
+test_radix(fmpz_modxx_ctx& M)
 {
-    fmpz_modxx_ctx M(1031);
+    M.set_modulus(1031);
     fmpz_mod_poly_vecxx v1(10, M), v2(10, M);
     v1[0].set_coeff(7, 1);
     tassert(v1 != v2);
@@ -337,10 +337,10 @@ test_radix()
 }
 
 void
-test_printing()
+test_printing(fmpz_modxx_ctx& M)
 {
     frandxx state;
-    fmpz_modxx_ctx M(7);
+    M.set_modulus(7);
     fmpz_mod_polyxx f = fmpz_mod_polyxx::randtest(M, state, 4);
     test_print_read(f);
     f.set_zero();
@@ -350,9 +350,9 @@ test_printing()
 }
 
 void
-test_unified_access()
+test_unified_access(fmpz_modxx_ctx& M)
 {
-    fmpz_modxx_ctx M(1031);
+    M.set_modulus(1031);
     fmpz_mod_polyxx p(M);
     p.set_coeff(0, 1);
     const fmpz_mod_polyxx& q = p;
@@ -363,18 +363,19 @@ int
 main()
 {
     std::cout << "fmpz_mod_polyxx....";
+    fmpz_modxx_ctx M(2);
 
-    test_init();
-    test_manipulation();
-    test_assignment();
-    test_conversion();
-    test_arithmetic();
-    test_functions();
-    test_factoring();
-    test_randomisation();
-    test_radix();
-    test_printing();
-    test_unified_access();
+    test_init(M);
+    test_manipulation(M);
+    test_assignment(M);
+    test_conversion(M);
+    test_arithmetic(M);
+    test_functions(M);
+    test_factoring(M);
+    test_randomisation(M);
+    test_radix(M);
+    test_printing(M);
+    test_unified_access(M);
 
     std::cout << "PASS" << std::endl;
     return 0;

--- a/fmpz_mod_polyxx.h
+++ b/fmpz_mod_polyxx.h
@@ -522,7 +522,9 @@ FLINT_DEFINE_PRINT_COND(FMPZ_MOD_POLYXX_COND_S,
 FLINT_DEFINE_PRINT_PRETTY_COND_2(FMPZ_MOD_POLYXX_COND_S, const char*,
     fmpz_mod_poly_fprint_pretty(to, from._poly(), extra, from._ctx()))
 
-//fread is illegal because the ctx is read-only
+// be careful with fread as it writes to the possibly shared ctx
+FLINT_DEFINE_READ_COND(FMPZ_MOD_POLYXX_COND_T,
+    fmpz_mod_poly_fread(from, to._poly(), to._ctx()))
 
 FLINT_DEFINE_BINARY_EXPR_COND2(plus,
     fmpz_mod_polyxx, FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,

--- a/fmpz_mod_polyxx.h
+++ b/fmpz_mod_polyxx.h
@@ -56,6 +56,16 @@ public:
     }
 
     ~fmpz_modxx_ctx() {fmpz_mod_ctx_clear(ctx);}
+
+    void set_modulus(fmpzxx_srcref p)
+    {
+        fmpz_mod_ctx_set_modulus(ctx, p._fmpz());
+    }
+
+    void set_modulus(ulong p)
+    {
+        fmpz_mod_ctx_set_modulus_ui(ctx, p);
+    }
 };
 
 class fmpz_modxx_ctx_srcref

--- a/fmpz_mod_polyxx.h
+++ b/fmpz_mod_polyxx.h
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2013 Tom Bachmann
+    Copyright (C) 2020 Daniel Schultz
 
     This file is part of FLINT.
 
@@ -26,9 +27,93 @@
 #include "flintxx/stdmath.h"
 #include "flintxx/vector.h"
 
-// TODO create/use fmpz_modxx class?
 
 namespace flint {
+
+///////////////////////////////////////////////////////////////////////////////
+// fmpz_mod_ctx_struct wrappers
+///////////////////////////////////////////////////////////////////////////////
+
+class fmpz_modxx_ctx
+{
+private:
+    mutable fmpz_mod_ctx_t ctx;
+
+public:
+    fmpz_mod_ctx_t& _ctx() const {return ctx;}
+
+    fmpzxx_ref modulus() {return fmpzxx_ref::make(ctx->n);}
+    fmpzxx_srcref modulus() const {return fmpzxx_srcref::make(ctx->n);}
+
+    fmpz_modxx_ctx(fmpzxx_srcref p)
+    {
+        fmpz_mod_ctx_init(ctx, p._fmpz());
+    }
+
+    fmpz_modxx_ctx(ulong p)
+    {
+        fmpz_mod_ctx_init_ui(ctx, p);
+    }
+
+    ~fmpz_modxx_ctx() {fmpz_mod_ctx_clear(ctx);}
+};
+
+class fmpz_modxx_ctx_srcref
+{
+private:
+    mutable fmpz_mod_ctx_struct* ctx;
+
+    fmpz_modxx_ctx_srcref(fmpz_mod_ctx_struct* c) : ctx(c) {}
+
+public:
+    fmpz_mod_ctx_struct* _ctx() const {return ctx;}
+
+    fmpzxx_ref modulus() {return fmpzxx_ref::make(ctx->n);}
+    fmpzxx_srcref modulus() const {return fmpzxx_srcref::make(ctx->n);}
+
+    fmpz_modxx_ctx_srcref(fmpz_modxx_ctx& c)
+        : ctx(c._ctx()) {}
+
+    fmpz_modxx_ctx_srcref(const fmpz_modxx_ctx& c)
+        : ctx(c._ctx()) {}
+
+    static fmpz_modxx_ctx_srcref make(fmpz_mod_ctx_struct* c)
+        {return fmpz_modxx_ctx_srcref(c);}
+};
+
+namespace traits {
+template<class T> struct has_fmpz_modxx_ctx : mp::false_ { };
+
+template<class T> struct is_fmpz_mod_expr
+    : has_fmpz_modxx_ctx<typename tools::evaluation_helper<T>::type> { };
+} // traits
+
+namespace detail {
+struct has_fmpz_modxx_ctx_predicate
+{
+    template<class T> struct type : traits::has_fmpz_modxx_ctx<T> { };
+};
+} // detail
+
+namespace tools {
+template<class Expr>
+fmpz_modxx_ctx_srcref find_fmpz_modxx_ctx(const Expr& e)
+{
+    return tools::find_subexpr<detail::has_fmpz_modxx_ctx_predicate>(e).get_ctx();
+}
+} // tools
+
+namespace detail {
+
+template<class T, class U>
+struct fakemodtemplate : mp::enable_if<mp::equal_types<T, U> > { };
+} // detail
+
+
+///////////////////////////////////////////////////////////////////////////////
+// fmpz_mod_poly_struct wrappers
+///////////////////////////////////////////////////////////////////////////////
+
 FLINT_DEFINE_BINOP(divrem_f)
 FLINT_DEFINE_BINOP(gcd_euclidean_f)
 FLINT_DEFINE_BINOP(gcd_f)
@@ -46,13 +131,14 @@ struct fmpz_mod_poly_traits
     typedef lead_ref_t lead_srcref_t;
     static lead_ref_t lead(const Poly& p) {return fmpz_mod_polyxx_lead(p);}
 };
-}
+} //detail
 
 template<class Operation, class Data>
 class fmpz_mod_polyxx_expression
     : public expression<derived_wrapper<fmpz_mod_polyxx_expression>,
                             Operation, Data>
 {
+public:
     typedef expression<derived_wrapper< ::flint::fmpz_mod_polyxx_expression>,
               Operation, Data> base_t;
     typedef detail::fmpz_mod_poly_traits<fmpz_mod_polyxx_expression>
@@ -62,67 +148,87 @@ class fmpz_mod_polyxx_expression
     FLINTXX_DEFINE_CTORS(fmpz_mod_polyxx_expression)
     FLINTXX_DEFINE_C_REF(fmpz_mod_polyxx_expression, fmpz_mod_poly_struct, _poly)
 
-    template<class Fmpz>
-    static fmpz_mod_polyxx_expression randtest(const Fmpz& m,
-            frandxx& state, slong len)
+public:
+
+    fmpz_modxx_ctx_srcref get_ctx() const {return this->_data().ctx;}
+    fmpz_mod_ctx_struct* _ctx() const {return get_ctx()._ctx();}
+
+    fmpz_modxx_ctx_srcref estimate_ctx() const {
+                                    return tools::find_fmpz_modxx_ctx(*this);}
+
+    static fmpz_mod_polyxx_expression zero(fmpz_modxx_ctx_srcref ctx)
     {
-        fmpz_mod_polyxx_expression res(m);
-        res.set_randtest(state, len);
-        return res;
+        return fmpz_mod_polyxx_expression(ctx);
     }
-    template<class Fmpz>
-    static fmpz_mod_polyxx_expression randtest_irreducible(const Fmpz& m,
-            frandxx& state, slong len)
+
+    static fmpz_mod_polyxx_expression one(fmpz_modxx_ctx_srcref ctx)
     {
-        fmpz_mod_polyxx_expression res(m);
-        res.set_randtest_irreducible(state, len);
-        return res;
-    }
-    template<class Fmpz>
-    static fmpz_mod_polyxx_expression randtest_not_zero(const Fmpz& m,
-            frandxx& state, slong len)
-    {
-        fmpz_mod_polyxx_expression res(m);
-        res.set_randtest_not_zero(state, len);
+        fmpz_mod_polyxx_expression res(ctx);
+        res.set_one();
         return res;
     }
 
-    template<class Fmpz>
-    static fmpz_mod_polyxx_expression zero(const Fmpz& m)
-        {return fmpz_mod_polyxx_expression(m);}
+    // Create a temporary. The context will be estimated.
+    evaluated_t create_temporary() const
+    {
+        return evaluated_t(estimate_ctx());
+    }
 
-    // these only make sense with immediates
-    fmpzxx_srcref _mod() const
-        {return fmpzxx_srcref::make(fmpz_mod_poly_modulus(_poly()));}
+    static fmpz_mod_polyxx_expression randtest(
+                          fmpz_modxx_ctx_srcref ctx, frandxx& state, slong len)
+    {
+        fmpz_mod_polyxx_expression res(ctx);
+        fmpz_mod_poly_randtest(res._poly(), state._data(), len, ctx._ctx());
+        return res;
+    }
+
+    static fmpz_mod_polyxx_expression randtest_irreducible(
+                          fmpz_modxx_ctx_srcref ctx, frandxx& state, slong len)
+    {
+        fmpz_mod_polyxx_expression res(ctx);
+        fmpz_mod_poly_randtest_irreducible(res._poly(), state._data(), len, ctx._ctx());
+        return res;
+    }
+
+    static fmpz_mod_polyxx_expression randtest_not_zero(
+                          fmpz_modxx_ctx_srcref ctx, frandxx& state, slong len)
+    {
+        fmpz_mod_polyxx_expression res(ctx);
+        fmpz_mod_poly_randtest_not_zero(res._poly(), state._data(), len, ctx._ctx());
+        return res;
+    }
+
+    // These only make sense with immediates
+    fmpzxx_srcref modulus() const {return get_ctx().modulus();}
 
     // These only make sense with target immediates
-    void realloc(slong alloc) {fmpz_mod_poly_realloc(_poly(), alloc);}
-    void fit_length(slong len) {fmpz_mod_poly_fit_length(_poly(), len);}
+    void realloc(slong alloc) {fmpz_mod_poly_realloc(_poly(), alloc, _ctx());}
+    void fit_length(slong len) {fmpz_mod_poly_fit_length(_poly(), len, _ctx());}
     void _normalise() {_fmpz_mod_poly_normalise(_poly());}
-    void set_coeff(slong n, ulong c) {fmpz_mod_poly_set_coeff_ui(_poly(), n, c);}
+    void set_coeff(slong n, ulong c) {fmpz_mod_poly_set_coeff_ui(_poly(), n, c, _ctx());}
     template<class Fmpz>
     typename mp::enable_if<traits::is_fmpzxx<Fmpz> >::type
     set_coeff(slong j, const Fmpz& c)
     {
-        fmpz_mod_poly_set_coeff_fmpz(_poly(), j, c.evaluate()._fmpz());
+        fmpz_mod_poly_set_coeff_fmpz(_poly(), j, c.evaluate()._fmpz(), _ctx());
     }
-    void truncate(slong n) {fmpz_mod_poly_truncate(_poly(), n);}
-    void zero_coeffs(slong i, slong j) {fmpz_mod_poly_zero_coeffs(_poly(), i, j);}
+    void truncate(slong n) {fmpz_mod_poly_truncate(_poly(), n, _ctx());}
+    void zero_coeffs(slong i, slong j) {fmpz_mod_poly_zero_coeffs(_poly(), i, j, _ctx());}
 
     void set_randtest(frandxx& state, slong len)
-        {fmpz_mod_poly_randtest(_poly(), state._data(), len);}
+        {fmpz_mod_poly_randtest(_poly(), state._data(), len, _ctx());}
     void set_randtest_irreducible(frandxx& state, slong len)
-        {fmpz_mod_poly_randtest_irreducible(_poly(), state._data(), len);}
+        {fmpz_mod_poly_randtest_irreducible(_poly(), state._data(), len, _ctx());}
     void set_randtest_not_zero(frandxx& state, slong len)
-        {fmpz_mod_poly_randtest_not_zero(_poly(), state._data(), len);}
+        {fmpz_mod_poly_randtest_not_zero(_poly(), state._data(), len, _ctx());}
 
     template<class Poly>
     slong remove(const Poly& p)
     {
-        return fmpz_mod_poly_remove(_poly(), p.evaluate()._poly());
+        return fmpz_mod_poly_remove(_poly(), p.evaluate()._poly(), _ctx());
     }
 
-    void set_zero() {fmpz_mod_poly_zero(_poly());}
+    void set_zero() {fmpz_mod_poly_zero(_poly(), _ctx());}
 
     // unified coefficient access
     typename poly_traits_t::lead_ref_t lead()
@@ -134,26 +240,47 @@ class fmpz_mod_polyxx_expression
         return poly_traits_t::lead(*this);
     }
 
-    // this works without evaluation
-    fmpzxx_srcref modulus() const;
-
-    evaluated_t create_temporary() const
+    // these cause evaluation
+    slong length() const
     {
-        return evaluated_t(modulus());
+        auto e = this->evaluate();
+        return fmpz_mod_poly_length(e._poly(), e._ctx());
     }
-
-    // These cause evaluation
-    slong length() const {return fmpz_mod_poly_length(this->evaluate()._poly());}
-    slong degree() const {return fmpz_mod_poly_degree(this->evaluate()._poly());}
-    bool is_zero() const {return fmpz_mod_poly_is_zero(this->evaluate()._poly());}
+    slong degree() const
+    {
+        auto e = this->evaluate();
+        return fmpz_mod_poly_degree(e._poly(), e._ctx());
+    }
+    bool is_zero() const
+    {
+        auto e = this->evaluate();
+        return fmpz_mod_poly_is_zero(e._poly(), e._ctx());
+    }
+    bool is_one() const
+    {
+        auto e = this->evaluate();
+        return fmpz_mod_poly_is_one(e._poly(), e._ctx());
+    }
     bool is_squarefree() const
-        {return fmpz_mod_poly_is_squarefree(this->evaluate()._poly());}
+    {
+        auto e = this->evaluate();
+        return fmpz_mod_poly_is_squarefree(e._poly(), e._ctx());
+    }
     bool is_irreducible() const
-        {return fmpz_mod_poly_is_irreducible(this->evaluate()._poly());}
+    {
+        auto e = this->evaluate();
+        return fmpz_mod_poly_is_irreducible(e._poly(), e._ctx());
+    }
     bool is_irreducible_ddf() const
-        {return fmpz_mod_poly_is_irreducible_ddf(this->evaluate()._poly());}
+    {
+        auto e = this->evaluate();
+       return fmpz_mod_poly_is_irreducible_ddf(e._poly(), e._ctx());
+    }
     bool is_irreducible_rabin() const
-        {return fmpz_mod_poly_is_irreducible_rabin(this->evaluate()._poly());}
+    {
+        auto e = this->evaluate();
+        return fmpz_mod_poly_is_irreducible_rabin(e._poly(), e._ctx());
+    }
 
     // Lazy members
     FLINTXX_DEFINE_MEMBER_BINOP_(get_coeff, fmpz_mod_polyxx_get_coeff)
@@ -200,15 +327,76 @@ namespace detail {
 struct fmpz_mod_poly_data;
 }
 
-typedef fmpz_mod_polyxx_expression<operations::immediate, detail::fmpz_mod_poly_data>
-           fmpz_mod_polyxx;
+typedef fmpz_mod_polyxx_expression<operations::immediate,
+            detail::fmpz_mod_poly_data> fmpz_mod_polyxx;
 typedef fmpz_mod_polyxx_expression<operations::immediate,
             flint_classes::ref_data<fmpz_mod_polyxx, fmpz_mod_poly_struct> >
-           fmpz_mod_polyxx_ref;
-typedef fmpz_mod_polyxx_expression<operations::immediate,
-            flint_classes::srcref_data<
-                fmpz_mod_polyxx, fmpz_mod_polyxx_ref, fmpz_mod_poly_struct> >
-           fmpz_mod_polyxx_srcref;
+                fmpz_mod_polyxx_ref;
+typedef fmpz_mod_polyxx_expression<operations::immediate, flint_classes::srcref_data<
+    fmpz_mod_polyxx, fmpz_mod_polyxx_ref, fmpz_mod_poly_struct> > fmpz_mod_polyxx_srcref;
+
+namespace traits {
+template<> struct has_fmpz_modxx_ctx<fmpz_mod_polyxx> : mp::true_ { };
+template<> struct has_fmpz_modxx_ctx<fmpz_mod_polyxx_ref> : mp::true_ { };
+template<> struct has_fmpz_modxx_ctx<fmpz_mod_polyxx_srcref> : mp::true_ { };
+} // traits
+
+namespace flint_classes {
+template<>
+struct ref_data<fmpz_mod_polyxx, fmpz_mod_poly_struct>
+{
+    typedef void IS_REF_OR_CREF;
+    typedef fmpz_mod_polyxx wrapped_t;
+
+    typedef fmpz_mod_poly_struct* data_ref_t;
+    typedef const fmpz_mod_poly_struct* data_srcref_t;
+
+    fmpz_mod_poly_struct* inner;
+    fmpz_modxx_ctx_srcref ctx;
+
+    template<class T>
+    ref_data(T& o, typename detail::fakemodtemplate<T, fmpz_mod_polyxx>::type* = 0)
+        : inner(o._data().inner), ctx(o._data().ctx) {}
+
+    static ref_data make(fmpz_mod_poly_struct* f, fmpz_modxx_ctx_srcref ctx)
+    {
+        return ref_data(f, ctx);
+    }
+
+private:
+    ref_data(fmpz_mod_poly_struct* fp, fmpz_modxx_ctx_srcref c) : inner(fp), ctx(c) {}
+};
+
+template<class Ref>
+struct srcref_data<fmpz_mod_polyxx, Ref, fmpz_mod_poly_struct>
+{
+    typedef void IS_REF_OR_CREF;
+    typedef fmpz_mod_polyxx wrapped_t;
+
+    typedef const fmpz_mod_poly_struct* data_ref_t;
+    typedef const fmpz_mod_poly_struct* data_srcref_t;
+
+    const fmpz_mod_poly_struct* inner;
+    fmpz_modxx_ctx_srcref ctx;
+
+    template<class T>
+    srcref_data(const T& o,
+            typename detail::fakemodtemplate<T, fmpz_mod_polyxx>::type* = 0)
+        : inner(o._data().inner), ctx(o._data().ctx) {}
+    template<class T>
+    srcref_data(T o, typename detail::fakemodtemplate<T, Ref>::type* = 0)
+        : inner(o._data().inner), ctx(o._data().ctx) {}
+
+    static srcref_data make(const fmpz_mod_poly_struct* f, fmpz_modxx_ctx_srcref ctx)
+    {
+        return srcref_data(f, ctx);
+    }
+
+private:
+    srcref_data(const fmpz_mod_poly_struct* fp, fmpz_modxx_ctx_srcref c)
+        : inner(fp), ctx(c) {}
+};
+} // flint_classes
 
 #define FMPZ_MOD_POLYXX_COND_S FLINTXX_COND_S(fmpz_mod_polyxx)
 #define FMPZ_MOD_POLYXX_COND_T FLINTXX_COND_T(fmpz_mod_polyxx)
@@ -222,7 +410,7 @@ struct fmpz_mod_poly_traits<fmpz_mod_polyxx_srcref>
 
     template<class P>
     static lead_srcref_t lead(P p)
-        {return lead_srcref_t::make(fmpz_mod_poly_lead(p._poly()));}
+        {return lead_srcref_t::make(fmpz_mod_poly_lead(p._poly(), p._ctx()));}
 };
 template<>
 struct fmpz_mod_poly_traits<fmpz_mod_polyxx_ref>
@@ -232,7 +420,7 @@ struct fmpz_mod_poly_traits<fmpz_mod_polyxx_ref>
 
     template<class P>
     static lead_ref_t lead(P p)
-        {return lead_ref_t::make(fmpz_mod_poly_lead(p._poly()));}
+        {return lead_ref_t::make(fmpz_mod_poly_lead(p._poly(), p._ctx()));}
 };
 template<>
 struct fmpz_mod_poly_traits<fmpz_mod_polyxx>
@@ -242,57 +430,54 @@ struct fmpz_mod_poly_traits<fmpz_mod_polyxx>
 
     template<class P>
     static lead_ref_t lead(P& p)
-        {return lead_ref_t::make(fmpz_mod_poly_lead(p._poly()));}
+        {return lead_ref_t::make(fmpz_mod_poly_lead(p._poly(), p._ctx()));}
     template<class P>
     static lead_srcref_t lead(const P& p)
-        {return lead_srcref_t::make(fmpz_mod_poly_lead(p._poly()));}
+        {return lead_srcref_t::make(fmpz_mod_poly_lead(p._poly(), p._ctx()));}
 };
 
 struct fmpz_mod_poly_data
 {
-    fmpz_mod_poly_t inner;
     typedef fmpz_mod_poly_t& data_ref_t;
     typedef const fmpz_mod_poly_t& data_srcref_t;
 
-    template<class Fmpz>
-    fmpz_mod_poly_data(const Fmpz& n,
-            typename mp::enable_if<traits::is_fmpzxx<Fmpz> >::type* = 0)
+    fmpz_modxx_ctx_srcref ctx;
+    fmpz_mod_poly_t inner;
+
+    fmpz_mod_poly_data(fmpz_modxx_ctx_srcref c)
+        : ctx(c)
     {
-        fmpz_mod_poly_init(inner, n.evaluate()._fmpz());
+        fmpz_mod_poly_init(inner, ctx._ctx());
     }
-    template<class Fmpz>
-    fmpz_mod_poly_data(const Fmpz& n, slong alloc,
-            typename mp::enable_if<traits::is_fmpzxx<Fmpz> >::type* = 0)
+
+    fmpz_mod_poly_data(fmpz_modxx_ctx_srcref c, slong alloc)
+        : ctx(c)
     {
-        fmpz_mod_poly_init2(inner, n.evaluate()._fmpz(), alloc);
+        fmpz_mod_poly_init2(inner, alloc, ctx._ctx());
     }
-    ~fmpz_mod_poly_data() {fmpz_mod_poly_clear(inner);}
 
     fmpz_mod_poly_data(const fmpz_mod_poly_data& o)
+        : ctx(o.ctx)
     {
-        fmpz_mod_poly_init(inner, fmpz_mod_poly_modulus(o.inner));
-        fmpz_mod_poly_set(inner, o.inner);
+        fmpz_mod_poly_init2(inner, o.inner->length, ctx._ctx());
+        fmpz_mod_poly_set(inner, o.inner, ctx._ctx());
     }
 
-    fmpz_mod_poly_data(fmpz_mod_polyxx_srcref r)
+    fmpz_mod_poly_data(fmpz_mod_polyxx_srcref c)
+        : ctx(c.get_ctx())
     {
-        fmpz_mod_poly_init(inner, r.modulus()._fmpz());
-        fmpz_mod_poly_set(inner, r._poly());
+        fmpz_mod_poly_init2(inner, c.length(), ctx._ctx());
+        fmpz_mod_poly_set(inner, c._poly(), ctx._ctx());
     }
+
+    ~fmpz_mod_poly_data() {fmpz_mod_poly_clear(inner, ctx._ctx());}
 };
 
 struct is_fmpz_mod_polyxx_predicate
 {
     template<class T> struct type : FMPZ_MOD_POLYXX_COND_S<T> { };
 };
-}
-template<class Operation, class Data>
-inline fmpzxx_srcref
-fmpz_mod_polyxx_expression<Operation, Data>::modulus() const
-{
-    return tools::find_subexpr<detail::is_fmpz_mod_polyxx_predicate>(
-            *this)._mod();
-}
+} // detail
 
 namespace traits {
 template<class T> struct is_fmpz_mod_polyxx : mp::or_<
@@ -301,98 +486,120 @@ template<class T> struct is_fmpz_mod_polyxx : mp::or_<
 }
 
 namespace rules {
-FLINT_DEFINE_DOIT_COND2(assignment, FMPZ_MOD_POLYXX_COND_T,
-        FMPZ_MOD_POLYXX_COND_S, fmpz_mod_poly_set(to._poly(), from._poly()))
-FLINT_DEFINE_DOIT_COND2(assignment, FMPZ_MOD_POLYXX_COND_T,
-        traits::is_unsigned_integer, fmpz_mod_poly_set_ui(to._poly(), from))
-FLINT_DEFINE_DOIT_COND2(assignment, FMPZ_MOD_POLYXX_COND_T,
-        FMPZXX_COND_S, fmpz_mod_poly_set_fmpz(to._poly(), from._fmpz()))
-FLINT_DEFINE_DOIT_COND2(assignment, FMPZ_MOD_POLYXX_COND_T, FMPZ_POLYXX_COND_S,
-        fmpz_mod_poly_set_fmpz_poly(to._poly(), from._poly()))
+
+FLINT_DEFINE_DOIT_COND2(assignment,
+    FMPZ_MOD_POLYXX_COND_T, FMPZ_MOD_POLYXX_COND_S,
+    fmpz_mod_poly_set(to._poly(), from._poly(), to._ctx()))
+
+FLINT_DEFINE_DOIT_COND2(assignment,
+    FMPZ_MOD_POLYXX_COND_T, traits::is_unsigned_integer,
+    fmpz_mod_poly_set_ui(to._poly(), from, to._ctx()))
+
+FLINT_DEFINE_DOIT_COND2(assignment,
+    FMPZ_MOD_POLYXX_COND_T, FMPZXX_COND_S,
+    fmpz_mod_poly_set_fmpz(to._poly(), from._fmpz(), to._ctx()))
+
+FLINT_DEFINE_DOIT_COND2(assignment,
+    FMPZ_MOD_POLYXX_COND_T, FMPZ_POLYXX_COND_S,
+    fmpz_mod_poly_set_fmpz_poly(to._poly(), from._poly(), to._ctx()))
+
 FLINTXX_DEFINE_CONVERSION_TMP(fmpz_polyxx, fmpz_mod_polyxx,
-        fmpz_mod_poly_get_fmpz_poly(to._poly(), from._poly()))
+    fmpz_mod_poly_get_fmpz_poly(to._poly(), from._poly(), from._ctx()))
 
-FLINTXX_DEFINE_SWAP(fmpz_mod_polyxx, fmpz_mod_poly_swap(e1._poly(), e2._poly()))
+FLINTXX_DEFINE_SWAP(fmpz_mod_polyxx,
+    fmpz_mod_poly_swap(e1._poly(), e2._poly()))
 
-FLINTXX_DEFINE_EQUALS(fmpz_mod_polyxx, fmpz_mod_poly_equal(e1._poly(), e2._poly()))
+FLINTXX_DEFINE_EQUALS(fmpz_mod_polyxx,
+    fmpz_mod_poly_equal(e1._poly(), e2._poly(), e1._ctx()))
 
-FLINT_DEFINE_BINARY_EXPR_COND2(fmpz_mod_polyxx_get_coeff_op, fmpzxx,
-        FMPZ_MOD_POLYXX_COND_S, traits::fits_into_slong,
-        fmpz_mod_poly_get_coeff_fmpz(to._fmpz(), e1._poly(), e2))
+FLINT_DEFINE_BINARY_EXPR_COND2(fmpz_mod_polyxx_get_coeff_op,
+    fmpzxx, FMPZ_MOD_POLYXX_COND_S, traits::fits_into_slong,
+    fmpz_mod_poly_get_coeff_fmpz(to._fmpz(), e1._poly(), e2, e1._ctx()))
 
-FLINT_DEFINE_PRINT_COND(FMPZ_MOD_POLYXX_COND_S, fmpz_mod_poly_fprint(to, from._poly()))
+FLINT_DEFINE_PRINT_COND(FMPZ_MOD_POLYXX_COND_S,
+    fmpz_mod_poly_fprint(to, from._poly(), from._ctx()))
+
 FLINT_DEFINE_PRINT_PRETTY_COND_2(FMPZ_MOD_POLYXX_COND_S, const char*,
-        fmpz_mod_poly_fprint_pretty(to, from._poly(), extra))
-FLINT_DEFINE_READ_COND(FMPZ_MOD_POLYXX_COND_T, fmpz_mod_poly_fread(from, to._poly()))
+    fmpz_mod_poly_fprint_pretty(to, from._poly(), extra, from._ctx()))
 
-FLINT_DEFINE_BINARY_EXPR_COND2(plus, fmpz_mod_polyxx,
-        FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-        fmpz_mod_poly_add(to._poly(), e1._poly(), e2._poly()))
-FLINT_DEFINE_BINARY_EXPR_COND2(minus, fmpz_mod_polyxx,
-        FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-        fmpz_mod_poly_sub(to._poly(), e1._poly(), e2._poly()))
+//fread is illegal because the ctx is read-only
 
-FLINT_DEFINE_CBINARY_EXPR_COND2(times, fmpz_mod_polyxx,
-        FMPZ_MOD_POLYXX_COND_S, FMPZXX_COND_S,
-        fmpz_mod_poly_scalar_mul_fmpz(to._poly(), e1._poly(), e2._fmpz()))
+FLINT_DEFINE_BINARY_EXPR_COND2(plus,
+    fmpz_mod_polyxx, FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
+    fmpz_mod_poly_add(to._poly(), e1._poly(), e2._poly(), to._ctx()))
+
+FLINT_DEFINE_BINARY_EXPR_COND2(minus,
+    fmpz_mod_polyxx, FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
+    fmpz_mod_poly_sub(to._poly(), e1._poly(), e2._poly(), to._ctx()))
+
+FLINT_DEFINE_CBINARY_EXPR_COND2(times,
+    fmpz_mod_polyxx, FMPZ_MOD_POLYXX_COND_S, FMPZXX_COND_S,
+    fmpz_mod_poly_scalar_mul_fmpz(to._poly(), e1._poly(), e2._fmpz(), to._ctx()))
+
 FLINT_DEFINE_BINARY_EXPR_COND2(times, fmpz_mod_polyxx,
-        FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-        fmpz_mod_poly_mul(to._poly(), e1._poly(), e2._poly()))
+    FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
+    fmpz_mod_poly_mul(to._poly(), e1._poly(), e2._poly(), to._ctx()))
 
 // TODO expose the temporary
 FLINT_DEFINE_BINARY_EXPR_COND2(divided_by, fmpz_mod_polyxx,
-        FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-        fmpz_mod_polyxx tmp(to.modulus());
-        fmpz_mod_poly_divrem(to._poly(), tmp._poly(), e1._poly(), e2._poly()))
+    FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
+    fmpz_mod_polyxx tmp(to.get_ctx());
+    fmpz_mod_poly_divrem(to._poly(), tmp._poly(), e1._poly(), e2._poly(), to._ctx()))
 
-FLINT_DEFINE_UNARY_EXPR_COND(negate, fmpz_mod_polyxx, FMPZ_MOD_POLYXX_COND_S,
-        fmpz_mod_poly_neg(to._poly(), from._poly()))
+FLINT_DEFINE_UNARY_EXPR_COND(negate,
+    fmpz_mod_polyxx, FMPZ_MOD_POLYXX_COND_S,
+    fmpz_mod_poly_neg(to._poly(), from._poly(), to._ctx()))
 
-FLINT_DEFINE_UNARY_EXPR_COND(fmpz_mod_polyxx_lead_op, fmpzxx,
-        FMPZ_MOD_POLYXX_COND_S,
-        fmpz_set(to._fmpz(), fmpz_mod_poly_lead(from._poly())))
+FLINT_DEFINE_UNARY_EXPR_COND(fmpz_mod_polyxx_lead_op,
+    fmpzxx, FMPZ_MOD_POLYXX_COND_S,
+    fmpz_set(to._fmpz(), fmpz_mod_poly_lead(from._poly(), from._ctx())))
 
-FLINT_DEFINE_BINARY_EXPR_COND2(shift_left_op, fmpz_mod_polyxx,
-        FMPZ_MOD_POLYXX_COND_S, traits::fits_into_slong,
-        fmpz_mod_poly_shift_left(to._poly(), e1._poly(), e2))
-FLINT_DEFINE_BINARY_EXPR_COND2(shift_right_op, fmpz_mod_polyxx,
-        FMPZ_MOD_POLYXX_COND_S, traits::fits_into_slong,
-        fmpz_mod_poly_shift_right(to._poly(), e1._poly(), e2))
+FLINT_DEFINE_BINARY_EXPR_COND2(shift_left_op,
+    fmpz_mod_polyxx, FMPZ_MOD_POLYXX_COND_S, traits::fits_into_slong,
+    fmpz_mod_poly_shift_left(to._poly(), e1._poly(), e2, to._ctx()))
 
-FLINT_DEFINE_UNARY_EXPR_COND(make_monic_op, fmpz_mod_polyxx, FMPZ_MOD_POLYXX_COND_S,
-        fmpz_mod_poly_make_monic(to._poly(), from._poly()))
+FLINT_DEFINE_BINARY_EXPR_COND2(shift_right_op,
+    fmpz_mod_polyxx, FMPZ_MOD_POLYXX_COND_S, traits::fits_into_slong,
+    fmpz_mod_poly_shift_right(to._poly(), e1._poly(), e2, to._ctx()))
+
+FLINT_DEFINE_UNARY_EXPR_COND(make_monic_op,
+    fmpz_mod_polyxx, FMPZ_MOD_POLYXX_COND_S,
+    fmpz_mod_poly_make_monic(to._poly(), from._poly(), to._ctx()))
 
 FLINT_DEFINE_THREEARY_EXPR_COND3(mullow_op, fmpz_mod_polyxx,
     FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S, traits::fits_into_slong,
-    fmpz_mod_poly_mullow(to._poly(), e1._poly(), e2._poly(), e3))
+    fmpz_mod_poly_mullow(to._poly(), e1._poly(), e2._poly(), e3, to._ctx()))
+
 FLINT_DEFINE_THREEARY_EXPR_COND3(mulmod_op, fmpz_mod_polyxx,
     FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-    fmpz_mod_poly_mulmod(to._poly(), e1._poly(), e2._poly(), e3._poly()))
+    fmpz_mod_poly_mulmod(to._poly(), e1._poly(), e2._poly(), e3._poly(), to._ctx()))
+
 FLINT_DEFINE_UNARY_EXPR_COND(sqr_op, fmpz_mod_polyxx, FMPZ_MOD_POLYXX_COND_S,
-        fmpz_mod_poly_sqr(to._poly(), from._poly()))
+        fmpz_mod_poly_sqr(to._poly(), from._poly(), to._ctx()))
 
 FLINT_DEFINE_BINARY_EXPR_COND2(modulo, fmpz_mod_polyxx,
         FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-        fmpz_mod_poly_rem(to._poly(), e1._poly(), e2._poly()))
+        fmpz_mod_poly_rem(to._poly(), e1._poly(), e2._poly(), to._ctx()))
 
 FLINT_DEFINE_THREEARY_EXPR_COND3(powmod_binexp_op, fmpz_mod_polyxx,
     FMPZ_MOD_POLYXX_COND_S, traits::is_unsigned_integer, FMPZ_MOD_POLYXX_COND_S,
-    fmpz_mod_poly_powmod_ui_binexp(to._poly(), e1._poly(), e2, e3._poly()))
+    fmpz_mod_poly_powmod_ui_binexp(to._poly(), e1._poly(), e2, e3._poly(), to._ctx()))
+
 FLINT_DEFINE_THREEARY_EXPR_COND3(powmod_binexp_op, fmpz_mod_polyxx,
     FMPZ_MOD_POLYXX_COND_S, FMPZXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-    fmpz_mod_poly_powmod_fmpz_binexp(
-        to._poly(), e1._poly(), e2._fmpz(), e3._poly()))
+    fmpz_mod_poly_powmod_fmpz_binexp(to._poly(), e1._poly(), e2._fmpz(), e3._poly(), to._ctx()))
 
 FLINT_DEFINE_THREEARY_EXPR_COND3(pow_trunc_op, fmpz_mod_polyxx,
     FMPZ_MOD_POLYXX_COND_S, traits::is_unsigned_integer, traits::fits_into_slong,
-    fmpz_mod_poly_pow_trunc(to._poly(), e1._poly(), e2, e3))
+    fmpz_mod_poly_pow_trunc(to._poly(), e1._poly(), e2, e3, to._ctx()))
+
 FLINT_DEFINE_THREEARY_EXPR_COND3(pow_trunc_binexp_op, fmpz_mod_polyxx,
     FMPZ_MOD_POLYXX_COND_S, traits::is_unsigned_integer, traits::fits_into_slong,
-    fmpz_mod_poly_pow_trunc_binexp(to._poly(), e1._poly(), e2, e3))
+    fmpz_mod_poly_pow_trunc_binexp(to._poly(), e1._poly(), e2, e3, to._ctx()))
 
 FLINT_DEFINE_BINARY_EXPR_COND2(pow_op, fmpz_mod_polyxx,
     FMPZ_MOD_POLYXX_COND_S, traits::is_unsigned_integer,
-    fmpz_mod_poly_pow(to._poly(), e1._poly(), e2))
+    fmpz_mod_poly_pow(to._poly(), e1._poly(), e2, to._ctx()))
 
 namespace rdetail {
 typedef make_ltuple<mp::make_tuple<fmpz_mod_polyxx, fmpz_mod_polyxx>::type>::type
@@ -401,114 +608,127 @@ typedef make_ltuple<mp::make_tuple<
         fmpzxx, fmpz_mod_polyxx, fmpz_mod_polyxx>::type>::type
     fmpz_mod_poly_divrem_f_rt;
 } // rdetail
+
 FLINT_DEFINE_BINARY_EXPR_COND2(divrem_basecase_op, rdetail::fmpz_mod_polyxx_pair,
     FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
     fmpz_mod_poly_divrem_basecase(
         to.template get<0>()._poly(), to.template get<1>()._poly(),
-        e1._poly(), e2._poly()))
+        e1._poly(), e2._poly(), e1._ctx()))
+
 FLINT_DEFINE_BINARY_EXPR_COND2(divrem_divconquer_op, rdetail::fmpz_mod_polyxx_pair,
     FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
     fmpz_mod_poly_divrem_divconquer(
         to.template get<0>()._poly(), to.template get<1>()._poly(),
-        e1._poly(), e2._poly()))
+        e1._poly(), e2._poly(), e1._ctx()))
+
 FLINT_DEFINE_BINARY_EXPR_COND2(divrem_op, rdetail::fmpz_mod_polyxx_pair,
     FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
     fmpz_mod_poly_divrem_divconquer(
         to.template get<0>()._poly(), to.template get<1>()._poly(),
-        e1._poly(), e2._poly()))
+        e1._poly(), e2._poly(), e1._ctx()))
+
 FLINT_DEFINE_BINARY_EXPR_COND2(divrem_f_op, rdetail::fmpz_mod_poly_divrem_f_rt,
     FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
     fmpz_mod_poly_divrem_f(
         to.template get<0>()._fmpz(), to.template get<1>()._poly(),
-        to.template get<2>()._poly(), e1._poly(), e2._poly()))
+        to.template get<2>()._poly(), e1._poly(), e2._poly(), e1._ctx()))
 
 FLINT_DEFINE_BINARY_EXPR_COND2(div_basecase_op, fmpz_mod_polyxx,
-        FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-        fmpz_mod_poly_div_basecase(to._poly(), e1._poly(), e2._poly()))
+    FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
+    fmpz_mod_poly_div_basecase(to._poly(), e1._poly(), e2._poly(), to._ctx()))
+
 FLINT_DEFINE_BINARY_EXPR_COND2(rem_basecase_op, fmpz_mod_polyxx,
-        FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-        fmpz_mod_poly_rem_basecase(to._poly(), e1._poly(), e2._poly()))
+    FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
+    fmpz_mod_poly_rem_basecase(to._poly(), e1._poly(), e2._poly(), to._ctx()))
 
 FLINT_DEFINE_BINARY_EXPR_COND2(inv_series_newton_op, fmpz_mod_polyxx,
-        FMPZ_MOD_POLYXX_COND_S, traits::fits_into_slong,
-        fmpz_mod_poly_inv_series_newton(to._poly(), e1._poly(), e2))
+    FMPZ_MOD_POLYXX_COND_S, traits::fits_into_slong,
+    fmpz_mod_poly_inv_series_newton(to._poly(), e1._poly(), e2, to._ctx()))
 
 FLINT_DEFINE_BINARY_EXPR_COND2(gcd_op, fmpz_mod_polyxx,
-        FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-        fmpz_mod_poly_gcd(to._poly(), e1._poly(), e2._poly()))
+    FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
+    fmpz_mod_poly_gcd(to._poly(), e1._poly(), e2._poly(), to._ctx()))
+
 FLINT_DEFINE_BINARY_EXPR_COND2(gcd_euclidean_op, fmpz_mod_polyxx,
-        FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-        fmpz_mod_poly_gcd_euclidean(to._poly(), e1._poly(), e2._poly()))
+    FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
+    fmpz_mod_poly_gcd_euclidean(to._poly(), e1._poly(), e2._poly(), to._ctx()))
 
 namespace rdetail {
 typedef make_ltuple<mp::make_tuple<
         fmpz_mod_polyxx, fmpz_mod_polyxx, fmpz_mod_polyxx>::type>::type
     fmpz_mod_polyxx_triple;
 } // rdetail
+
 FLINT_DEFINE_BINARY_EXPR_COND2(xgcd_op, rdetail::fmpz_mod_polyxx_triple,
     FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
     fmpz_mod_poly_xgcd(to.template get<0>()._poly(), to.template get<1>()._poly(),
-        to.template get<2>()._poly(), e1._poly(), e2._poly()))
+        to.template get<2>()._poly(), e1._poly(), e2._poly(), e1._ctx()))
+
 FLINT_DEFINE_BINARY_EXPR_COND2(xgcd_euclidean_op, rdetail::fmpz_mod_polyxx_triple,
     FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
     fmpz_mod_poly_xgcd_euclidean(to.template get<0>()._poly(),
         to.template get<1>()._poly(),
-        to.template get<2>()._poly(), e1._poly(), e2._poly()))
+        to.template get<2>()._poly(), e1._poly(), e2._poly(), e1._ctx()))
 
 namespace rdetail {
 typedef make_ltuple<mp::make_tuple<fmpzxx, fmpz_mod_polyxx>::type>::type
     fmpz_mod_gcd_f_rt;
 } // rdetail
+
 FLINT_DEFINE_BINARY_EXPR_COND2(gcd_f_op, rdetail::fmpz_mod_gcd_f_rt,
-        FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-        fmpz_mod_poly_gcd_f(to.template get<0>()._fmpz(),
-            to.template get<1>()._poly(), e1._poly(), e2._poly()))
+    FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
+    fmpz_mod_poly_gcd_f(to.template get<0>()._fmpz(),
+        to.template get<1>()._poly(), e1._poly(), e2._poly(), e1._ctx()))
+
 FLINT_DEFINE_BINARY_EXPR_COND2(gcd_euclidean_f_op, rdetail::fmpz_mod_gcd_f_rt,
-        FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-        fmpz_mod_poly_gcd_euclidean_f(to.template get<0>()._fmpz(),
-            to.template get<1>()._poly(), e1._poly(), e2._poly()))
+    FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
+    fmpz_mod_poly_gcd_euclidean_f(to.template get<0>()._fmpz(),
+        to.template get<1>()._poly(), e1._poly(), e2._poly(), e1._ctx()))
 
 FLINT_DEFINE_BINARY_EXPR_COND2(gcdinv_op, rdetail::fmpz_mod_polyxx_pair,
     FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
     fmpz_mod_poly_gcdinv(
         to.template get<0>()._poly(), to.template get<1>()._poly(),
-        e1._poly(), e2._poly()))
+        e1._poly(), e2._poly(), e1._ctx()))
 
 FLINT_DEFINE_BINARY_EXPR_COND2(invmod_op, fmpz_mod_polyxx,
     FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-    execution_check(fmpz_mod_poly_invmod(to._poly(), e1._poly(), e2._poly()),
+    execution_check(fmpz_mod_poly_invmod(to._poly(), e1._poly(), e2._poly(), to._ctx()),
         "invmod", "fmpz_mod_polyxx"))
 
-FLINT_DEFINE_UNARY_EXPR_COND(derivative_op, fmpz_mod_polyxx, FMPZ_MOD_POLYXX_COND_S,
-        fmpz_mod_poly_derivative(to._poly(), from._poly()))
+FLINT_DEFINE_UNARY_EXPR_COND(derivative_op, fmpz_mod_polyxx,
+    FMPZ_MOD_POLYXX_COND_S,
+    fmpz_mod_poly_derivative(to._poly(), from._poly(), to._ctx()))
 
 FLINT_DEFINE_BINARY_EXPR_COND2(evaluate_op, fmpzxx,
-        FMPZ_MOD_POLYXX_COND_S, FMPZXX_COND_S,
-        fmpz_mod_poly_evaluate_fmpz(to._fmpz(), e1._poly(), e2._fmpz()))
+    FMPZ_MOD_POLYXX_COND_S, FMPZXX_COND_S,
+    fmpz_mod_poly_evaluate_fmpz(to._fmpz(), e1._poly(), e2._fmpz(), e1._ctx()))
 
 FLINT_DEFINE_BINARY_EXPR_COND2(compose_op, fmpz_mod_polyxx,
-        FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-        fmpz_mod_poly_compose(to._poly(), e1._poly(), e2._poly()))
+    FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
+    fmpz_mod_poly_compose(to._poly(), e1._poly(), e2._poly(), to._ctx()))
+
 FLINT_DEFINE_BINARY_EXPR_COND2(compose_divconquer_op, fmpz_mod_polyxx,
-        FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-        fmpz_mod_poly_compose_divconquer(to._poly(), e1._poly(), e2._poly()))
+    FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
+    fmpz_mod_poly_compose_divconquer(to._poly(), e1._poly(), e2._poly(), to._ctx()))
+
 FLINT_DEFINE_BINARY_EXPR_COND2(compose_horner_op, fmpz_mod_polyxx,
-        FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-        fmpz_mod_poly_compose_horner(to._poly(), e1._poly(), e2._poly()))
+    FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
+    fmpz_mod_poly_compose_horner(to._poly(), e1._poly(), e2._poly(), to._ctx()))
 
 FLINT_DEFINE_THREEARY_EXPR_COND3(compose_mod_op, fmpz_mod_polyxx,
-        FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-        fmpz_mod_poly_compose_mod(to._poly(), e1._poly(), e2._poly(), e3._poly()))
-FLINT_DEFINE_THREEARY_EXPR_COND3(compose_mod_horner_op, fmpz_mod_polyxx,
-        FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-        fmpz_mod_poly_compose_mod_horner(
-            to._poly(), e1._poly(), e2._poly(), e3._poly()))
-FLINT_DEFINE_THREEARY_EXPR_COND3(compose_mod_brent_kung_op, fmpz_mod_polyxx,
-        FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-        fmpz_mod_poly_compose_mod_brent_kung(
-            to._poly(), e1._poly(), e2._poly(), e3._poly()))
-} // rules
+    FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
+    fmpz_mod_poly_compose_mod(to._poly(), e1._poly(), e2._poly(), e3._poly(), to._ctx()))
 
+FLINT_DEFINE_THREEARY_EXPR_COND3(compose_mod_horner_op, fmpz_mod_polyxx,
+    FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
+    fmpz_mod_poly_compose_mod_horner(to._poly(), e1._poly(), e2._poly(), e3._poly(), to._ctx()))
+
+FLINT_DEFINE_THREEARY_EXPR_COND3(compose_mod_brent_kung_op, fmpz_mod_polyxx,
+    FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
+    fmpz_mod_poly_compose_mod_brent_kung(to._poly(), e1._poly(), e2._poly(), e3._poly(), to._ctx()))
+
+} // rules
 
 ///////////////////////////////////////////////////////////////////////////////
 // fmpz_mod_poly_vecxx (for radix conversion)
@@ -518,73 +738,56 @@ struct fmpz_mod_poly_vector_data
 {
     slong size;
     fmpz_mod_poly_struct** array;
+    fmpz_modxx_ctx_srcref ctx;
 
-    template<class Fmpz>
-    void init(slong n, const Fmpz& f)
+    fmpz_mod_poly_vector_data(slong n, fmpz_modxx_ctx_srcref c)
+        : size(n), ctx(c)
     {
-        size = n;
         array = new fmpz_mod_poly_struct*[n];
         for(slong i = 0;i < n;++i)
         {
             array[i] = new fmpz_mod_poly_struct();
-            fmpz_mod_poly_init(array[i], f._fmpz());
+            fmpz_mod_poly_init(array[i], ctx._ctx());
         }
-    }
-
-    template<class Fmpz>
-    fmpz_mod_poly_vector_data(slong n, const Fmpz& f,
-            typename mp::enable_if<traits::is_fmpzxx<Fmpz> >::type* = 0)
-    {
-        init(n, f.evaluate());
     }
 
     ~fmpz_mod_poly_vector_data()
     {
         for(slong i = 0;i < size;++i)
         {
-            fmpz_mod_poly_clear(array[i]);
+            fmpz_mod_poly_clear(array[i], ctx._ctx());
             delete array[i];
         }
         delete[] array;
     }
 
     fmpz_mod_poly_vector_data(const fmpz_mod_poly_vector_data& o)
-        : size(o.size)
+        : size(o.size), ctx(o.ctx)
     {
         array = new fmpz_mod_poly_struct*[size];
         for(slong i = 0;i < size;++i)
         {
             array[i] = new fmpz_mod_poly_struct();
-            fmpz_mod_poly_init(array[i], &o.array[0]->p);
-            fmpz_mod_poly_set(array[i], o.array[i]);
+            fmpz_mod_poly_init(array[i], ctx._ctx());
+            fmpz_mod_poly_set(array[i], o.array[i], ctx._ctx());
         }
     }
 
     fmpz_mod_polyxx_ref at(slong i)
-        {return fmpz_mod_polyxx_ref::make(array[i]);}
+        {return fmpz_mod_polyxx_ref::make(array[i], ctx);}
     fmpz_mod_polyxx_srcref at(slong i) const
-        {return fmpz_mod_polyxx_srcref::make(array[i]);}
+        {return fmpz_mod_polyxx_srcref::make(array[i], ctx);}
 
     bool equals(const fmpz_mod_poly_vector_data& o) const
     {
         if(size != o.size)
             return false;
         for(slong i = 0;i < size;++i)
-            if(!fmpz_mod_poly_equal(array[i], o.array[i]))
+            if(!fmpz_mod_poly_equal(array[i], o.array[i], ctx._ctx()))
                 return false;
         return true;
     }
 };
-
-// TODO extend this somewhat similarly to the nmod* setup
-template<class T>
-fmpzxx_srcref find_fmpz_mod_polyxx_mod(const T& t)
-{
-    // this works because there are not actually any functions operating on
-    // fmpz_mod_poly_vecxx
-    return tools::find_subexpr<detail::is_fmpz_mod_polyxx_predicate>(
-            t)._mod();
-}
 
 struct fmpz_mod_poly_vector_traits
     : wrapped_vector_traits<fmpz_mod_polyxx, slong, fmpz_mod_polyxx_ref,
@@ -593,8 +796,7 @@ struct fmpz_mod_poly_vector_traits
     template<class Expr>
     static typename Expr::evaluated_t create_temporary(const Expr& e)
     {
-        return typename Expr::evaluated_t(
-                e.size(), find_fmpz_mod_polyxx_mod(e));
+        return typename Expr::evaluated_t(e.size(), tools::find_fmpz_modxx_ctx(e));
     }
 };
 } // detail
@@ -636,7 +838,11 @@ public:
     fmpz_mod_poly_radixxx(const Fmpz_mod_poly& r, slong deg,
             typename mp::enable_if<
                 traits::is_fmpz_mod_polyxx<Fmpz_mod_poly> >::type* = 0)
-        {fmpz_mod_poly_radix_init(inner, r.evaluate()._poly(), deg);}
+    {
+        auto e = r.evaluate();
+        fmpz_mod_poly_radix_init(inner, e._poly(), deg, e._ctx());
+    }
+
     ~fmpz_mod_poly_radixxx() {fmpz_mod_poly_radix_clear(inner);}
 
     fmpz_mod_poly_radix_t& _data() {return inner;}
@@ -664,8 +870,8 @@ struct outsize<operations::radix_op>
 
 namespace rules {
 FLINT_DEFINE_BINARY_EXPR_COND2(radix_op, fmpz_mod_poly_vecxx,
-        FMPZ_MOD_POLYXX_COND_S, traits::is_fmpz_mod_poly_radixxx,
-        fmpz_mod_poly_radix(to._array(), e1._poly(), e2._data()))
+    FMPZ_MOD_POLYXX_COND_S, traits::is_fmpz_mod_poly_radixxx,
+    fmpz_mod_poly_radix(to._array(), e1._poly(), e2._data(), e1._ctx()))
 }
 } // flint
 


### PR DESCRIPTION
After many toils and snares, I present an fmpz_mod_polyxx that _doesn't_ copy the context object into each polynomial instance.
https://github.com/wbhart/flint2/issues/842