### PR TITLE
CMakeLists.txt: support standard GNU installation directories.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,10 +296,12 @@ if(NOT MSVC)
 	target_link_libraries(flint PUBLIC m)
 endif()
 
+include(GNUInstallDirs)
+
 install(TARGETS flint
-            RUNTIME DESTINATION bin
-            ARCHIVE DESTINATION lib
-            LIBRARY DESTINATION lib
+            RUNTIME DESTINATION "${CMAKE_INSTALL_FULL_BINDIR}"
+            ARCHIVE DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}"
+            LIBRARY DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}"
         )
 
 install(FILES ${HEADERS} DESTINATION include/flint)


### PR DESCRIPTION
Modern systems have varied naming schemes for their 32- and 64-bit
library directories. For example, Gentoo uses /usr/lib for 32-bit
libraries and /usr/lib64 for 64-bit libraries. The current default of
"lib" in CMakeLists.txt is therefore inappropriate in the common case
of a 64-bit build on Gentoo. Debian makes a similar (but different)
distinction.

This commit uses the GNUInstallDirs module to determine the library
directory, as well as all of the other standard GNU installation
directories. A sensible default exists, but the user now has the
ability to override these directories with the values appropriate for
his system. Distributions, in particular, can pass these values to the
build system in a consistent way.