### PR TITLE
equal degree factorization via traces

### DIFF
--- a/fmpz_mod_poly.h
+++ b/fmpz_mod_poly.h
@@ -225,6 +225,12 @@ fmpz * fmpz_mod_poly_lead(const fmpz_mod_poly_t poly, const fmpz_mod_ctx_t ctx)
 }
 
 FMPZ_MOD_POLY_INLINE
+int fmpz_mod_poly_is_monic(const fmpz_mod_poly_t f, const fmpz_mod_ctx_t ctx)
+{
+    return f->length > 0 && fmpz_is_one(f->coeffs + f->length - 1);
+}
+
+FMPZ_MOD_POLY_INLINE
 int fmpz_mod_poly_is_one(const fmpz_mod_poly_t poly, const fmpz_mod_ctx_t ctx)
 {
    return poly->length == 1 && fmpz_is_one(poly->coeffs + 0);
@@ -268,16 +274,12 @@ void fmpz_mod_poly_zero(fmpz_mod_poly_t poly, const fmpz_mod_ctx_t ctx)
 FMPZ_MOD_POLY_INLINE
 void fmpz_mod_poly_one(fmpz_mod_poly_t poly, const fmpz_mod_ctx_t ctx)
 {
-   if (fmpz_is_one(fmpz_mod_ctx_modulus(ctx)))
-   {
-      _fmpz_mod_poly_set_length(poly, 0);
-   } else
-   {
-      fmpz_mod_poly_fit_length(poly, 1, ctx);
-      _fmpz_mod_poly_set_length(poly, 1);
-      fmpz_set_ui(poly->coeffs + 0, 1);
-   }
+    fmpz_mod_poly_fit_length(poly, 1, ctx);
+    fmpz_one(poly->coeffs + 0);
+    _fmpz_mod_poly_set_length(poly, !fmpz_is_one(fmpz_mod_ctx_modulus(ctx)));
 }
+
+FLINT_DLL void fmpz_mod_poly_gen(fmpz_mod_poly_t poly, const fmpz_mod_ctx_t ctx);
 
 FLINT_DLL void fmpz_mod_poly_zero_coeffs(fmpz_mod_poly_t poly,
                                    slong i, slong j, const fmpz_mod_ctx_t ctx);
@@ -540,6 +542,10 @@ FLINT_DLL void _fmpz_mod_poly_powmod_x_fmpz_preinv(fmpz * res, const fmpz_t e,
 FLINT_DLL void fmpz_mod_poly_powmod_x_fmpz_preinv(fmpz_mod_poly_t res,
          const fmpz_t e, const fmpz_mod_poly_t f, const fmpz_mod_poly_t finv,
                                                      const fmpz_mod_ctx_t ctx);
+
+FLINT_DLL void fmpz_mod_poly_powmod_linear_fmpz_preinv(fmpz_mod_poly_t res,
+                      const fmpz_t a, const fmpz_t e, const fmpz_mod_poly_t f,
+                         const fmpz_mod_poly_t finv, const fmpz_mod_ctx_t ctx);
 
 FLINT_DLL void _fmpz_mod_poly_powers_mod_preinv_naive(fmpz ** res,
                     const fmpz * f, slong flen, slong n, const fmpz * g,

--- a/fmpz_mod_poly/gen.c
+++ b/fmpz_mod_poly/gen.c
@@ -1,0 +1,24 @@
+/*
+    Copyright (C) 2020 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <gmp.h>
+#include "flint.h"
+#include "fmpz.h"
+#include "fmpz_mod_poly.h"
+
+void fmpz_mod_poly_gen(fmpz_mod_poly_t poly, const fmpz_mod_ctx_t ctx)
+{
+    fmpz_mod_poly_fit_length(poly, 2, ctx);
+    fmpz_zero(poly->coeffs + 0);
+    fmpz_one(poly->coeffs + 1);
+    _fmpz_mod_poly_set_length(poly, 2*!fmpz_is_one(fmpz_mod_ctx_modulus(ctx)));
+}
+

--- a/fmpz_mod_poly/powmod_linear_fmpz_preinv.c
+++ b/fmpz_mod_poly/powmod_linear_fmpz_preinv.c
@@ -1,0 +1,130 @@
+/*
+    Copyright (C) 2020 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz_mod_poly.h"
+
+
+static void _fmpz_mod_poly_powmod_linear_fmpz_preinv(
+    fmpz * res,
+    const fmpz_t a,
+    const fmpz_t e,
+    const fmpz * f, slong lenf,
+    const fmpz* finv, slong lenfinv,
+    const fmpz_mod_ctx_t ctx)
+{
+    fmpz * T, * Q;
+    slong lenT = 2 * lenf - 3;
+    slong lenQ = lenT - lenf + 1;
+    slong i, j;
+    fmpz_t t, lcinv;
+
+    FLINT_ASSERT(lenf > 1);
+    FLINT_ASSERT(!fmpz_is_zero(e));
+
+    fmpz_init(t);
+
+    if (lenf <= 2)
+    {
+        fmpz_mod_mul(t, f + 0, finv + 0, ctx);
+        fmpz_mod_sub(t, a, t, ctx);
+        fmpz_mod_pow_fmpz(res + 0, t, e, ctx);
+        fmpz_clear(t);
+        return;
+    }
+
+    fmpz_init(lcinv);
+    T = _fmpz_vec_init(lenT + lenQ);
+    Q = T + lenT;
+
+    _fmpz_vec_zero(res, lenf - 1);
+    fmpz_set(res + 0, a);
+    fmpz_one(res + 1);
+
+    for (i = fmpz_sizeinbase(e, 2) - 2; i >= 0; i--)
+    {
+        _fmpz_mod_poly_sqr(T, res, lenf - 1, fmpz_mod_ctx_modulus(ctx));
+        _fmpz_mod_poly_divrem_newton_n_preinv(Q, res, T, 2 * lenf - 3, f, lenf,
+                                     finv, lenfinv, fmpz_mod_ctx_modulus(ctx));
+        if (fmpz_tstbit(e, i))
+        {
+            j = lenf - 1;
+            fmpz_mod_mul(lcinv, finv + 0, res + j - 1, ctx);
+            fmpz_mod_neg(lcinv, lcinv, ctx);
+            for (j--; j > 0; j--)
+            {
+                fmpz_mul(t, a, res + j);
+                fmpz_addmul(t, lcinv, f + j);
+                fmpz_add(t, t, res + j - 1);
+                fmpz_mod(res + j, t, fmpz_mod_ctx_modulus(ctx));
+            }
+            fmpz_mul(t, a, res + j);
+            fmpz_addmul(t, lcinv, f + j);
+            fmpz_mod(res + j, t, fmpz_mod_ctx_modulus(ctx));
+        }
+    }
+
+    fmpz_clear(lcinv);
+    fmpz_clear(t);
+    _fmpz_vec_clear(T, lenT + lenQ);
+}
+
+
+/* res = (x+a)^e mod f */
+void fmpz_mod_poly_powmod_linear_fmpz_preinv(
+    fmpz_mod_poly_t res,
+    const fmpz_t a,
+    const fmpz_t e,
+    const fmpz_mod_poly_t f,
+    const fmpz_mod_poly_t finv,
+    const fmpz_mod_ctx_t ctx)
+{
+    slong lenf = f->length;
+    slong trunc = lenf - 1;
+    int sgn = fmpz_sgn(e);
+    fmpz_mod_poly_t tmp;
+
+    if (lenf < 2)
+    {
+        fmpz_mod_poly_zero(res, ctx);
+        return;
+    }
+
+    if (sgn < 0)
+    {
+        flint_throw(FLINT_ERROR, "fmpz_mod_poly_powmod_linear_fmpz_preinv: "
+                                               "negative exp not implemented");
+    }
+
+    if (sgn == 0)
+    {
+        fmpz_mod_poly_one(res, ctx);
+        return;
+    }
+
+    if (res == f || res == finv)
+    {
+        fmpz_mod_poly_init2(tmp, trunc, ctx);
+        _fmpz_mod_poly_powmod_linear_fmpz_preinv(tmp->coeffs, a, e,
+                             f->coeffs, lenf, finv->coeffs, finv->length, ctx);
+        fmpz_mod_poly_swap(res, tmp, ctx);
+        fmpz_mod_poly_clear(tmp, ctx);
+    }
+    else
+    {
+        fmpz_mod_poly_fit_length(res, trunc, ctx);
+        _fmpz_mod_poly_powmod_linear_fmpz_preinv(res->coeffs, a, e,
+                             f->coeffs, lenf, finv->coeffs, finv->length, ctx);
+    }
+
+    _fmpz_mod_poly_set_length(res, trunc);
+    _fmpz_mod_poly_normalise(res);
+}
+

--- a/fmpz_mod_poly_factor.h
+++ b/fmpz_mod_poly_factor.h
@@ -121,19 +121,33 @@ FLINT_DLL int fmpz_mod_poly_factor_equal_deg_prob(fmpz_mod_poly_t factor,
                        flint_rand_t state, const fmpz_mod_poly_t pol, slong d,
                                                      const fmpz_mod_ctx_t ctx);
 
+FLINT_DLL void fmpz_mod_poly_factor_equal_deg_with_frob(
+             fmpz_mod_poly_factor_t factors, const fmpz_mod_poly_t f, slong d,
+                         const fmpz_mod_poly_t frob, const fmpz_mod_ctx_t ctx);
+
 FLINT_DLL void fmpz_mod_poly_factor_equal_deg(fmpz_mod_poly_factor_t factors,
                  const fmpz_mod_poly_t pol, slong d, const fmpz_mod_ctx_t ctx);
+
+FLINT_DLL void fmpz_mod_poly_factor_distinct_deg_with_frob(
+                    fmpz_mod_poly_factor_t res,  const fmpz_mod_poly_t poly,
+                    const fmpz_mod_poly_t polyinv, const fmpz_mod_poly_t frob,
+                                                     const fmpz_mod_ctx_t ctx);
 
 FLINT_DLL void fmpz_mod_poly_factor_distinct_deg(fmpz_mod_poly_factor_t res,
                               const fmpz_mod_poly_t poly, slong * const *degs,
                                                      const fmpz_mod_ctx_t ctx);
 
-FLINT_DLL void fmpz_mod_poly_factor_squarefree(fmpz_mod_poly_factor_t res,
-                            const fmpz_mod_poly_t f, const fmpz_mod_ctx_t ctx);
+FLINT_DLL void fmpz_mod_poly_factor_distinct_deg_threaded_with_frob(
+                    fmpz_mod_poly_factor_t res, const fmpz_mod_poly_t poly,
+                    const fmpz_mod_poly_t polyinv, const fmpz_mod_poly_t frob,
+                                                     const fmpz_mod_ctx_t ctx);
 
 FLINT_DLL void fmpz_mod_poly_factor_distinct_deg_threaded(
                     fmpz_mod_poly_factor_t res, const fmpz_mod_poly_t poly,
                                slong * const * degs, const fmpz_mod_ctx_t ctx);
+
+FLINT_DLL void fmpz_mod_poly_factor_squarefree(fmpz_mod_poly_factor_t res,
+                            const fmpz_mod_poly_t f, const fmpz_mod_ctx_t ctx);
 
 FLINT_DLL void fmpz_mod_poly_factor(fmpz_mod_poly_factor_t res,
                             const fmpz_mod_poly_t f, const fmpz_mod_ctx_t ctx);

--- a/fmpz_mod_poly_factor/factor_cantor_zassenhaus.c
+++ b/fmpz_mod_poly_factor/factor_cantor_zassenhaus.c
@@ -4,6 +4,7 @@
     Copyright (C) 2008 Richard Howell-Peak
     Copyright (C) 2011 Fredrik Johansson
     Copyright (C) 2012 Lina Kulakova
+    Copyright (C) 2020 Daniel Schultz
 
     This file is part of FLINT.
 
@@ -15,50 +16,59 @@
 
 #include "fmpz_mod_poly.h"
 
-void
-fmpz_mod_poly_factor_cantor_zassenhaus(fmpz_mod_poly_factor_t res,
+void fmpz_mod_poly_factor_cantor_zassenhaus(fmpz_mod_poly_factor_t res,
                              const fmpz_mod_poly_t f, const fmpz_mod_ctx_t ctx)
 {
-    fmpz_mod_poly_t h, v, g, x;
-    slong i, j, num;
+    slong i, j;
+    fmpz_mod_poly_t t, h, v, g, x;
+    fmpz_mod_poly_factor_t tfac;
 
+    res->num = 0;
+
+    fmpz_mod_poly_init(t, ctx);
     fmpz_mod_poly_init(h, ctx);
     fmpz_mod_poly_init(g, ctx);
     fmpz_mod_poly_init(v, ctx);
     fmpz_mod_poly_init(x, ctx);
+    fmpz_mod_poly_factor_init(tfac, ctx);
 
-    fmpz_mod_poly_set_coeff_ui(h, 1, 1, ctx);
-    fmpz_mod_poly_set_coeff_ui(x, 1, 1, ctx);
+    fmpz_mod_poly_gen(h, ctx);
+    fmpz_mod_poly_gen(x, ctx);
 
     fmpz_mod_poly_make_monic(v, f, ctx);
 
     i = 0;
-    do
-    {
+    do {
         i++;
-        fmpz_mod_poly_powmod_fmpz_binexp(h, h, fmpz_mod_ctx_modulus(ctx), v, ctx);
+        fmpz_mod_poly_powmod_fmpz_binexp(t, h, fmpz_mod_ctx_modulus(ctx), v, ctx);
+        fmpz_mod_poly_swap(h, t, ctx);
 
-        fmpz_mod_poly_sub(h, h, x, ctx);
-        fmpz_mod_poly_gcd(g, h, v, ctx);
-        fmpz_mod_poly_add(h, h, x, ctx);
+        fmpz_mod_poly_sub(t, h, x, ctx);
+        fmpz_mod_poly_gcd(g, t, v, ctx);
 
         if (g->length != 1)
         {
-            fmpz_mod_poly_make_monic(g, g, ctx);
-            num = res->num;
+            FLINT_ASSERT(fmpz_mod_poly_is_monic(g, ctx));
 
-            fmpz_mod_poly_factor_equal_deg(res, g, i, ctx);
-            for (j = num; j < res->num; j++)
-                res->exp[j] = fmpz_mod_poly_remove(v, res->poly + j, ctx);
+            fmpz_mod_poly_factor_equal_deg(tfac, g, i, ctx);
+            fmpz_mod_poly_factor_fit_length(res, res->num + tfac->num, ctx);
+            for (j = 0; j < tfac->num; j++)
+            {
+                res->exp[res->num] = fmpz_mod_poly_remove(v, tfac->poly + j, ctx);
+                fmpz_mod_poly_swap(res->poly + res->num, tfac->poly + j, ctx);
+                res->num++;
+            }
         }
-    }
-    while (v->length >= 2 * i + 3);
+    } while (v->length >= 2 * i + 3);
 
     if (v->length > 1)
         fmpz_mod_poly_factor_insert(res, v, 1, ctx);
 
+    fmpz_mod_poly_clear(t, ctx);
     fmpz_mod_poly_clear(g, ctx);
     fmpz_mod_poly_clear(h, ctx);
     fmpz_mod_poly_clear(v, ctx);
     fmpz_mod_poly_clear(x, ctx);
+    fmpz_mod_poly_factor_clear(tfac, ctx);
 }
+

--- a/fmpz_mod_poly_factor/factor_equal_deg.c
+++ b/fmpz_mod_poly_factor/factor_equal_deg.c
@@ -4,6 +4,7 @@
     Copyright (C) 2008 Richard Howell-Peak
     Copyright (C) 2011 Fredrik Johansson
     Copyright (C) 2012 Lina Kulakova
+    Copyright (C) 2020 Daniel Schultz
 
     This file is part of FLINT.
 
@@ -16,37 +17,491 @@
 #include "fmpz_mod_poly.h"
 #include "ulong_extras.h"
 
-void
-fmpz_mod_poly_factor_equal_deg(fmpz_mod_poly_factor_t factors,
-                  const fmpz_mod_poly_t pol, slong d, const fmpz_mod_ctx_t ctx)
+
+typedef struct {
+    fmpz_mod_poly_t f, xp, a, g;
+} split_struct;
+
+typedef struct {
+    fmpz_mod_poly_t f, xp;
+} queue_struct;
+
+static void _queue_vec_fit_length(queue_struct ** Q, slong * Qalloc,
+                                    slong new_length, const fmpz_mod_ctx_t ctx)
 {
-    if (pol->length == d + 1)
+    if (new_length > *Qalloc)
     {
-        fmpz_mod_poly_factor_insert(factors, pol, 1, ctx);
+        slong i;
+        slong old_alloc = *Qalloc;
+        slong new_alloc = FLINT_MAX(2*old_alloc, new_length);
+        *Q = (queue_struct *) flint_realloc(*Q, new_alloc*sizeof(queue_struct));
+        *Qalloc = new_alloc;
+        for (i = old_alloc; i < new_alloc; i++)
+        {
+            fmpz_mod_poly_init((*Q)[i].f, ctx);
+            fmpz_mod_poly_init((*Q)[i].xp, ctx);
+        }
+    }
+}
+
+/* given g|f, update Q and res with g and f/g */
+void _add_split(
+    fmpz_mod_poly_factor_t res,
+    queue_struct ** Q_, slong * Qlen_, slong * Qalloc_,
+    fmpz_mod_poly_t f,
+    fmpz_mod_poly_t g,
+    slong d,
+    const fmpz_mod_poly_t xp,
+    const fmpz_mod_ctx_t ctx,
+    fmpz_mod_poly_t tmp)
+{
+    queue_struct * Q = *Q_;
+    slong Qlen = *Qlen_;
+    slong Qalloc = *Qalloc_;
+    slong i, inc = 0;
+
+    _queue_vec_fit_length(&Q, &Qalloc, Qlen + 2, ctx);
+
+    fmpz_mod_poly_divrem(Q[Qlen + 0].f, tmp, f, g, ctx);
+    fmpz_mod_poly_swap(Q[Qlen + 1].f, g, ctx);
+
+    if (Q[Qlen + 0].f->length < Q[Qlen + 1].f->length)
+        fmpz_mod_poly_swap(Q[Qlen + 0].f, Q[Qlen + 1].f, ctx);
+
+    /* {Q[Qlen + 0], Q[Qlen + 1]} has been sorted by length */
+    for (i = 0; i < 2; i++)
+    {
+        if (fmpz_mod_poly_degree(Q[Qlen + i].f, ctx) > d)
+        {
+            inc++;
+            fmpz_mod_poly_divrem(tmp, Q[Qlen + i].xp, xp, Q[Qlen + i].f, ctx);
+        }
+        else if (fmpz_mod_poly_degree(Q[Qlen + i].f, ctx) == d)
+        {
+            fmpz_mod_poly_factor_fit_length(res, res->num + 1, ctx);
+            res->exp[res->num] = 1;
+            fmpz_mod_poly_set(res->poly + res->num, Q[Qlen + i].f, ctx);
+            res->num++;
+        }
+    }
+
+    *Q_ = Q;
+    *Qlen_ = Qlen + inc;
+    *Qalloc_ = Qalloc;
+}
+
+/* a = b^p^0 + ... + b^p^(d-1) in berlekamp subalgebra, i.e. a^p = a mod f */
+static void _compute_trace(
+    fmpz_mod_poly_t a,
+    fmpz_mod_poly_t b,
+    slong d,
+    const fmpz_mod_poly_t xp,
+    const fmpz_mod_poly_t f,
+    const fmpz_mod_poly_t finv,
+    const fmpz_mod_ctx_t ctx,
+    fmpz_mod_poly_t xi,
+    fmpz_mod_poly_t t)
+{
+    slong i;
+    fmpz_mat_t H;
+#if FLINT_WANT_ASSERT
+    fmpz_mod_poly_t a_check;
+
+    fmpz_mod_poly_init(a_check, ctx);
+    fmpz_mod_poly_set(t, b, ctx);
+    fmpz_mod_poly_set(a_check, b, ctx);
+    for (i = 1; i < d; i++)
+    {
+        fmpz_mod_poly_powmod_fmpz_binexp(t, t, fmpz_mod_ctx_modulus(ctx), f, ctx);
+        fmpz_mod_poly_add(a_check, a_check, t, ctx);
+    }
+#endif
+
+    fmpz_mat_init(H, n_sqrt(f->length - 1) + 1, f->length - 1);
+
+    if (d < 2)
+    {
+        fmpz_mod_poly_swap(a, b, ctx);
+    }
+    else if (d < 16)
+    {
+        fmpz_mod_poly_precompute_matrix(H, xp, f, finv, ctx);
+
+        fmpz_mod_poly_compose_mod_brent_kung_precomp_preinv(xi, b, H, f, finv, ctx);
+        fmpz_mod_poly_add(a, b, xi, ctx);
+        for (i = 2; i < d; i++)
+        {
+            fmpz_mod_poly_compose_mod_brent_kung_precomp_preinv(t, xi, H, f, finv, ctx);
+            fmpz_mod_poly_swap(xi, t, ctx);
+            fmpz_mod_poly_add(a, a, xi, ctx);
+        }
     }
     else
     {
-        fmpz_mod_poly_t f, g, r;
-        flint_rand_t state;
+        /*
+            Optimized trace calculation from
+                Computing Frobenius maps and factoring polynomials
+                    Gathen and Shoup
+            underwhelming for small d
+        */
+        fmpz_mod_poly_zero(a, ctx);
+        fmpz_mod_poly_set(xi, xp, ctx); /* x^p^2^i*/
 
-        fmpz_mod_poly_init(f, ctx);
-
-        flint_randinit(state);
-
-        while (!fmpz_mod_poly_factor_equal_deg_prob(f, state, pol, d, ctx))
+        while (1)
         {
-        };
+            FLINT_ASSERT(d > 1);
 
-        flint_randclear(state);
+            fmpz_mod_poly_precompute_matrix(H, xi, f, finv, ctx);
 
-        fmpz_mod_poly_init(g, ctx);
-        fmpz_mod_poly_init(r, ctx);
-        fmpz_mod_poly_divrem(g, r, pol, f, ctx);
-        fmpz_mod_poly_clear(r, ctx);
+            if (d % 2 == 0)
+            {
+                fmpz_mod_poly_compose_mod_brent_kung_precomp_preinv(t, b, H, f,
+                                                                    finv, ctx);
+                fmpz_mod_poly_add(b, b, t, ctx);
+            }
+            else if (fmpz_mod_poly_is_zero(a, ctx))
+            {
+                fmpz_mod_poly_swap(a, b, ctx);
+                fmpz_mod_poly_compose_mod_brent_kung_precomp_preinv(b, a, H, f,
+                                                                    finv, ctx);
+                fmpz_mod_poly_add(b, b, a, ctx);
+            }
+            else
+            {
+                fmpz_mod_poly_compose_mod_brent_kung_precomp_preinv(t, a, H, f,
+                                                                    finv, ctx);
+                fmpz_mod_poly_add(a, b, t, ctx);
+                fmpz_mod_poly_compose_mod_brent_kung_precomp_preinv(t, b, H, f,
+                                                                    finv, ctx);
+                fmpz_mod_poly_add(b, b, t, ctx);
+            }
 
-        fmpz_mod_poly_factor_equal_deg(factors, f, d, ctx);
-        fmpz_mod_poly_clear(f, ctx);
-        fmpz_mod_poly_factor_equal_deg(factors, g, d, ctx);
-        fmpz_mod_poly_clear(g, ctx);
+            d = d/2;
+            if (d <= 1)
+            {
+                if (fmpz_mod_poly_is_zero(a, ctx))
+                {
+                    fmpz_mod_poly_swap(a, b, ctx);
+                    break;
+
+                }
+
+                fmpz_mod_poly_compose_mod_brent_kung_precomp_preinv(t, xi, H, f,
+                                                                    finv, ctx);
+                fmpz_mod_poly_swap(xi, t, ctx);
+
+                fmpz_mod_poly_precompute_matrix(H, xi, f, finv, ctx);
+
+                fmpz_mod_poly_compose_mod_brent_kung_precomp_preinv(t, a, H, f,
+                                                                    finv, ctx);
+                fmpz_mod_poly_add(a, t, b, ctx);
+
+                break;
+            }
+
+            fmpz_mod_poly_compose_mod(t, xi, xi, f, ctx);
+            fmpz_mod_poly_swap(xi, t, ctx);
+        }
+    }
+
+    fmpz_mat_clear(H);
+
+    FLINT_ASSERT(fmpz_mod_poly_equal(a, a_check, ctx));
+#if FLINT_WANT_ASSERT
+    fmpz_mod_poly_clear(a_check, ctx);
+#endif
+}
+
+
+/*
+    Two (non-deterministic) algorithms Algorithm 3 and Theorem 2.3.1 from
+        Deterministic Factorization of Polynomials over Finite Fields
+            thesis by David Marquis
+*/
+static void _fmpz_mod_poly_factor_equal_deg_via_trace(
+    fmpz_mod_poly_factor_t res,
+    const fmpz_mod_poly_t ff,
+    slong d,
+    const fmpz_mod_poly_t frob,
+    const fmpz_mod_ctx_t ctx)
+{
+    slong i, j, k;
+    const fmpz * p = fmpz_mod_ctx_modulus(ctx);
+    fmpz_t halfp;   /* floor((p-1)/2) */
+    slong n = fmpz_mod_poly_degree(ff, ctx);
+    slong r = n/d;
+    flint_bitcnt_t r_cutoff;
+    fmpz_mod_poly_t t, tq, tr, finv;
+    slong Qlen, Qalloc;
+    queue_struct * Q;
+    split_struct S[FLINT_BITS + 1];
+    fmpz_mod_berlekamp_massey_t bma;
+    flint_rand_t state;
+
+    FLINT_ASSERT(r > 1 && d > 1);
+
+    r_cutoff = 8*FLINT_BIT_COUNT(d + 1) + fmpz_bits(p);
+
+    res->num = 0;
+
+    flint_randinit(state);
+
+    fmpz_init(halfp);
+    fmpz_sub_ui(halfp, p, 1);
+    fmpz_fdiv_q_2exp(halfp, halfp, 1);
+
+    fmpz_mod_berlekamp_massey_init(bma, ctx);
+
+    for (i = 0; i <= FLINT_BITS; i++)
+    {
+        fmpz_mod_poly_init(S[i].f, ctx);
+        fmpz_mod_poly_init(S[i].xp, ctx);
+        fmpz_mod_poly_init(S[i].a, ctx);
+        fmpz_mod_poly_init(S[i].g, ctx);
+    }
+
+    fmpz_mod_poly_init(t, ctx);
+    fmpz_mod_poly_init(tq, ctx);
+    fmpz_mod_poly_init(tr, ctx);
+    fmpz_mod_poly_init(finv, ctx);
+
+    Qalloc = 1;
+    Q = FLINT_ARRAY_ALLOC(Qalloc, queue_struct);
+    for (j = 0; j < Qalloc; j++)
+    {
+        fmpz_mod_poly_init(Q[j].f, ctx);
+        fmpz_mod_poly_init(Q[j].xp, ctx);
+    }
+
+    fmpz_mod_poly_set(Q[0].f, ff, ctx);
+    fmpz_mod_poly_set(Q[0].xp, frob, ctx);
+    Qlen = 1;
+
+    /* init done */
+
+next_queued:
+
+    /* try to factor Q[end].f */
+    Qlen--;
+    if (Qlen < 0)
+        goto cleanup;
+
+    n = fmpz_mod_poly_degree(Q[Qlen].f, ctx);
+    r = n/d;
+
+    FLINT_ASSERT(n == r*d);
+    FLINT_ASSERT(r > 1);
+
+    fmpz_mod_poly_swap(S->f, Q[Qlen].f, ctx);
+    fmpz_mod_poly_swap(S->xp, Q[Qlen].xp, ctx);
+    fmpz_mod_poly_reverse(finv, S->f, S->f->length, ctx);
+    fmpz_mod_poly_inv_series_newton(finv, finv, S->f->length, ctx);
+
+#if FLINT_WANT_ASSERT
+    fmpz_mod_poly_powmod_x_fmpz_preinv(tq, p, S->f, finv, ctx);
+    FLINT_ASSERT(fmpz_mod_poly_equal(S->xp, tq, ctx));
+#endif
+
+next_alpha:
+
+    fmpz_mod_poly_randtest(t, state, S->f->length - 1, ctx);
+    _compute_trace(S->a, t, d, S->xp, S->f, finv, ctx, tq, tr);
+    if (fmpz_mod_poly_degree(S->a, ctx) < 1)
+        goto next_alpha;
+
+    if (r > r_cutoff)
+    {
+        if (fmpz_is_zero(halfp))
+            fmpz_mod_poly_set(tr, S->a, ctx);
+        else
+            fmpz_mod_poly_powmod_fmpz_binexp_preinv(tr, S->a, halfp,
+                                                              S->f, finv, ctx);
+        fmpz_mod_poly_sub_si(tr, tr, 1, ctx);
+        fmpz_mod_poly_gcd(t, tr, S->f, ctx);
+        if (t->length <= 1 || t->length >= S->f->length)
+            goto next_alpha;
+
+        _add_split(res, &Q, &Qlen, &Qalloc, S->f, t, d, S->xp, ctx, tr);
+        goto next_queued;
+    }
+
+    /*
+        If r is not too big, try the "deterministic simplification" to root
+        finding. Instead of constructing h(y) = Res_x(f(x), a(x) - y), find
+        probablistically a non-trivial divisor g of h, which is good enough.
+        If p is large, g^d = h is likely.
+    */
+    fmpz_mod_berlekamp_massey_start_over(bma, ctx);
+    fmpz_mod_poly_one(t, ctx);
+    fmpz_mod_berlekamp_massey_add_point_ui(bma, 1, ctx);
+    for (i = 1; i < 2*r; i++)
+    {
+        fmpz_mod_poly_mulmod_preinv(tq, t, S->a, S->f, finv, ctx);
+        fmpz_mod_poly_swap(t, tq, ctx);
+        FLINT_ASSERT(t->length > 0);
+        fmpz_mod_berlekamp_massey_add_point(bma, t->coeffs + 0, ctx);
+    }
+
+    /* something went wrong if V does not kill the whole sequence */
+    fmpz_mod_berlekamp_massey_reduce(bma, ctx);
+    FLINT_ASSERT(bma->R1->length < bma->V1->length);
+
+    fmpz_mod_poly_make_monic(S->g, bma->V1, ctx);
+
+    /* S->g should be squarefree and factor into linears */
+    FLINT_ASSERT(1 <= fmpz_mod_poly_degree(S->g, ctx));
+    FLINT_ASSERT(fmpz_mod_poly_degree(S->g, ctx) <= r);
+#if FLINT_WANT_ASSERT
+    fmpz_mod_poly_gen(t, ctx);
+    fmpz_mod_poly_powmod_fmpz_binexp(tq, t, p, S->g, ctx);
+    fmpz_mod_poly_sub(tq, tq, t, ctx);
+    fmpz_mod_poly_gcd(t, tq, S->g, ctx);
+    FLINT_ASSERT(fmpz_mod_poly_equal(t, S->g, ctx));
+#endif
+
+    /* split S->g into linears and split S->f along the way */
+    k = 1;
+    while (k > 0)
+    {
+        k--;
+        FLINT_ASSERT(k + 1 < FLINT_BITS);
+        FLINT_ASSERT(fmpz_mod_poly_degree(S[k].g, ctx) >= 1);
+
+        if (fmpz_mod_poly_degree(S[k].g, ctx) < 2)
+        {
+            if (fmpz_mod_poly_degree(S[k].f, ctx) == d)
+            {
+                fmpz_mod_poly_factor_fit_length(res, res->num + 1, ctx);
+                res->exp[res->num] = 1;
+                fmpz_mod_poly_set(res->poly + res->num, S[k].f, ctx);
+                res->num++;
+            }
+            else if (fmpz_mod_poly_degree(S[k].f, ctx) > d)
+            {
+                FLINT_ASSERT(S[k].g->length == 2);
+                fmpz_mod_poly_scalar_mul_fmpz(tr, S[k].a, S[k].g->coeffs + 1, ctx);
+                fmpz_mod_poly_add_fmpz(tr, S[k].a, S[k].g->coeffs + 0, ctx);
+                fmpz_mod_poly_gcd(t, tr, S[k].f, ctx);
+                _add_split(res, &Q, &Qlen, &Qalloc, S[k].f, t, d, S[k].xp, ctx, tr);
+            }
+            continue;
+        }
+
+        if (fmpz_mod_poly_is_zero(finv, ctx))
+        {
+            fmpz_mod_poly_reverse(finv, S[k].f, S[k].f->length, ctx);
+            fmpz_mod_poly_inv_series_newton(finv, finv, S[k].f->length, ctx);
+        }
+
+        fmpz_mod_poly_swap(t, S[k].g, ctx);
+        _fmpz_mod_poly_split_rabin(S[k+0].g, S[k+1].g, t, halfp,
+                                                           tq, tr, state, ctx);
+        fmpz_mod_poly_compose_mod_brent_kung_preinv(tr, S[k+1].g, S[k].a,
+                                                            S[k].f, finv, ctx);
+        fmpz_mod_poly_gcd(t, tr, S[k].f, ctx);
+        fmpz_mod_poly_divrem(tq, tr, S[k].f, t, ctx);
+        fmpz_mod_poly_swap(S[k+0].f, tq, ctx);
+        fmpz_mod_poly_swap(S[k+1].f, t, ctx);
+        fmpz_mod_poly_zero(finv, ctx); /* finv no longer inv(S[0].f) */
+
+        fmpz_mod_poly_divrem(tq, S[k+1].a, S[k].a, S[k+1].f, ctx);
+        fmpz_mod_poly_divrem(tq, tr, S[k].a, S[k+0].f, ctx);
+        fmpz_mod_poly_swap(S[k+0].a, tr, ctx);
+
+        fmpz_mod_poly_divrem(tq, S[k+1].xp, S[k+0].xp, S[k+1].f, ctx);
+        fmpz_mod_poly_divrem(tq, tr, S[k+0].xp, S[k+0].f, ctx);
+        fmpz_mod_poly_swap(S[k+0].xp, tr, ctx);
+
+        k += 2;
+    }
+
+    goto next_queued;
+
+cleanup:
+
+    fmpz_mod_berlekamp_massey_clear(bma, ctx);
+
+    for (i = 0; i < Qalloc; i++)
+    {
+        fmpz_mod_poly_clear(Q[i].f, ctx);
+        fmpz_mod_poly_clear(Q[i].xp, ctx);
+    }
+    flint_free(Q);
+
+    for (i = 0; i <= FLINT_BITS; i++)
+    {
+        fmpz_mod_poly_clear(S[i].f, ctx);
+        fmpz_mod_poly_clear(S[i].xp, ctx);
+        fmpz_mod_poly_clear(S[i].a, ctx);
+        fmpz_mod_poly_clear(S[i].g, ctx);
+    }
+
+    fmpz_mod_poly_clear(t, ctx);
+    fmpz_mod_poly_clear(tq, ctx);
+    fmpz_mod_poly_clear(tr, ctx);
+    fmpz_mod_poly_clear(finv, ctx);
+
+    flint_randclear(state);
+    fmpz_clear(halfp);
+
+    return;
+}
+
+void fmpz_mod_poly_factor_equal_deg_with_frob(
+    fmpz_mod_poly_factor_t factors,
+    const fmpz_mod_poly_t f,
+    slong d,
+    const fmpz_mod_poly_t frob,
+    const fmpz_mod_ctx_t ctx)
+{
+    slong r = fmpz_mod_poly_degree(f, ctx)/d;
+
+    FLINT_ASSERT(fmpz_mod_poly_degree(f, ctx) == r*d);
+
+    if (r == 1)
+    {
+        factors->num = 0;
+        fmpz_mod_poly_factor_insert(factors, f, 1, ctx);
+    }
+    else if (d == 1)
+    {
+        fmpz_mod_poly_roots(factors, f, 0, ctx);
+    }
+    else
+    {
+        _fmpz_mod_poly_factor_equal_deg_via_trace(factors, f, d, frob, ctx);
+    }
+}
+
+void fmpz_mod_poly_factor_equal_deg(
+    fmpz_mod_poly_factor_t factors,
+    const fmpz_mod_poly_t f,
+    slong d,
+    const fmpz_mod_ctx_t ctx)
+{
+    slong r = fmpz_mod_poly_degree(f, ctx)/d;
+
+    FLINT_ASSERT(fmpz_mod_poly_degree(f, ctx) == r*d);
+
+    if (r == 1)
+    {
+        factors->num = 0;
+        fmpz_mod_poly_factor_insert(factors, f, 1, ctx);
+    }
+    else if (d == 1)
+    {
+        fmpz_mod_poly_roots(factors, f, 0, ctx);
+    }
+    else
+    {
+        fmpz_mod_poly_t xp, t;
+        fmpz_mod_poly_init(xp, ctx);
+        fmpz_mod_poly_init(t, ctx);
+        fmpz_mod_poly_reverse(t, f, f->length, ctx);
+        fmpz_mod_poly_inv_series_newton(t, t, f->length, ctx);
+        fmpz_mod_poly_powmod_x_fmpz_preinv(xp, fmpz_mod_ctx_modulus(ctx), f, t, ctx);
+        fmpz_mod_poly_clear(t, ctx);
+        _fmpz_mod_poly_factor_equal_deg_via_trace(factors, f, d, xp, ctx);
+        fmpz_mod_poly_clear(xp, ctx);
     }
 }

--- a/fmpz_mod_poly_factor/factor_equal_deg_prob.c
+++ b/fmpz_mod_poly_factor/factor_equal_deg_prob.c
@@ -22,7 +22,7 @@ fmpz_mod_poly_factor_equal_deg_prob(fmpz_mod_poly_t factor, flint_rand_t state,
 {
     const fmpz * p = fmpz_mod_ctx_modulus(ctx);
     fmpz_mod_poly_t a, b, c, polinv;
-    fmpz_t exp, t;
+    fmpz_t exp;
     int res = 1;
     slong i;
 
@@ -61,7 +61,6 @@ fmpz_mod_poly_factor_equal_deg_prob(fmpz_mod_poly_t factor, flint_rand_t state,
         fmpz_pow_ui(exp, p, d);
         fmpz_sub_ui(exp, exp, 1);
         fmpz_fdiv_q_2exp(exp, exp, 1);
-
         fmpz_mod_poly_powmod_fmpz_binexp_preinv(b, a, exp, pol, polinv, ctx);
     }
     else
@@ -81,12 +80,7 @@ fmpz_mod_poly_factor_equal_deg_prob(fmpz_mod_poly_t factor, flint_rand_t state,
     }
     fmpz_clear(exp);
 
-    fmpz_init(t);
-    fmpz_sub_ui(t, &(b->coeffs[0]), 1);
-    fmpz_mod(t, t, p);
-    fmpz_mod_poly_set_coeff_fmpz(b, 0, t, ctx);
-    fmpz_clear(t);
-
+    fmpz_mod_poly_sub_si(b, b, 1, ctx);
     fmpz_mod_poly_gcd(factor, b, pol, ctx);
 
     if ((factor->length <= 1) || (factor->length == pol->length))

--- a/fmpz_mod_poly_factor/factor_kaltofen_shoup.c
+++ b/fmpz_mod_poly_factor/factor_kaltofen_shoup.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2012 Lina Kulakova
+    Copyright (C) 2020 Daniel Schultz
 
     This file is part of FLINT.
 
@@ -17,60 +18,66 @@ void
 fmpz_mod_poly_factor_kaltofen_shoup(fmpz_mod_poly_factor_t res,
                           const fmpz_mod_poly_t poly, const fmpz_mod_ctx_t ctx)
 {
-    fmpz_mod_poly_t v;
-    fmpz_mod_poly_factor_t sq_free, dist_deg;
-    slong i, j, k, l, res_num, dist_deg_num;
-    slong *degs;
+    slong i, j, k;
+    slong num_threads = flint_get_num_threads();
+    fmpz_mod_poly_t t, DDxp, EDxp;
+    fmpz_mod_poly_factor_t SF, DD, ED;
 
-    fmpz_mod_poly_init(v, ctx);
+    res->num = 0;
 
-    fmpz_mod_poly_make_monic(v, poly, ctx);
+    fmpz_mod_poly_init(t, ctx);
+    fmpz_mod_poly_make_monic(t, poly, ctx);
     
     if (poly->length <= 2)
     {
-        fmpz_mod_poly_factor_insert(res, v, 1, ctx);
-        fmpz_mod_poly_clear(v, ctx);
+        fmpz_mod_poly_factor_insert(res, t, 1, ctx);
+        fmpz_mod_poly_clear(t, ctx);
         return;        
     }
-    
-    if (!(degs = flint_malloc(fmpz_mod_poly_degree(poly, ctx) * sizeof(slong))))
+
+    fmpz_mod_poly_init(DDxp, ctx);
+    fmpz_mod_poly_init(EDxp, ctx);
+    fmpz_mod_poly_factor_init(SF, ctx);
+    fmpz_mod_poly_factor_init(DD, ctx);
+    fmpz_mod_poly_factor_init(ED, ctx);
+
+    fmpz_mod_poly_factor_squarefree(SF, t, ctx);
+    for (i = 0; i < SF->num; i++)
     {
-        flint_printf("Exception (fmpz_mod_poly_factor_kaltofen_shoup): \n");
-        flint_printf("Not enough memory.\n");
-        flint_abort();
-    }
+        fmpz_mod_poly_struct * f = SF->poly + i;
 
-    /* compute squarefree factorisation */
-    fmpz_mod_poly_factor_init(sq_free, ctx);
-    fmpz_mod_poly_factor_squarefree(sq_free, v, ctx);
+        fmpz_mod_poly_reverse(t, f, f->length, ctx);
+        fmpz_mod_poly_inv_series_newton(t, t, f->length, ctx);
+        fmpz_mod_poly_powmod_x_fmpz_preinv(DDxp, fmpz_mod_ctx_modulus(ctx), f, t, ctx);
 
-    /* compute distinct-degree factorisation */
-    fmpz_mod_poly_factor_init(dist_deg, ctx);
-    for (i = 0; i < sq_free->num; i++)
-    {
-        dist_deg_num = dist_deg->num;
-
-        if ((flint_get_num_threads() > 1) &&
-            ((sq_free->poly + i)->length > (1024*flint_get_num_threads())/4))
-            fmpz_mod_poly_factor_distinct_deg_threaded(dist_deg,
-                                                sq_free->poly + i, &degs, ctx);
+        /*
+            TODO Since there is a fair amount of code duplicated in the
+            threaded version, the two functions should be combined into one.
+        */
+        if (num_threads > 1 && f->length > 256*num_threads)
+            fmpz_mod_poly_factor_distinct_deg_threaded_with_frob(DD, f, t, DDxp, ctx);
         else
-            fmpz_mod_poly_factor_distinct_deg(dist_deg, sq_free->poly + i,
-                                              &degs, ctx);
+            fmpz_mod_poly_factor_distinct_deg_with_frob(DD, f, t, DDxp, ctx);
 
-        /* compute equal-degree factorisation */
-        for (j = dist_deg_num, l = 0; j < dist_deg->num; j++, l++)
+        for (j = 0; j < DD->num; j++)
         {
-            res_num = res->num;
-
-            fmpz_mod_poly_factor_equal_deg(res, dist_deg->poly + j, degs[l], ctx);
-            for (k = res_num; k < res->num; k++)
-                res->exp[k] = fmpz_mod_poly_remove(v, res->poly + k, ctx);
+            fmpz_mod_poly_divrem(t, EDxp, DDxp, DD->poly + j, ctx);
+            fmpz_mod_poly_factor_equal_deg_with_frob(ED, DD->poly + j,
+                                                        DD->exp[j], EDxp, ctx);
+            fmpz_mod_poly_factor_fit_length(res, ED->num, ctx);
+            for (k = 0; k < ED->num; k++)
+            {
+                fmpz_mod_poly_swap(res->poly + res->num, ED->poly + k, ctx);
+                res->exp[res->num] = SF->exp[i];
+                res->num++;
+            }
         }
     }
 
-    flint_free(degs);
-    fmpz_mod_poly_clear(v, ctx);
-    fmpz_mod_poly_factor_clear(dist_deg, ctx);
-    fmpz_mod_poly_factor_clear(sq_free, ctx);
+    fmpz_mod_poly_clear(t, ctx);
+    fmpz_mod_poly_clear(DDxp, ctx);
+    fmpz_mod_poly_clear(EDxp, ctx);
+    fmpz_mod_poly_factor_clear(SF, ctx);
+    fmpz_mod_poly_factor_clear(DD, ctx);
+    fmpz_mod_poly_factor_clear(ED, ctx);
 }

--- a/fmpz_mod_poly_factor/factor_squarefree.c
+++ b/fmpz_mod_poly_factor/factor_squarefree.c
@@ -24,11 +24,10 @@ fmpz_mod_poly_factor_squarefree(fmpz_mod_poly_factor_t res,
     fmpz_t x;
     slong deg, i, p_ui;
 
+    res->num = 0;
+
     if (f->length <= 1)
-    {
-        res->num = 0;
         return;
-    }
 
     if (f->length == 2)
     {

--- a/fmpz_mod_poly_factor/profile/p-factor_equal_deg.c
+++ b/fmpz_mod_poly_factor/profile/p-factor_equal_deg.c
@@ -1,0 +1,108 @@
+/*
+    Copyright (C) 2020 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "fmpz_mod_poly.h"
+#include "profiler.h"
+
+int main(void)
+{
+    slong i, j, d, r;
+    flint_rand_t state;
+    fmpz_t p, t;
+    fmpz_mod_ctx_t ctx;
+    fmpz_mod_poly_t a, b, c;
+    fmpz_mod_poly_factor_t f;
+    timeit_t timer;
+
+    flint_randinit(state);
+    fmpz_init_set_ui(p, 1);
+    fmpz_init(t);
+    fmpz_mod_ctx_init(ctx, p);
+    fmpz_mod_poly_init(a, ctx);
+    fmpz_mod_poly_init(b, ctx);
+    fmpz_mod_poly_init(c, ctx);
+    fmpz_mod_poly_factor_init(f, ctx);
+
+    while (fmpz_bits(p) < 100)
+    {
+        if (fmpz_cmp_ui(p, 10) > 0)
+        {
+            fmpz_sqrt(t, p);
+            fmpz_sqrt(t, t);
+            fmpz_sqrt(t, t);
+            fmpz_add_ui(t, t, 1);
+            fmpz_mul(p, p, t);
+        }
+        fmpz_nextprime(p, p, 0);
+        fmpz_mod_ctx_set_modulus(ctx, p);
+
+        flint_printf("++++++++++ p = ");
+        fmpz_print(p);
+        flint_printf(" ++++++++++\n");
+
+        for (d = 2; d <= 5; d++)
+        {
+            flint_printf("d = %wd: ", d);
+            fmpz_mod_poly_randtest_monic_irreducible(a, state, d + 1, ctx);
+            for (r = 1; r <= 10; r++)
+            {
+                slong reps = a->length + 1;
+                reps = 1000000/reps/reps/fmpz_bits(p);
+
+                fmpz_mod_poly_randtest_monic_irreducible(b, state, d + 1, ctx);
+                fmpz_mod_poly_mul(a, a, b, ctx);
+
+                timeit_start(timer);
+                for (i = 0; i <= reps; i++)
+                    fmpz_mod_poly_factor(f, a, ctx);
+                timeit_stop(timer);
+
+                flint_printf(" %06wd", timer->wall*100/reps);
+                fflush(stdout);
+
+                fmpz_mod_poly_one(c, ctx);
+                for (i = 0; i < f->num; i++)
+                {
+                    if (fmpz_mod_poly_degree(f->poly + i, ctx) != d)
+                    {
+                        flint_printf("!!! oops !!!");
+                        flint_abort();
+                    }
+
+                    for (j = 0; j < f->exp[i]; j++)
+                        fmpz_mod_poly_mul(c, c, f->poly + i, ctx);
+                }
+
+                if (!fmpz_mod_poly_equal(c, a, ctx))
+                {
+                    flint_printf("!!! oops !!!");
+                    flint_abort();
+                }
+            }
+
+            flint_printf("\n");
+        }
+    }
+
+    fmpz_mod_poly_clear(a, ctx);
+    fmpz_mod_poly_clear(b, ctx);
+    fmpz_mod_poly_clear(c, ctx);
+    fmpz_mod_poly_factor_clear(f, ctx);
+    fmpz_mod_ctx_clear(ctx);
+    fmpz_clear(p);
+    fmpz_clear(t);
+    flint_randclear(state);
+
+    return 0;
+}
+

--- a/fmpz_mod_poly_factor/roots.c
+++ b/fmpz_mod_poly_factor/roots.c
@@ -96,18 +96,12 @@ static void _fmpz_mod_poly_push_roots(
     fmpz_mod_poly_inv_series_newton(t2, t, t->length, ctx);
 
     a = stack + 0;
-    fmpz_mod_poly_zero(a, ctx);
-    fmpz_mod_poly_set_coeff_ui(a, 1, 1, ctx);
-    fmpz_mod_poly_powmod_fmpz_binexp_preinv(t, a, halfp, f, t2, ctx);
-    fmpz_mod_poly_zero(a, ctx);
-    fmpz_mod_poly_set_coeff_ui(a, 0, 1, ctx);
-    fmpz_mod_poly_sub(t, t, a, ctx);
+    fmpz_mod_poly_powmod_x_fmpz_preinv(t, halfp, f, t2, ctx);
+    fmpz_mod_poly_sub_si(t, t, 1, ctx);
     fmpz_mod_poly_gcd(a, t, f, ctx);
 
     b = stack + 1;
-    fmpz_mod_poly_zero(b, ctx);
-    fmpz_mod_poly_set_coeff_ui(b, 0, 2, ctx);
-    fmpz_mod_poly_add(t, t, b, ctx);
+    fmpz_mod_poly_add_si(t, t, 2, ctx);
     fmpz_mod_poly_gcd(b, t, f, ctx);
 
     /* ensure deg a >= deg b */
@@ -191,11 +185,13 @@ void fmpz_mod_poly_roots(fmpz_mod_poly_factor_t r, const fmpz_mod_poly_t f,
     for (i = 0; i < FLINT_BITS + 3; i++)
         fmpz_mod_poly_init(t + i, ctx);
 
+    fmpz_mod_poly_make_monic(t + 0, f, ctx);
+
     if (with_mult)
     {
         fmpz_mod_poly_factor_t sqf;
         fmpz_mod_poly_factor_init(sqf, ctx);
-        fmpz_mod_poly_factor_squarefree(sqf, f, ctx);
+        fmpz_mod_poly_factor_squarefree(sqf, t + 0, ctx);
         for (i = 0; i < sqf->num; i++)
         {
             _fmpz_mod_poly_push_roots(r, sqf->poly + i, sqf->exp[i],
@@ -205,7 +201,6 @@ void fmpz_mod_poly_roots(fmpz_mod_poly_factor_t r, const fmpz_mod_poly_t f,
     }
     else
     {
-        fmpz_mod_poly_make_monic(t + 0, f, ctx);
         _fmpz_mod_poly_push_roots(r, t + 0, 1,
                                       p2, t + 1, t + 2, t + 3, randstate, ctx);
     }

--- a/fmpz_mod_poly_factor/test/t-factor_distinct_deg_threaded.c
+++ b/fmpz_mod_poly_factor/test/t-factor_distinct_deg_threaded.c
@@ -20,7 +20,7 @@
 #include "flint.h"
 #include "thread_support.h"
 
-#define MAX_DEG 7
+#define MAX_DEG 9
 
 int main(void)
 {
@@ -37,7 +37,7 @@ int main(void)
 
     fmpz_mod_ctx_init_ui(ctx, 2);
 
-    for (iter = 0; iter < 20 * flint_test_multiplier(); iter++)
+    for (iter = 0; iter < 50 * flint_test_multiplier(); iter++)
     {
         fmpz_mod_poly_t poly1, poly, q, r, product;
         fmpz_mod_poly_factor_t res;
@@ -53,7 +53,7 @@ int main(void)
         fmpz_set_ui(modulus, n_randtest_prime(state, 0));
         fmpz_mod_ctx_set_modulus(ctx, modulus);
 
-        flint_set_num_threads(1 + n_randint(state, 3));
+        flint_set_num_threads(1 + n_randint(state, 5));
 
         fmpz_mod_poly_init(poly1, ctx);
         fmpz_mod_poly_init(poly, ctx);
@@ -76,7 +76,7 @@ int main(void)
 
         num_of_deg[fmpz_mod_poly_degree(poly, ctx)]++;
 
-        num = n_randint(state, 5) + 1;
+        num = n_randint(state, 10) + 1;
 
         for (i = 1; i < num; i++)
         {

--- a/fmpz_mpoly/interp.c
+++ b/fmpz_mpoly/interp.c
@@ -289,7 +289,7 @@ void fmpz_mpoly_interp_lift_p_mpolyn(
     slong Ai;
     slong var = ctx->minfo->nvars;
 
-    FLINT_ASSERT(var = pctx->minfo->nvars);
+    FLINT_ASSERT(var == pctx->minfo->nvars);
 
     fmpz_mpoly_fit_length(A, Blen, ctx);
     Acoeff = A->coeffs;


### PR DESCRIPTION
should solve https://github.com/wbhart/flint2/issues/832
The old code was using norms (and traces only for p=2) and was calculating it with a particularly slow method.
The new code uses traces in all cases, and the old code is still there.
Also, I removed the behavior in https://github.com/wbhart/flint2/issues/811 for fmpz_mod_poly_factor.