### PR TITLE
Fix stack overflow in sort

### DIFF
--- a/fmpz_mpoly/mul_dense.c
+++ b/fmpz_mpoly/mul_dense.c
@@ -207,26 +207,14 @@ void fmpz_mpoly_consume_fmpz_mpolyd_clear(fmpz_mpoly_t A, fmpz_mpolyd_t B,
     /* sort the exponents if needed */
     if (ctx->minfo->ord != ORD_LEX)
     {
-        slong msb;
+        flint_bitcnt_t pos;
         mpoly_get_cmpmask(ptempexp, N, bits, ctx->minfo);
-        if (topmask != WORD(0))
-        {
-            count_leading_zeros(msb, topmask);
-            msb = (FLINT_BITS - 1)^msb;
-        } else
-        {
-            msb = -WORD(1);
-        }
-        if (N == 1) {
-            if (msb >= WORD(0))
-            {
-                _fmpz_mpoly_radix_sort1(A, 0, A->length,
-                                                   msb, ptempexp[0], topmask);
-            }
-        } else {
+        pos = FLINT_BIT_COUNT(topmask);
+        if (N == 1)
+            _fmpz_mpoly_radix_sort1(A, 0, A->length, pos, ptempexp[0], topmask);
+        else
             _fmpz_mpoly_radix_sort(A, 0, A->length,
-                                        (N - 1)*FLINT_BITS + msb, N, ptempexp);
-        }
+                                        (N - 1)*FLINT_BITS + pos, N, ptempexp);
     }
 
     flint_free(B->deg_bounds);

--- a/fmpz_mpoly/sort_terms.c
+++ b/fmpz_mpoly/sort_terms.c
@@ -11,118 +11,152 @@
 
 #include "fmpz_mpoly.h"
 
-
 /*
     sort terms in [left, right) by exponent
-    assuming that bits in position > pos are already sorted
+    assuming that bits in position >= pos are already sorted
     and assuming exponent vectors fit into one word
     and assuming that all bit positions that need to be sorted are in totalmask
 */
 void _fmpz_mpoly_radix_sort1(fmpz_mpoly_t A, slong left, slong right,
-                               flint_bitcnt_t pos, ulong cmpmask, ulong totalmask)
+                            flint_bitcnt_t pos, ulong cmpmask, ulong totalmask)
 {
-    ulong mask = UWORD(1) << pos;
-    ulong cmp = cmpmask & mask;
+    ulong mask, cmp;
     slong mid, cur;
 
-    FLINT_ASSERT(left <= right);
-    FLINT_ASSERT(pos < FLINT_BITS);
-
-    /* do nothing on lists of 0 or 1 elements */
-    if (left + 1 >= right)
+    while (pos > 0)
     {
-        return;
-    }
+        pos--;
 
-    /* return if there is no information to sort on this bit */
-    if ((totalmask & mask) == WORD(0))
-    {
-        --pos;
-        if ((slong)(pos) >= 0)
+        FLINT_ASSERT(left <= right);
+        FLINT_ASSERT(pos < FLINT_BITS);
+
+        mask = UWORD(1) << pos;
+        cmp = cmpmask & mask;
+
+        /* insertion base case */
+        if (right - left < 20)
         {
-            _fmpz_mpoly_radix_sort1(A, left,  right, pos, cmpmask, totalmask);
+            slong i, j;
+
+            for (i = left + 1; i < right; i++)
+            {
+                for (j = i; j > left && mpoly_monomial_gt1(A->exps[j],
+                                                 A->exps[j - 1], cmpmask); j--)
+                {
+                    fmpz_swap(A->coeffs + j, A->coeffs + j - 1);
+                    ULONG_SWAP(A->exps[j], A->exps[j - 1]);
+                }
+            }
+
+            return;
         }
-        return;
-    }
 
-    /* find first 'zero' */
-    mid = left;
-    while (mid < right && ((A->exps + 1*mid)[0] & mask) != cmp)
-    {
-        mid++;
-    }
+        /* return if there is no information to sort on this bit */
+        if ((totalmask & mask) == 0)
+            continue;
 
-    /* make sure [left,mid)  doesn't match cmpmask in position pos 'one'
-                 [mid,right)    does match cmpmask in position pos 'zero' */
-    cur = mid;
-    while (++cur < right)
-    {
-        if (((A->exps + 1*cur)[0] & mask) != cmp)
-        {
-            fmpz_swap(A->coeffs + cur, A->coeffs + mid);
-            mpoly_monomial_swap(A->exps + 1*cur, A->exps + 1*mid, 1);
+        /* find first 'zero' */
+        mid = left;
+        while (mid < right && (A->exps[mid] & mask) != cmp)
             mid++;
-        }
-    }
 
-    --pos;
-    if ((slong)(pos) >= 0)
-    {
-        _fmpz_mpoly_radix_sort1(A, left,  mid, pos, cmpmask, totalmask);
-        _fmpz_mpoly_radix_sort1(A, mid, right, pos, cmpmask, totalmask);
+        /* make sure [left,mid)  doesn't match cmpmask in position pos 'one'
+                     [mid,right)    does match cmpmask in position pos 'zero' */
+        cur = mid;
+        while (++cur < right)
+        {
+            if ((A->exps[cur] & mask) != cmp)
+            {
+                fmpz_swap(A->coeffs + cur, A->coeffs + mid);
+                ULONG_SWAP(A->exps[cur], A->exps[mid]);
+                mid++;
+            }
+        }
+
+        if (mid - left < right - mid)
+        {
+            _fmpz_mpoly_radix_sort1(A, left, mid, pos, cmpmask, totalmask);
+            left = mid;
+        }
+        else
+        {
+            _fmpz_mpoly_radix_sort1(A, mid, right, pos, cmpmask, totalmask);
+            right = mid;
+        }
     }
 }
 
 
 /*
     sort terms in [left, right) by exponent
-    assuming that bits in position > pos are already sorted
-
-    TODO: Stack depth is proportional to N*FLINT_BITS
-            Might turn into iterative version
-            Low priority
+    assuming that bits in position >= pos are already sorted
 */
 void _fmpz_mpoly_radix_sort(fmpz_mpoly_t A, slong left, slong right,
-                                     flint_bitcnt_t pos, slong N, ulong * cmpmask)
+                                  flint_bitcnt_t pos, slong N, ulong * cmpmask)
 {
-    ulong off = pos/FLINT_BITS;
-    ulong bit = pos%FLINT_BITS;
-    ulong mask = UWORD(1) << bit;
-    ulong cmp = cmpmask[off] & mask;
+    ulong off, bit, mask, cmp;
     slong mid, check;
 
-    FLINT_ASSERT(left <= right);
-    FLINT_ASSERT(pos < N*FLINT_BITS);
-
-    /* do nothing on lists of 0 or 1 elements */
-    if (left + 1 >= right)
-        return;
-
-    /* find first 'zero' */
-    mid = left;
-    while (mid < right && ((A->exps+N*mid)[off] & mask) != cmp)
+    while (pos > 0)
     {
-        mid++;
-    }
+        pos--;
 
-    /* make sure [left,mid)  doesn't match cmpmask in position pos 'one'
-                 [mid,right)    does match cmpmask in position pos 'zero' */
-    check = mid;
-    while (++check < right)
-    {
-        if (((A->exps + N*check)[off] & mask) != cmp)
+        FLINT_ASSERT(left <= right);
+        FLINT_ASSERT(pos < N*FLINT_BITS);
+
+        off = pos/FLINT_BITS;
+        bit = pos%FLINT_BITS;
+        mask = UWORD(1) << bit;
+        cmp = cmpmask[off] & mask;
+
+        /* insertion base case */
+        if (right - left < 10)
         {
-            fmpz_swap(A->coeffs + check, A->coeffs + mid);
-            mpoly_monomial_swap(A->exps + N*check, A->exps + N*mid, N);
-            mid++;
-        }
-    }
+            slong i, j;
 
-    --pos;
-    if ((slong)(pos) >= 0)
-    {
-        _fmpz_mpoly_radix_sort(A, left,  mid, pos, N, cmpmask);
-        _fmpz_mpoly_radix_sort(A, mid, right, pos, N, cmpmask);
+            for (i = left + 1; i < right; i++)
+            {
+                for (j = i; j > left && mpoly_monomial_gt(A->exps + N*j,
+                                         A->exps + N*(j - 1), N, cmpmask); j--)
+                {
+                    fmpz_swap(A->coeffs + j, A->coeffs + j - 1);
+                    mpoly_monomial_swap(A->exps + N*j, A->exps + N*(j - 1), N);
+                }
+            }
+
+            return;
+        }
+
+        /* find first 'zero' */
+        mid = left;
+        while (mid < right && ((A->exps+N*mid)[off] & mask) != cmp)
+            mid++;
+
+        /* make sure [left,mid)  doesn't match cmpmask in position pos 'one'
+                     [mid,right)    does match cmpmask in position pos 'zero' */
+        check = mid;
+        while (++check < right)
+        {
+            if (((A->exps + N*check)[off] & mask) != cmp)
+            {
+                fmpz_swap(A->coeffs + check, A->coeffs + mid);
+                mpoly_monomial_swap(A->exps + N*check, A->exps + N*mid, N);
+                mid++;
+            }
+        }
+
+        FLINT_ASSERT(left <= mid && mid <= right);
+
+        if (mid - left < right - mid)
+        {
+            _fmpz_mpoly_radix_sort(A, left, mid, pos, N, cmpmask);
+            left = mid;
+        }
+        else
+        {
+            _fmpz_mpoly_radix_sort(A, mid, right, pos, N, cmpmask);
+            right = mid;
+        }
     }
 }
 
@@ -133,7 +167,8 @@ void _fmpz_mpoly_radix_sort(fmpz_mpoly_t A, slong left, slong right,
 */
 void fmpz_mpoly_sort_terms(fmpz_mpoly_t A, const fmpz_mpoly_ctx_t ctx)
 {
-    slong i, msb, N;
+    slong i, N;
+    flint_bitcnt_t pos;
     ulong himask, * ptempexp;
     TMP_INIT;
 
@@ -144,29 +179,14 @@ void fmpz_mpoly_sort_terms(fmpz_mpoly_t A, const fmpz_mpoly_ctx_t ctx)
 
     himask = 0;
     for (i = 0; i < A->length; i++)
-    {
         himask |= (A->exps + N*i)[N - 1];
-    }
 
-    if (himask != 0)
-    {
-        count_leading_zeros(msb, himask);
-        msb = (FLINT_BITS - 1)^msb;
-    } else
-    {
-        msb = -WORD(1);
-    }
-
+    pos = FLINT_BIT_COUNT(himask);
     if (N == 1)
-    {
-        if (msb >= 0)
-        {
-            _fmpz_mpoly_radix_sort1(A, 0, A->length, msb, ptempexp[0], himask);
-        }
-    } else
-    {
-        _fmpz_mpoly_radix_sort(A, 0, A->length, (N - 1)*FLINT_BITS + msb, N, ptempexp);
-    }
+        _fmpz_mpoly_radix_sort1(A, 0, A->length, pos, ptempexp[0], himask);
+    else
+        _fmpz_mpoly_radix_sort(A, 0, A->length,
+                                       (N - 1)*FLINT_BITS + pos, N, ptempexp);
 
     TMP_END;
 }

--- a/fmpz_mpoly/test/t-repack_bits.c
+++ b/fmpz_mpoly/test/t-repack_bits.c
@@ -17,7 +17,8 @@
 int
 main(void)
 {
-    int i, j, success;
+    slong i, j;
+    int success;
 
     FLINT_TEST_INIT(state);
 
@@ -25,7 +26,7 @@ main(void)
     fflush(stdout);
 
     /* Check packing up */
-    for (i = 0; i < 40 * flint_test_multiplier(); i++)
+    for (i = 0; i < 50 * flint_test_multiplier(); i++)
     {
         fmpz_mpoly_ctx_t ctx;
         fmpz_mpoly_t f, g;
@@ -36,8 +37,8 @@ main(void)
         fmpz_mpoly_init(f, ctx);
         fmpz_mpoly_init(g, ctx);
 
-        len1 = n_randint(state, 10);
-        len2 = n_randint(state, 10);
+        len1 = n_randint(state, 50);
+        len2 = n_randint(state, 50);
         exp_bits1 = n_randint(state, 100) + 2;
         exp_bits2 = n_randint(state, 100) + 2;
         coeff_bits = n_randint(state, 100);
@@ -78,7 +79,7 @@ main(void)
     }
 
     /* Check repacking down up */
-    for (i = 0; i < 40 * flint_test_multiplier(); i++)
+    for (i = 0; i < 50 * flint_test_multiplier(); i++)
     {
         fmpz_mpoly_ctx_t ctx;
         fmpz_mpoly_t f, g, h;
@@ -90,8 +91,8 @@ main(void)
         fmpz_mpoly_init(g, ctx);
         fmpz_mpoly_init(h, ctx);
 
-        len1 = n_randint(state, 10);
-        len2 = n_randint(state, 10);
+        len1 = n_randint(state, 50);
+        len2 = n_randint(state, 50);
         exp_bits1 = n_randint(state, 100) + 2;
         exp_bits2 = n_randint(state, 100) + 2;
         coeff_bits = n_randint(state, 100);
@@ -139,7 +140,7 @@ main(void)
     }
 
     /* Check packing down */
-    for (i = 0; i < 40 * flint_test_multiplier(); i++)
+    for (i = 0; i < 50 * flint_test_multiplier(); i++)
     {
         fmpz_mpoly_ctx_t ctx;
         fmpz_mpoly_t f, g;
@@ -150,8 +151,8 @@ main(void)
         fmpz_mpoly_init(f, ctx);
         fmpz_mpoly_init(g, ctx);
 
-        len1 = n_randint(state, 10);
-        len2 = n_randint(state, 10);
+        len1 = n_randint(state, 50);
+        len2 = n_randint(state, 50);
         exp_bits1 = n_randint(state, 100) + 2;
         exp_bits2 = n_randint(state, 100) + 2;
         coeff_bits = n_randint(state, 100);

--- a/fq_nmod_mpoly/test/t-repack_bits.c
+++ b/fq_nmod_mpoly/test/t-repack_bits.c
@@ -1,0 +1,201 @@
+/*
+    Copyright (C) 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "fq_nmod_mpoly.h"
+
+
+int
+main(void)
+{
+    slong i, j;
+    int success;
+
+    FLINT_TEST_INIT(state);
+
+    flint_printf("repack_bits....");
+    fflush(stdout);
+
+    /* Check packing up */
+    for (i = 0; i < 50 * flint_test_multiplier(); i++)
+    {
+        fq_nmod_mpoly_ctx_t ctx;
+        fq_nmod_mpoly_t f, g;
+        slong len1, len2;
+        flint_bitcnt_t exp_bits1, exp_bits2, newbits;
+
+        fq_nmod_mpoly_ctx_init_rand(ctx, state, 20, FLINT_BITS, 9);
+        fq_nmod_mpoly_init(f, ctx);
+        fq_nmod_mpoly_init(g, ctx);
+
+        len1 = n_randint(state, 50);
+        len2 = n_randint(state, 50);
+        exp_bits1 = n_randint(state, 100) + 2;
+        exp_bits2 = n_randint(state, 100) + 2;
+
+        for (j = 0; j < 4; j++)
+        {
+            fq_nmod_mpoly_randtest_bits(f, state, len1, exp_bits1, ctx);
+            fq_nmod_mpoly_randtest_bits(g, state, len2, exp_bits2, ctx);
+
+            newbits = g->bits + n_randint(state, 2*FLINT_BITS);
+            newbits = mpoly_fix_bits(newbits, ctx->minfo);
+            success = fq_nmod_mpoly_repack_bits(f, g, newbits, ctx);
+            fq_nmod_mpoly_assert_canonical(f, ctx);
+
+            if (!success || !fq_nmod_mpoly_equal(f, g, ctx))
+            {
+                flint_printf("FAIL\n");
+                flint_printf("Check packing up\ni: %wd  j: %wd\n", i, j);
+                flint_abort();
+            }
+
+            newbits = g->bits + n_randint(state, 2*FLINT_BITS);
+            newbits = mpoly_fix_bits(newbits, ctx->minfo);
+            success = fq_nmod_mpoly_repack_bits(g, g, newbits, ctx);
+            fq_nmod_mpoly_assert_canonical(g, ctx);
+
+            if (!success || !fq_nmod_mpoly_equal(f, g, ctx))
+            {
+                flint_printf("FAIL\n");
+                flint_printf("Check packing up with aliasing\ni: %wd  j: %wd\n", i, j);
+                flint_abort();
+            }
+        }
+
+        fq_nmod_mpoly_clear(f, ctx);
+        fq_nmod_mpoly_clear(g, ctx);
+        fq_nmod_mpoly_ctx_clear(ctx);
+    }
+
+    /* Check repacking down up */
+    for (i = 0; i < 50 * flint_test_multiplier(); i++)
+    {
+        fq_nmod_mpoly_ctx_t ctx;
+        fq_nmod_mpoly_t f, g, h;
+        slong len1, len2;
+        flint_bitcnt_t exp_bits1, exp_bits2, newbits;
+
+        fq_nmod_mpoly_ctx_init_rand(ctx, state, 20, FLINT_BITS, 9);
+        fq_nmod_mpoly_init(f, ctx);
+        fq_nmod_mpoly_init(g, ctx);
+        fq_nmod_mpoly_init(h, ctx);
+
+        len1 = n_randint(state, 50);
+        len2 = n_randint(state, 50);
+        exp_bits1 = n_randint(state, 100) + 2;
+        exp_bits2 = n_randint(state, 100) + 2;
+
+        for (j = 0; j < 4; j++)
+        {
+            fq_nmod_mpoly_randtest_bits(f, state, len1, exp_bits1, ctx);
+            fq_nmod_mpoly_randtest_bits(g, state, len2, exp_bits2, ctx);
+            fq_nmod_mpoly_randtest_bits(h, state, len2, exp_bits2, ctx);
+
+            newbits = g->bits + n_randint(state, 2*FLINT_BITS);
+            newbits = mpoly_fix_bits(newbits, ctx->minfo);
+            fq_nmod_mpoly_repack_bits(f, g, newbits, ctx);
+            fq_nmod_mpoly_assert_canonical(f, ctx);
+
+            newbits = g->bits + n_randint(state, 2*FLINT_BITS);
+            newbits = mpoly_fix_bits(newbits, ctx->minfo);
+            success = fq_nmod_mpoly_repack_bits(h, f, newbits, ctx);
+            fq_nmod_mpoly_assert_canonical(h, ctx);
+
+            if (!success || !fq_nmod_mpoly_equal(h, g, ctx))
+            {
+                flint_printf("FAIL\n");
+                flint_printf("Check repacking down\ni: %wd  j: %wd\n", i, j);
+                flint_abort();
+            }
+
+            newbits = g->bits + n_randint(state, 2*FLINT_BITS);
+            newbits = mpoly_fix_bits(newbits, ctx->minfo);
+            success = fq_nmod_mpoly_repack_bits(f, f, newbits, ctx);
+            fq_nmod_mpoly_assert_canonical(f, ctx);
+
+            if (!success || !fq_nmod_mpoly_equal(f, g, ctx))
+            {
+                flint_printf("FAIL\n");
+                flint_printf("Check repacking down with aliasing\ni: %wd  j: %wd\n", i, j);
+                flint_abort();
+            }
+        }
+
+        fq_nmod_mpoly_clear(f, ctx);
+        fq_nmod_mpoly_clear(g, ctx);
+        fq_nmod_mpoly_clear(h, ctx);
+        fq_nmod_mpoly_ctx_clear(ctx);
+    }
+
+    /* Check packing down */
+    for (i = 0; i < 50 * flint_test_multiplier(); i++)
+    {
+        fq_nmod_mpoly_ctx_t ctx;
+        fq_nmod_mpoly_t f, g;
+        slong len1, len2;
+        flint_bitcnt_t exp_bits1, exp_bits2, newbits;
+
+        fq_nmod_mpoly_ctx_init_rand(ctx, state, 20, FLINT_BITS, 9);
+        fq_nmod_mpoly_init(f, ctx);
+        fq_nmod_mpoly_init(g, ctx);
+
+        len1 = n_randint(state, 50);
+        len2 = n_randint(state, 50);
+        exp_bits1 = n_randint(state, 100) + 2;
+        exp_bits2 = n_randint(state, 100) + 2;
+
+        for (j = 0; j < 4; j++)
+        {
+            fq_nmod_mpoly_randtest_bits(f, state, len1, exp_bits1, ctx);
+            fq_nmod_mpoly_randtest_bits(g, state, len2, exp_bits2, ctx);
+
+            if (g->bits <= MPOLY_MIN_BITS)
+                continue;
+
+            newbits = n_randint(state, g->bits - MPOLY_MIN_BITS) + MPOLY_MIN_BITS;
+            newbits = mpoly_fix_bits(newbits, ctx->minfo);
+            success = fq_nmod_mpoly_repack_bits(f, g, newbits, ctx);
+            fq_nmod_mpoly_assert_canonical(f, ctx);
+
+            if (success && !fq_nmod_mpoly_equal(f, g, ctx))
+            {
+                flint_printf("FAIL\n");
+                flint_printf("Check packing down\ni: %wd  j: %wd\n", i, j);
+                flint_abort();
+            }
+
+            fq_nmod_mpoly_set(f, g, ctx);
+            newbits = n_randint(state, g->bits - MPOLY_MIN_BITS) + MPOLY_MIN_BITS;
+            newbits = mpoly_fix_bits(newbits, ctx->minfo);
+            success = fq_nmod_mpoly_repack_bits(g, g, newbits, ctx);
+            fq_nmod_mpoly_assert_canonical(g, ctx);
+
+            if (success && !fq_nmod_mpoly_equal(f, g, ctx))
+            {
+                flint_printf("FAIL\n");
+                flint_printf("Check packing down with aliasing\ni: %wd  j: %wd\n", i, j);
+                flint_abort();
+            }
+        }
+
+        fq_nmod_mpoly_clear(f, ctx);
+        fq_nmod_mpoly_clear(g, ctx);
+        fq_nmod_mpoly_ctx_clear(ctx);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+
+    flint_printf("PASS\n");
+    return 0;
+}
+

--- a/fq_zech_mpoly/sort_terms.c
+++ b/fq_zech_mpoly/sort_terms.c
@@ -14,62 +14,76 @@
 
 /*
     sort terms in [left, right) by exponent
-    assuming that bits in position > pos are already sorted
+    assuming that bits in position >= pos are already sorted
     and assuming exponent vectors fit into one word
     and assuming that all bit positions that need to be sorted are in totalmask
 */
 void _fq_zech_mpoly_radix_sort1(fq_zech_mpoly_t A, slong left, slong right,
-                               flint_bitcnt_t pos, ulong cmpmask, ulong totalmask)
+                            flint_bitcnt_t pos, ulong cmpmask, ulong totalmask)
 {
-    ulong mask = UWORD(1) << pos;
-    ulong cmp = cmpmask & mask;
+    ulong mask, cmp;
     slong mid, cur;
 
-    FLINT_ASSERT(left <= right);
-    FLINT_ASSERT(pos < FLINT_BITS);
-
-    /* do nothing on lists of 0 or 1 elements */
-    if (left + 1 >= right)
+    while (pos > 0)
     {
-        return;
-    }
+        pos--;
 
-    /* return if there is no information to sort on this bit */
-    if ((totalmask & mask) == WORD(0))
-    {
-        --pos;
-        if ((slong)(pos) >= 0)
+        FLINT_ASSERT(left <= right);
+        FLINT_ASSERT(pos < FLINT_BITS);
+
+        mask = UWORD(1) << pos;
+        cmp = cmpmask & mask;
+
+        /* insertion base case */
+        if (right - left < 20)
         {
-            _fq_zech_mpoly_radix_sort1(A, left,  right, pos, cmpmask, totalmask);
+            slong i, j;
+
+            for (i = left + 1; i < right; i++)
+            {
+                for (j = i; j > left && mpoly_monomial_gt1(A->exps[j],
+                                                 A->exps[j - 1], cmpmask); j--)
+                {
+                    fq_zech_swap(A->coeffs + j, A->coeffs + j - 1, NULL);
+                    ULONG_SWAP(A->exps[j], A->exps[j - 1]);
+                }
+            }
+
+            return;
         }
-        return;
-    }
 
-    /* find first 'zero' */
-    mid = left;
-    while (mid < right && ((A->exps + 1*mid)[0] & mask) != cmp)
-    {
-        mid++;
-    }
+        /* return if there is no information to sort on this bit */
+        if ((totalmask & mask) == 0)
+            continue;
 
-    /* make sure [left,mid)  doesn't match cmpmask in position pos 'one'
-                 [mid,right)    does match cmpmask in position pos 'zero' */
-    cur = mid;
-    while (++cur < right)
-    {
-        if (((A->exps + 1*cur)[0] & mask) != cmp)
-        {
-            fq_zech_swap(A->coeffs + cur, A->coeffs + mid, NULL);
-            mpoly_monomial_swap(A->exps + 1*cur, A->exps + 1*mid, 1);
+        /* find first 'zero' */
+        mid = left;
+        while (mid < right && (A->exps[mid] & mask) != cmp)
             mid++;
-        }
-    }
 
-    --pos;
-    if ((slong)(pos) >= 0)
-    {
-        _fq_zech_mpoly_radix_sort1(A, left,  mid, pos, cmpmask, totalmask);
-        _fq_zech_mpoly_radix_sort1(A, mid, right, pos, cmpmask, totalmask);
+        /* make sure [left,mid)  doesn't match cmpmask in position pos 'one'
+                     [mid,right)    does match cmpmask in position pos 'zero' */
+        cur = mid;
+        while (++cur < right)
+        {
+            if ((A->exps[cur] & mask) != cmp)
+            {
+                fq_zech_swap(A->coeffs + cur, A->coeffs + mid, NULL);
+                ULONG_SWAP(A->exps[cur], A->exps[mid]);
+                mid++;
+            }
+        }
+
+        if (mid - left < right - mid)
+        {
+            _fq_zech_mpoly_radix_sort1(A, left, mid, pos, cmpmask, totalmask);
+            left = mid;
+        }
+        else
+        {
+            _fq_zech_mpoly_radix_sort1(A, mid, right, pos, cmpmask, totalmask);
+            right = mid;
+        }
     }
 }
 
@@ -77,52 +91,73 @@ void _fq_zech_mpoly_radix_sort1(fq_zech_mpoly_t A, slong left, slong right,
 /*
     sort terms in [left, right) by exponent
     assuming that bits in position > pos are already sorted
-
-    TODO: Stack depth is proportional to N*FLINT_BITS
-            Might turn into iterative version
-            Low priority
 */
 void _fq_zech_mpoly_radix_sort(fq_zech_mpoly_t A, slong left, slong right,
-                                     flint_bitcnt_t pos, slong N, ulong * cmpmask)
+                                  flint_bitcnt_t pos, slong N, ulong * cmpmask)
 {
-    ulong off = pos/FLINT_BITS;
-    ulong bit = pos%FLINT_BITS;
-    ulong mask = UWORD(1) << bit;
-    ulong cmp = cmpmask[off] & mask;
+    ulong off, bit, mask, cmp;
     slong mid, check;
 
-    FLINT_ASSERT(left <= right);
-    FLINT_ASSERT(pos < N*FLINT_BITS);
-
-    /* do nothing on lists of 0 or 1 elements */
-    if (left + 1 >= right)
-        return;
-
-    /* find first 'zero' */
-    mid = left;
-    while (mid < right && ((A->exps+N*mid)[off] & mask) != cmp)
+    while (pos > 0)
     {
-        mid++;
-    }
+        pos--;
 
-    /* make sure [left,mid)  doesn't match cmpmask in position pos 'one'
-                 [mid,right)    does match cmpmask in position pos 'zero' */
-    check = mid;
-    while (++check < right)
-    {
-        if (((A->exps + N*check)[off] & mask) != cmp)
+        FLINT_ASSERT(left <= right);
+        FLINT_ASSERT(pos < N*FLINT_BITS);
+
+        off = pos/FLINT_BITS;
+        bit = pos%FLINT_BITS;
+        mask = UWORD(1) << bit;
+        cmp = cmpmask[off] & mask;
+
+        /* insertion base case */
+        if (right - left < 10)
         {
-            fq_zech_swap(A->coeffs + check, A->coeffs + mid, NULL);
-            mpoly_monomial_swap(A->exps + N*check, A->exps + N*mid, N);
-            mid++;
-        }
-    }
+            slong i, j;
 
-    --pos;
-    if ((slong)(pos) >= 0)
-    {
-        _fq_zech_mpoly_radix_sort(A, left,  mid, pos, N, cmpmask);
-        _fq_zech_mpoly_radix_sort(A, mid, right, pos, N, cmpmask);
+            for (i = left + 1; i < right; i++)
+            {
+                for (j = i; j > left && mpoly_monomial_gt(A->exps + N*j,
+                                         A->exps + N*(j - 1), N, cmpmask); j--)
+                {
+                    fq_zech_swap(A->coeffs + j, A->coeffs + j - 1, NULL);
+                    mpoly_monomial_swap(A->exps + N*j, A->exps + N*(j - 1), N);
+                }
+            }
+
+            return;
+        }
+
+        /* find first 'zero' */
+        mid = left;
+        while (mid < right && ((A->exps+N*mid)[off] & mask) != cmp)
+            mid++;
+
+        /* make sure [left,mid)  doesn't match cmpmask in position pos 'one'
+                     [mid,right)    does match cmpmask in position pos 'zero' */
+        check = mid;
+        while (++check < right)
+        {
+            if (((A->exps + N*check)[off] & mask) != cmp)
+            {
+                fq_zech_swap(A->coeffs + check, A->coeffs + mid, NULL);
+                mpoly_monomial_swap(A->exps + N*check, A->exps + N*mid, N);
+                mid++;
+            }
+        }
+
+        FLINT_ASSERT(left <= mid && mid <= right);
+
+        if (mid - left < right - mid)
+        {
+            _fq_zech_mpoly_radix_sort(A, left, mid, pos, N, cmpmask);
+            left = mid;
+        }
+        else
+        {
+            _fq_zech_mpoly_radix_sort(A, mid, right, pos, N, cmpmask);
+            right = mid;
+        }
     }
 }
 
@@ -133,7 +168,8 @@ void _fq_zech_mpoly_radix_sort(fq_zech_mpoly_t A, slong left, slong right,
 */
 void fq_zech_mpoly_sort_terms(fq_zech_mpoly_t A, const fq_zech_mpoly_ctx_t ctx)
 {
-    slong i, msb, N;
+    slong i, N;
+    flint_bitcnt_t pos;
     ulong himask, * ptempexp;
     TMP_INIT;
 
@@ -144,31 +180,15 @@ void fq_zech_mpoly_sort_terms(fq_zech_mpoly_t A, const fq_zech_mpoly_ctx_t ctx)
 
     himask = 0;
     for (i = 0; i < A->length; i++)
-    {
         himask |= (A->exps + N*i)[N - 1];
-    }
 
-    if (himask != 0)
-    {
-        count_leading_zeros(msb, himask);
-        msb = (FLINT_BITS - 1)^msb;
-    }
-    else
-    {
-        msb = -WORD(1);
-    }
+    pos = FLINT_BIT_COUNT(himask);
 
     if (N == 1)
-    {
-        if (msb >= 0)
-        {
-            _fq_zech_mpoly_radix_sort1(A, 0, A->length, msb, ptempexp[0], himask);
-        }
-    }
+        _fq_zech_mpoly_radix_sort1(A, 0, A->length, pos, ptempexp[0], himask);
     else
-    {
-        _fq_zech_mpoly_radix_sort(A, 0, A->length, (N - 1)*FLINT_BITS + msb, N, ptempexp);
-    }
+        _fq_zech_mpoly_radix_sort(A, 0, A->length,
+                                        (N - 1)*FLINT_BITS + pos, N, ptempexp);
 
     TMP_END;
 }

--- a/nmod_mpoly/divides_dense.c
+++ b/nmod_mpoly/divides_dense.c
@@ -128,26 +128,14 @@ int nmod_mpoly_convert_from_nmod_mpolyd_degbound(
     /* sort the exponents if needed */
     if (ctx->minfo->ord != ORD_LEX || perm_nontrivial != WORD(0))
     {
-        slong msb;
+        flint_bitcnt_t pos;
         mpoly_get_cmpmask(pcurexp, N, bits, ctx->minfo);
-        if (topmask != UWORD(0))
-        {
-            count_leading_zeros(msb, topmask);
-            msb = (FLINT_BITS - 1)^msb;
-        } else
-        {
-            msb = -WORD(1);
-        }
-        if (N == 1) {
-            if (msb >= WORD(0))
-            {
-                _nmod_mpoly_radix_sort1(A, 0, A->length,
-                                                   msb, pcurexp[0], topmask);
-            }
-        } else {
+        pos = FLINT_BIT_COUNT(topmask);
+        if (N == 1)
+            _nmod_mpoly_radix_sort1(A, 0, A->length, pos, pcurexp[0], topmask);
+        else
             _nmod_mpoly_radix_sort(A, 0, A->length,
-                                        (N - 1)*FLINT_BITS + msb, N, pcurexp);
-        }
+                                         (N - 1)*FLINT_BITS + pos, N, pcurexp);
     }
 
     ret = 1;

--- a/nmod_mpoly/mpolyd.c
+++ b/nmod_mpoly/mpolyd.c
@@ -341,26 +341,14 @@ void nmod_mpoly_convert_from_nmod_mpolyd(
     /* sort the exponents if needed */
     if (ctx->minfo->ord != ORD_LEX || perm_nontrivial != WORD(0))
     {
-        slong msb;
+        flint_bitcnt_t pos;
         mpoly_get_cmpmask(pcurexp, N, bits, ctx->minfo);
-        if (topmask != WORD(0))
-        {
-            count_leading_zeros(msb, topmask);
-            msb = (FLINT_BITS - 1)^msb;
-        } else
-        {
-            msb = -WORD(1);
-        }
-        if (N == 1) {
-            if (msb >= WORD(0))
-            {
-                _nmod_mpoly_radix_sort1(A, 0, A->length,
-                                                   msb, pcurexp[0], topmask);
-            }
-        } else {
+        pos = FLINT_BIT_COUNT(topmask);
+        if (N == 1)
+            _nmod_mpoly_radix_sort1(A, 0, A->length, pos, pcurexp[0], topmask);
+        else
             _nmod_mpoly_radix_sort(A, 0, A->length,
-                                        (N - 1)*FLINT_BITS + msb, N, pcurexp);
-        }
+                                         (N - 1)*FLINT_BITS + pos, N, pcurexp);
     }
 
     TMP_END;

--- a/nmod_mpoly/test/t-repack_bits.c
+++ b/nmod_mpoly/test/t-repack_bits.c
@@ -1,0 +1,201 @@
+/*
+    Copyright (C) 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "nmod_mpoly.h"
+
+
+int
+main(void)
+{
+    slong i, j;
+    int success;
+
+    FLINT_TEST_INIT(state);
+
+    flint_printf("repack_bits....");
+    fflush(stdout);
+
+    /* Check packing up */
+    for (i = 0; i < 50 * flint_test_multiplier(); i++)
+    {
+        nmod_mpoly_ctx_t ctx;
+        nmod_mpoly_t f, g;
+        slong len1, len2;
+        flint_bitcnt_t exp_bits1, exp_bits2, newbits;
+
+        nmod_mpoly_ctx_init_rand(ctx, state, 20, n_randint(state, 10000) + 2);
+        nmod_mpoly_init(f, ctx);
+        nmod_mpoly_init(g, ctx);
+
+        len1 = n_randint(state, 50);
+        len2 = n_randint(state, 50);
+        exp_bits1 = n_randint(state, 100) + 2;
+        exp_bits2 = n_randint(state, 100) + 2;
+
+        for (j = 0; j < 4; j++)
+        {
+            nmod_mpoly_randtest_bits(f, state, len1, exp_bits1, ctx);
+            nmod_mpoly_randtest_bits(g, state, len2, exp_bits2, ctx);
+
+            newbits = g->bits + n_randint(state, 2*FLINT_BITS);
+            newbits = mpoly_fix_bits(newbits, ctx->minfo);
+            success = nmod_mpoly_repack_bits(f, g, newbits, ctx);
+            nmod_mpoly_assert_canonical(f, ctx);
+
+            if (!success || !nmod_mpoly_equal(f, g, ctx))
+            {
+                flint_printf("FAIL\n");
+                flint_printf("Check packing up\ni: %wd  j: %wd\n", i, j);
+                flint_abort();
+            }
+
+            newbits = g->bits + n_randint(state, 2*FLINT_BITS);
+            newbits = mpoly_fix_bits(newbits, ctx->minfo);
+            success = nmod_mpoly_repack_bits(g, g, newbits, ctx);
+            nmod_mpoly_assert_canonical(g, ctx);
+
+            if (!success || !nmod_mpoly_equal(f, g, ctx))
+            {
+                flint_printf("FAIL\n");
+                flint_printf("Check packing up with aliasing\ni: %wd  j: %wd\n", i, j);
+                flint_abort();
+            }
+        }
+
+        nmod_mpoly_clear(f, ctx);
+        nmod_mpoly_clear(g, ctx);
+        nmod_mpoly_ctx_clear(ctx);
+    }
+
+    /* Check repacking down up */
+    for (i = 0; i < 50 * flint_test_multiplier(); i++)
+    {
+        nmod_mpoly_ctx_t ctx;
+        nmod_mpoly_t f, g, h;
+        slong len1, len2;
+        flint_bitcnt_t exp_bits1, exp_bits2, newbits;
+
+        nmod_mpoly_ctx_init_rand(ctx, state, 20, n_randint(state, 10000) + 2);
+        nmod_mpoly_init(f, ctx);
+        nmod_mpoly_init(g, ctx);
+        nmod_mpoly_init(h, ctx);
+
+        len1 = n_randint(state, 50);
+        len2 = n_randint(state, 50);
+        exp_bits1 = n_randint(state, 100) + 2;
+        exp_bits2 = n_randint(state, 100) + 2;
+
+        for (j = 0; j < 4; j++)
+        {
+            nmod_mpoly_randtest_bits(f, state, len1, exp_bits1, ctx);
+            nmod_mpoly_randtest_bits(g, state, len2, exp_bits2, ctx);
+            nmod_mpoly_randtest_bits(h, state, len2, exp_bits2, ctx);
+
+            newbits = g->bits + n_randint(state, 2*FLINT_BITS);
+            newbits = mpoly_fix_bits(newbits, ctx->minfo);
+            nmod_mpoly_repack_bits(f, g, newbits, ctx);
+            nmod_mpoly_assert_canonical(f, ctx);
+
+            newbits = g->bits + n_randint(state, 2*FLINT_BITS);
+            newbits = mpoly_fix_bits(newbits, ctx->minfo);
+            success = nmod_mpoly_repack_bits(h, f, newbits, ctx);
+            nmod_mpoly_assert_canonical(h, ctx);
+
+            if (!success || !nmod_mpoly_equal(h, g, ctx))
+            {
+                flint_printf("FAIL\n");
+                flint_printf("Check repacking down\ni: %wd  j: %wd\n", i, j);
+                flint_abort();
+            }
+
+            newbits = g->bits + n_randint(state, 2*FLINT_BITS);
+            newbits = mpoly_fix_bits(newbits, ctx->minfo);
+            success = nmod_mpoly_repack_bits(f, f, newbits, ctx);
+            nmod_mpoly_assert_canonical(f, ctx);
+
+            if (!success || !nmod_mpoly_equal(f, g, ctx))
+            {
+                flint_printf("FAIL\n");
+                flint_printf("Check repacking down with aliasing\ni: %wd  j: %wd\n", i, j);
+                flint_abort();
+            }
+        }
+
+        nmod_mpoly_clear(f, ctx);
+        nmod_mpoly_clear(g, ctx);
+        nmod_mpoly_clear(h, ctx);
+        nmod_mpoly_ctx_clear(ctx);
+    }
+
+    /* Check packing down */
+    for (i = 0; i < 50 * flint_test_multiplier(); i++)
+    {
+        nmod_mpoly_ctx_t ctx;
+        nmod_mpoly_t f, g;
+        slong len1, len2;
+        flint_bitcnt_t exp_bits1, exp_bits2, newbits;
+
+        nmod_mpoly_ctx_init_rand(ctx, state, 20, n_randint(state, 10000) + 2);
+        nmod_mpoly_init(f, ctx);
+        nmod_mpoly_init(g, ctx);
+
+        len1 = n_randint(state, 50);
+        len2 = n_randint(state, 50);
+        exp_bits1 = n_randint(state, 100) + 2;
+        exp_bits2 = n_randint(state, 100) + 2;
+
+        for (j = 0; j < 4; j++)
+        {
+            nmod_mpoly_randtest_bits(f, state, len1, exp_bits1, ctx);
+            nmod_mpoly_randtest_bits(g, state, len2, exp_bits2, ctx);
+
+            if (g->bits <= MPOLY_MIN_BITS)
+                continue;
+
+            newbits = n_randint(state, g->bits - MPOLY_MIN_BITS) + MPOLY_MIN_BITS;
+            newbits = mpoly_fix_bits(newbits, ctx->minfo);
+            success = nmod_mpoly_repack_bits(f, g, newbits, ctx);
+            nmod_mpoly_assert_canonical(f, ctx);
+
+            if (success && !nmod_mpoly_equal(f, g, ctx))
+            {
+                flint_printf("FAIL\n");
+                flint_printf("Check packing down\ni: %wd  j: %wd\n", i, j);
+                flint_abort();
+            }
+
+            nmod_mpoly_set(f, g, ctx);
+            newbits = n_randint(state, g->bits - MPOLY_MIN_BITS) + MPOLY_MIN_BITS;
+            newbits = mpoly_fix_bits(newbits, ctx->minfo);
+            success = nmod_mpoly_repack_bits(g, g, newbits, ctx);
+            nmod_mpoly_assert_canonical(g, ctx);
+
+            if (success && !nmod_mpoly_equal(f, g, ctx))
+            {
+                flint_printf("FAIL\n");
+                flint_printf("Check packing down with aliasing\ni: %wd  j: %wd\n", i, j);
+                flint_abort();
+            }
+        }
+
+        nmod_mpoly_clear(f, ctx);
+        nmod_mpoly_clear(g, ctx);
+        nmod_mpoly_ctx_clear(ctx);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+
+    flint_printf("PASS\n");
+    return 0;
+}
+


### PR DESCRIPTION
This fixes a badly need todo. Let us wait for @advanpix to confirm that all tests pass on icc with the previous settings.
What essentially happens is: with flint_test_multiplier() = 10, the test code hits a sort requiring recursive calls approx 5000 deep. Icc with no optimizations consumes a whopping 208 bytes on the stack per call, and this puts us over the 1MB limit.
Why our test code didn't catch it? maybe
- flint_test_multiplier() = 1 doesn't catch this case, or
- msvc uses much less stack space per call.

In any case, the new code uses a bounded amount of stack space.
