### PR TITLE
disable -ansi flag for fdopen tests

### DIFF
--- a/fmpq_poly/test/t-print_read.c
+++ b/fmpq_poly/test/t-print_read.c
@@ -9,6 +9,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+/* try to get fdopen declared */
+#if defined __STRICT_ANSI__
+#undef __STRICT_ANSI__
+#endif
+
 #include <sys/types.h>
 #if (!defined (__WIN32) || defined(__CYGWIN__)) && !defined(_MSC_VER) 
 #include <unistd.h>

--- a/fmpz/test/t-out_inp_raw.c
+++ b/fmpz/test/t-out_inp_raw.c
@@ -10,6 +10,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+/* try to get fdopen declared */
+#if defined __STRICT_ANSI__
+#undef __STRICT_ANSI__
+#endif
+
 #undef ulong
 #define ulong ulongxx /* interferes with standard libraries */
 #include <sys/types.h>

--- a/fmpz/test/t-print_read.c
+++ b/fmpz/test/t-print_read.c
@@ -9,6 +9,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+/* try to get fdopen declared */
+#if defined __STRICT_ANSI__
+#undef __STRICT_ANSI__
+#endif
+
 #include <sys/types.h>
 #if (!defined (__WIN32) || defined(__CYGWIN__)) && !defined(_MSC_VER) 
 #include <unistd.h>

--- a/fmpz_mat/test/t-print_read.c
+++ b/fmpz_mat/test/t-print_read.c
@@ -9,6 +9,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+/* try to get fdopen declared */
+#if defined __STRICT_ANSI__
+#undef __STRICT_ANSI__
+#endif
+
 #include <sys/types.h>
 #if (!defined (__WIN32) || defined(__CYGWIN__)) && !defined(_MSC_VER) 
 #include <unistd.h>

--- a/fmpz_mod_poly/test/t-print_read.c
+++ b/fmpz_mod_poly/test/t-print_read.c
@@ -9,6 +9,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+/* try to get fdopen declared */
+#if defined __STRICT_ANSI__
+#undef __STRICT_ANSI__
+#endif
+
 #include <sys/types.h>
 #if (!defined (__WIN32) || defined(__CYGWIN__)) && !defined(_MSC_VER) 
 #include <unistd.h>

--- a/fmpz_poly/test/t-print_read.c
+++ b/fmpz_poly/test/t-print_read.c
@@ -9,6 +9,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+/* try to get fdopen declared */
+#if defined __STRICT_ANSI__
+#undef __STRICT_ANSI__
+#endif
+
 #include <sys/types.h>
 #if (!defined (__WIN32) || defined(__CYGWIN__)) && !defined(_MSC_VER) 
 #include <unistd.h>

--- a/fmpz_poly/test/t-print_read_pretty.c
+++ b/fmpz_poly/test/t-print_read_pretty.c
@@ -9,6 +9,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+/* try to get fdopen declared */
+#if defined __STRICT_ANSI__
+#undef __STRICT_ANSI__
+#endif
+
 #include <sys/types.h>
 #if (!defined (__WIN32) || defined(__CYGWIN__)) && !defined(_MSC_VER) 
 #include <unistd.h>


### PR DESCRIPTION
@videlec @wbhart I hope this is an acceptable solution. The tests were failing before.
closes https://github.com/wbhart/flint2/issues/847, closes https://github.com/wbhart/flint2/issues/864