### PR TITLE
add some small convenience functions

### DIFF
--- a/doc/source/fmpz.rst
+++ b/doc/source/fmpz.rst
@@ -297,6 +297,14 @@ Conversion
     ``in[0] + in[1]*X  + ... + in[in_len - 1]*X^(in_len - 1)``
     where ``X = 2^FLINT_BITS``. It is assumed that ``in_len > 0``.
 
+.. function:: void fmpz_set_signed_ui_array(fmpz_t out, const ulong * in, slong in_len)
+
+    Sets ``out`` to the integer represented in ``in[0], ..., in[in_len - 1]``
+    as a signed two's complement integer with ``in_len * FLINT_BITS`` bits.
+    It is assumed that ``in_len > 0``. The function operates as a call to
+    :func:`fmpz_set_ui_array` followed by a symmetric remainder modulo
+    ``2*(in_len*FLINT_BITS)``.
+
 .. function:: void fmpz_get_ui_array(ulong * out, slong out_len, const fmpz_t in)
 
     Assuming that the nonnegative integer ``in`` can be represented in the
@@ -603,8 +611,7 @@ Comparison
 
 .. function:: int fmpz_is_pm1(const fmpz_t f)
 
-    Returns `1` if `f` is equal to one or minus one, otherwise returns 
-    `0`.
+    Returns `1` if `f` is equal to one or minus one, otherwise returns `0`.
 
 .. function:: int fmpz_is_even(const fmpz_t f)
 
@@ -628,65 +635,42 @@ Basic arithmetic
     Sets `f_1` to the absolute value of `f_2`.
 
 .. function:: void fmpz_add(fmpz_t f, const fmpz_t g, const fmpz_t h)
+              void fmpz_add_ui(fmpz_t f, const fmpz_t g, ulong h)
+              void fmpz_add_si(fmpz_t f, const fmpz_t g, slong h)
 
     Sets `f` to `g + h`.
 
-.. function:: void fmpz_add_ui(fmpz_t f, const fmpz_t g, ulong x)
-
-    Sets `f` to `g + x` where `x` is an ``ulong``.
-
-.. function:: void fmpz_add_si(fmpz_t f, const fmpz_t g, slong x)
-
-    Sets `f` to `g + x` where `x` is an ``slong``.
-
 .. function:: void fmpz_sub(fmpz_t f, const fmpz_t g, const fmpz_t h)
+              void fmpz_sub_ui(fmpz_t f, const fmpz_t g, ulong h)
+              void fmpz_sub_si(fmpz_t f, const fmpz_t g, slong h)
 
     Sets `f` to `g - h`.
 
-.. function:: void fmpz_sub_ui(fmpz_t f, const fmpz_t g, ulong x)
-
-    Sets `f` to `g - x` where `x` is an ``ulong``.
-
-.. function:: void fmpz_sub_si(fmpz_t f, const fmpz_t g, slong x)
-
-    Sets `f` to `g - x` where `x` is an ``slong``.
-
 .. function:: void fmpz_mul(fmpz_t f, const fmpz_t g, const fmpz_t h)
+              void fmpz_mul_ui(fmpz_t f, const fmpz_t g, ulong h)
+              void fmpz_mul_si(fmpz_t f, const fmpz_t g, slong h)
 
     Sets `f` to `g \times h`.
 
-.. function:: void fmpz_mul_si(fmpz_t f, const fmpz_t g, slong x)
-
-    Sets `f` to `g \times x` where `x` is a ``slong``.
-
-.. function:: void fmpz_mul_ui(fmpz_t f, const fmpz_t g, ulong x)
-
-    Sets `f` to `g \times x` where `x` is an ``ulong``.
-
 .. function:: void fmpz_mul2_uiui(fmpz_t f, const fmpz_t g, ulong x, ulong y)
 
-    Sets `f` to `g \times x \times y` where `x` and `y` are of type
-    ``ulong``.
+    Sets `f` to `g \times x \times y` where `x` and `y` are of type ``ulong``.
 
 .. function:: void fmpz_mul_2exp(fmpz_t f, const fmpz_t g, ulong e)
 
     Sets `f` to `g \times 2^e`.
 
 .. function:: void fmpz_addmul(fmpz_t f, const fmpz_t g, const fmpz_t h)
+              void fmpz_addmul_ui(fmpz_t f, const fmpz_t g, ulong h)
+              void fmpz_addmul_si(fmpz_t f, const fmpz_t g, slong h)
 
     Sets `f` to `f + g \times h`.
 
-.. function:: void fmpz_addmul_ui(fmpz_t f, const fmpz_t g, ulong x)
-
-    Sets `f` to `f + g \times x` where `x` is an ``ulong``.
-
 .. function:: void fmpz_submul(fmpz_t f, const fmpz_t g, const fmpz_t h)
+              void fmpz_submul_ui(fmpz_t f, const fmpz_t g, ulong h)
+              void fmpz_submul_si(fmpz_t f, const fmpz_t g, slong h)
 
     Sets `f` to `f - g \times h`.
-
-.. function:: void fmpz_submul_ui(fmpz_t f, const fmpz_t g, ulong x)
-
-    Sets `f` to `f - g \times x` where `x` is an ``ulong``.
 
 .. function:: void fmpz_fmma(fmpz_t f, const fmpz_t a, const fmpz_t b, const fmpz_t c, const fmpz_t d)
 

--- a/doc/source/ulong_extras.rst
+++ b/doc/source/ulong_extras.rst
@@ -90,15 +90,21 @@ Basic arithmetic
 
 .. function:: ulong n_flog(ulong n, ulong b)
 
-    Returns `\lfloor\log_b x\rfloor`.
+    Returns `\lfloor\log_b n\rfloor`.
 
-    Assumes that `x \geq 1` and `b \geq 2`.
+    Assumes that `n \geq 1` and `b \geq 2`.
 
 .. function:: ulong n_clog(ulong n, ulong b)
 
-    Returns `\lceil\log_b x\rceil`.
+    Returns `\lceil\log_b n\rceil`.
 
-    Assumes that `x \geq 1` and `b \geq 2`.
+    Assumes that `n \geq 1` and `b \geq 2`.
+
+.. function:: ulong n_clog_2exp(ulong n, ulong b)
+
+    Returns `\lceil\log_b 2^n\rceil`.
+
+    Assumes that `b \geq 2`.
 
 
 Miscellaneous

--- a/flint.h
+++ b/flint.h
@@ -377,6 +377,7 @@ mp_limb_t FLINT_BIT_COUNT(mp_limb_t x)
 
 /* common usage of flint_malloc */
 #define FLINT_ARRAY_ALLOC(n, T) (T *) flint_malloc((n)*sizeof(T))
+#define FLINT_ARRAY_REALLOC(p, n, T) (T *) flint_realloc(p, (n)*sizeof(T))
 
 /* temporary allocation */
 #define TMP_INIT \
@@ -406,6 +407,7 @@ mp_limb_t FLINT_BIT_COUNT(mp_limb_t x)
       alloca(size))
 #endif
 
+#define TMP_ARRAY_ALLOC(n, T) (T *) TMP_ALLOC((n)*sizeof(T))
 
 #define TMP_END \
    while (__tmp_root) { \

--- a/fmpz.h
+++ b/fmpz.h
@@ -298,6 +298,8 @@ FLINT_DLL void fmpz_set_ui_array(fmpz_t out, const ulong * in, slong in_len);
 
 FLINT_DLL void fmpz_get_ui_array(ulong * out, slong out_len, const fmpz_t in);
 
+FLINT_DLL void fmpz_set_signed_ui_array(fmpz_t out, const ulong * in, slong in_len);
+
 FLINT_DLL void fmpz_get_mpz(mpz_t x, const fmpz_t f);
 
 FLINT_DLL void fmpz_set_mpz(fmpz_t f, const mpz_t x);
@@ -492,6 +494,52 @@ FMPZ_INLINE void fmpz_sub_si(fmpz_t f, const fmpz_t g, slong x)
         fmpz_add_ui(f, g, (ulong) -x);
 }
 
+FMPZ_INLINE
+void flint_mpz_add_uiui(mpz_ptr a, mpz_srcptr b, ulong c1, ulong c0)
+{
+    ulong d[2];
+    mpz_t c;
+    d[0] = c0;
+    d[1] = c1;
+    c->_mp_d = d;
+    c->_mp_alloc = 2;
+    c->_mp_size = d[1] != 0 ? 2 : d[0] != 0;
+    mpz_add(a, b, c);
+}
+
+FMPZ_INLINE
+void flint_mpz_add_signed_uiui(mpz_ptr a, mpz_srcptr b, ulong c1, ulong c0)
+{
+    ulong d[2];
+    ulong c2 = FLINT_SIGN_EXT(c1);
+    mpz_t c;
+    sub_ddmmss(d[1], d[0], c2^c1, c2^c0, c2, c2);
+    c->_mp_d = d;
+    c->_mp_alloc = 2;
+    c->_mp_size = d[1] != 0 ? 2 : d[0] != 0;
+    if (c2 != 0)
+        c->_mp_size = -c->_mp_size;
+    mpz_add(a, b, c);
+}
+
+FMPZ_INLINE
+void flint_mpz_add_uiuiui(mpz_ptr a, mpz_srcptr b, ulong c2, ulong c1, ulong c0)
+{
+    ulong d[3];
+    mpz_t c;
+    d[0] = c0;
+    d[1] = c1;
+    d[2] = c2;
+    c->_mp_d = d;
+    c->_mp_alloc = 3;
+    c->_mp_size = d[2] != 0 ? 3 : d[1] != 0 ? 2 : d[0] != 0;
+    mpz_add(a, b, c);
+}
+
+FLINT_DLL void fmpz_addmul_si(fmpz_t f, const fmpz_t g, slong x);
+
+FLINT_DLL void fmpz_submul_si(fmpz_t f, const fmpz_t g, slong x);
+
 FLINT_DLL void fmpz_addmul_ui(fmpz_t f, const fmpz_t g, ulong x);
 
 FLINT_DLL void fmpz_submul_ui(fmpz_t f, const fmpz_t g, ulong x);
@@ -500,9 +548,11 @@ FLINT_DLL void fmpz_addmul(fmpz_t f, const fmpz_t g, const fmpz_t h);
 
 FLINT_DLL void fmpz_submul(fmpz_t f, const fmpz_t g, const fmpz_t h);
 
-FLINT_DLL void fmpz_fmma(fmpz_t f, const fmpz_t a, const fmpz_t b, const fmpz_t c, const fmpz_t d);
+FLINT_DLL void fmpz_fmma(fmpz_t f, const fmpz_t a, const fmpz_t b,
+                                   const fmpz_t c, const fmpz_t d);
 
-FLINT_DLL void fmpz_fmms(fmpz_t f, const fmpz_t a, const fmpz_t b, const fmpz_t c, const fmpz_t d);
+FLINT_DLL void fmpz_fmms(fmpz_t f, const fmpz_t a, const fmpz_t b,
+                                   const fmpz_t c, const fmpz_t d);
 
 FLINT_DLL void fmpz_pow_ui(fmpz_t f, const fmpz_t g, ulong exp);
 

--- a/fmpz/addmul_si.c
+++ b/fmpz/addmul_si.c
@@ -1,0 +1,62 @@
+/*
+    Copyright (C) 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <gmp.h>
+#include "flint.h"
+#include "ulong_extras.h"
+#include "fmpz.h"
+
+void fmpz_addmul_si(fmpz_t f, const fmpz_t g, slong x)
+{
+    fmpz F, G;
+
+    G = *g;
+    if (x == 0 || G == 0)
+        return;
+
+    F = *f;
+    if (F == 0)
+    {
+        fmpz_mul_si(f, g, x);
+        return;
+    }
+
+    if (!COEFF_IS_MPZ(G))
+    {
+        ulong p1, p0;
+        smul_ppmm(p1, p0, G, x);
+
+        if (!COEFF_IS_MPZ(F))
+        {
+            ulong F1 = FLINT_SIGN_EXT(F);
+            add_ssaaaa(p1, p0, p1, p0, F1, F);
+            fmpz_set_signed_uiui(f, p1, p0);
+        }
+        else
+        {
+            mpz_ptr pF = COEFF_TO_PTR(F);
+            flint_mpz_add_signed_uiui(pF, pF, p1, p0);
+        }
+    }
+    else
+    {
+        mpz_ptr pG = COEFF_TO_PTR(G);
+        mpz_ptr pF = _fmpz_promote_val(f);
+
+        if (x < 0)
+            flint_mpz_submul_ui(pF, pG, -x);
+        else
+            flint_mpz_addmul_ui(pF, pG, x);
+
+        _fmpz_demote_val(f);
+    }
+}
+

--- a/fmpz/set_signed_ui_array.c
+++ b/fmpz/set_signed_ui_array.c
@@ -1,0 +1,63 @@
+/*
+    Copyright (C) 2016 William Hart
+    Copyright (C) 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+
+/*
+    Given an array of limbs "in" representing a integer mod 2^(FLINT_BITS*n),
+    set "out" to the symmetric remainder with the halfway point
+    2^(FLINT_BITS*n/2) mapping to -2^(FLINT_BITS*n/2)
+*/
+
+void fmpz_set_signed_ui_array(fmpz_t f, const ulong * c_in, slong n)
+{
+    slong i;
+    ulong * c;
+    int neg;
+
+    TMP_INIT;
+
+    TMP_START;
+
+    c = (ulong *) TMP_ALLOC(n*sizeof(ulong));
+
+    for (i = 0; i < n; i++)
+       c[i] = c_in[i];
+
+    neg = 0 > (slong) c[n - 1];
+
+    if (neg)
+       mpn_neg_n(c, c, n);
+
+    while (n > 0 && c[n - 1] == 0)
+       n--;
+
+    if (n <= 1)
+    {
+       fmpz_set_ui(f, c[0]);
+    }
+    else
+    {
+       __mpz_struct * mpz = _fmpz_promote(f);
+
+       mpz_realloc2(mpz, n*FLINT_BITS);
+
+       mpn_copyi(mpz->_mp_d, c, n);
+       mpz->_mp_size = n;
+    }
+
+    if (neg)
+       fmpz_neg(f, f);
+
+    TMP_END;
+}
+

--- a/fmpz/submul_si.c
+++ b/fmpz/submul_si.c
@@ -1,0 +1,64 @@
+/*
+    Copyright (C) 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <gmp.h>
+#include "flint.h"
+#include "ulong_extras.h"
+#include "fmpz.h"
+
+void fmpz_submul_si(fmpz_t f, const fmpz_t g, slong x)
+{
+    fmpz F, G;
+
+    G = *g;
+    if (x == 0 || G == 0)
+        return;
+
+    F = *f;
+    if (F == 0)
+    {
+        fmpz_mul_si(f, g, x);
+        fmpz_neg(f, f);
+        return;
+    }
+
+    if (!COEFF_IS_MPZ(G))
+    {
+        ulong p1, p0;
+        smul_ppmm(p1, p0, G, x);
+
+        if (!COEFF_IS_MPZ(F))
+        {
+            ulong F1 = FLINT_SIGN_EXT(F);
+            sub_ddmmss(p1, p0, F1, F, p1, p0);
+            fmpz_set_signed_uiui(f, p1, p0);
+        }
+        else
+        {
+            mpz_ptr pF = COEFF_TO_PTR(F);
+            sub_ddmmss(p1, p0, UWORD(0), UWORD(0), p1, p0);
+            flint_mpz_add_signed_uiui(pF, pF, p1, p0);
+        }
+    }
+    else
+    {
+        mpz_ptr pG = COEFF_TO_PTR(G);
+        mpz_ptr pF = _fmpz_promote_val(f);
+
+        if (x < 0)
+            flint_mpz_addmul_ui(pF, pG, -x);
+        else
+            flint_mpz_submul_ui(pF, pG, x);
+
+        _fmpz_demote_val(f);
+    }
+}
+

--- a/fmpz/test/t-addmul_si.c
+++ b/fmpz/test/t-addmul_si.c
@@ -1,0 +1,116 @@
+/*
+    Copyright (C) 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <gmp.h>
+#include "flint.h"
+#include "long_extras.h"
+#include "fmpz.h"
+
+int
+main(void)
+{
+    int i, result;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("addmul_si....");
+    fflush(stdout);
+
+    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
+    {
+        fmpz_t a, b;
+        mpz_t d, e, f, xx;
+        slong x;
+
+        fmpz_init(a);
+        fmpz_init(b);
+
+        mpz_init(d);
+        mpz_init(e);
+        mpz_init(f);
+
+        fmpz_randtest(a, state, 200);
+        fmpz_randtest(b, state, 200);
+
+        fmpz_get_mpz(d, a);
+        fmpz_get_mpz(e, b);
+        x = z_randtest(state);
+
+        fmpz_addmul_si(b, a, x);
+        flint_mpz_init_set_si(xx, x);
+        mpz_addmul(e, d, xx);
+
+        fmpz_get_mpz(f, b);
+
+        result = (mpz_cmp(e, f) == 0);
+
+        if (!result)
+        {
+            flint_printf("FAIL:\n");
+            gmp_printf("d = %Zd, e = %Zd, f = %Zd, xx = %Zd\n", d, e, f, xx);
+            flint_abort();
+        }
+
+        fmpz_clear(a);
+        fmpz_clear(b);
+
+        mpz_clear(xx);
+        mpz_clear(d);
+        mpz_clear(e);
+        mpz_clear(f);
+    }
+
+    /* Check aliasing of a and b */
+    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
+    {
+        fmpz_t a;
+        mpz_t d, e, xx;
+        slong x;
+
+        fmpz_init(a);
+
+        mpz_init(d);
+        mpz_init(e);
+
+        fmpz_randtest(a, state, 200);
+
+        fmpz_get_mpz(d, a);
+        x = n_randtest(state);
+
+        fmpz_addmul_si(a, a, x);
+        flint_mpz_init_set_si(xx, x);
+        mpz_addmul(d, d, xx);
+
+        fmpz_get_mpz(e, a);
+
+        result = (mpz_cmp(d, e) == 0);
+
+        if (!result)
+        {
+            flint_printf("FAIL:\n");
+            gmp_printf("d = %Zd, e = %Zd, xx = %Zd\n", d, e, xx);
+            flint_abort();
+        }
+
+        fmpz_clear(a);
+
+        mpz_clear(xx);
+        mpz_clear(d);
+        mpz_clear(e);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+
+    flint_printf("PASS\n");
+    return 0;
+}
+

--- a/fmpz/test/t-set_signed_ui_array.c
+++ b/fmpz/test/t-set_signed_ui_array.c
@@ -1,0 +1,82 @@
+/*
+    Copyright (C) 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "ulong_extras.h"
+#include "fmpz.h"
+
+int
+main(void)
+{
+    int i;
+    slong max_limbs = 20;
+    ulong * limbs;
+    fmpz_t a, b, c;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("set_signed_ui_array....");
+    fflush(stdout);
+
+    fmpz_init(a);
+    fmpz_init(b);
+    fmpz_init(c);
+    limbs = (ulong *) flint_malloc(max_limbs*sizeof(ulong));
+
+    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
+    {
+        slong j, n;
+
+        n = n_randint(state, max_limbs) + 1;
+
+        for (j = 0; j < n; j++)
+            limbs[j] = n_randlimb(state);
+
+        fmpz_set_ui_array(a, limbs, n);
+        fmpz_set_signed_ui_array(b, limbs, n);
+
+        fmpz_sub(a, a, b);
+
+        fmpz_one(c);
+        fmpz_mul_2exp(c, c, n*FLINT_BITS);
+
+        if (!fmpz_divisible(a, c))
+        {
+            flint_printf("FAIL: check answer mod 2^(n*FLINT_BITS)\n");
+            flint_abort();
+        }
+
+        fmpz_one(c);
+        fmpz_mul_2exp(c, c, n*FLINT_BITS - 1);
+
+        if (fmpz_cmp(b, c) >= 0)
+        {
+            flint_printf("FAIL: check answer < 2^(n*FLINT_BITS - 1)\n");
+            flint_abort();
+        }
+
+        fmpz_neg(c, c);
+        if (fmpz_cmp(b, c) < 0)
+        {
+            flint_printf("FAIL: check answer >= -2^(n*FLINT_BITS - 1)\n");
+            flint_abort();
+        }
+    }
+
+    fmpz_clear(a);
+    fmpz_clear(b);
+    fmpz_clear(c);
+    flint_free(limbs);
+
+    FLINT_TEST_CLEANUP(state);
+
+    flint_printf("PASS\n");
+    return 0;
+}
+

--- a/fmpz/test/t-submul_si.c
+++ b/fmpz/test/t-submul_si.c
@@ -1,0 +1,116 @@
+/*
+    Copyright (C) 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <gmp.h>
+#include "flint.h"
+#include "long_extras.h"
+#include "fmpz.h"
+
+int
+main(void)
+{
+    int i, result;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("submul_si....");
+    fflush(stdout);
+
+    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
+    {
+        fmpz_t a, b;
+        mpz_t d, e, f, xx;
+        slong x;
+
+        fmpz_init(a);
+        fmpz_init(b);
+
+        mpz_init(d);
+        mpz_init(e);
+        mpz_init(f);
+
+        fmpz_randtest(a, state, 200);
+        fmpz_randtest(b, state, 200);
+
+        fmpz_get_mpz(d, a);
+        fmpz_get_mpz(e, b);
+        x = z_randtest(state);
+
+        fmpz_submul_si(b, a, x);
+        flint_mpz_init_set_si(xx, x);
+        mpz_submul(e, d, xx);
+
+        fmpz_get_mpz(f, b);
+
+        result = (mpz_cmp(e, f) == 0);
+
+        if (!result)
+        {
+            flint_printf("FAIL:\n");
+            gmp_printf("d = %Zd, e = %Zd, f = %Zd, xx = %Zd\n", d, e, f, xx);
+            flint_abort();
+        }
+
+        fmpz_clear(a);
+        fmpz_clear(b);
+
+        mpz_clear(xx);
+        mpz_clear(d);
+        mpz_clear(e);
+        mpz_clear(f);
+    }
+
+    /* Check aliasing of a and b */
+    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
+    {
+        fmpz_t a;
+        mpz_t d, e, xx;
+        slong x;
+
+        fmpz_init(a);
+
+        mpz_init(d);
+        mpz_init(e);
+
+        fmpz_randtest(a, state, 200);
+
+        fmpz_get_mpz(d, a);
+        x = n_randtest(state);
+
+        fmpz_submul_si(a, a, x);
+        flint_mpz_init_set_si(xx, x);
+        mpz_submul(d, d, xx);
+
+        fmpz_get_mpz(e, a);
+
+        result = (mpz_cmp(d, e) == 0);
+
+        if (!result)
+        {
+            flint_printf("FAIL:\n");
+            gmp_printf("d = %Zd, e = %Zd, xx = %Zd\n", d, e, xx);
+            flint_abort();
+        }
+
+        fmpz_clear(a);
+
+        mpz_clear(xx);
+        mpz_clear(d);
+        mpz_clear(e);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+
+    flint_printf("PASS\n");
+    return 0;
+}
+

--- a/fmpz_mpoly/pow_fps.c
+++ b/fmpz_mpoly/pow_fps.c
@@ -254,80 +254,6 @@ slong _fmpz_mpoly_pow_fps1(fmpz ** poly1, ulong ** exp1, slong * alloc,
    return rnext;
 }
 
-void fmpz_set_mpn(fmpz_t f, ulong * c_in, slong n)		
-{		
-    slong i;
-    ulong * c;
-    
-    TMP_INIT;
-
-    TMP_START;
-
-    c = (ulong *) TMP_ALLOC(n*sizeof(ulong));
-
-    for (i = 0; i < n; i++)
-       c[i] = c_in[i];
-
-    while (n > 0 && c[n - 1] == 0)		
-       n--;		
- 		
-    if (n <= 1)		
-       fmpz_set_ui(f, c[0]);		
-    else		
-    {		
-       __mpz_struct * mpz = _fmpz_promote(f);		
- 	
-       mpz_realloc2(mpz, n*FLINT_BITS);		
- 		
-       mpn_copyi(mpz->_mp_d, c, n);		
-       mpz->_mp_size = n;		
-    }	
-
-    TMP_END;
- }		
-
-
-void fmpz_set_mpn_signed(fmpz_t f, ulong * c_in, slong n)		
-{		
-    slong i;
-    ulong * c;
-    int neg;
-
-    TMP_INIT;
-
-    TMP_START;
-
-    c = (ulong *) TMP_ALLOC(n*sizeof(ulong));
-
-    for (i = 0; i < n; i++)
-       c[i] = c_in[i];
-
-    neg = 0 > (slong) c[n - 1];		
-		
-    if (neg)		
-       mpn_neg_n(c, c, n);		
-		
-    while (n > 0 && c[n - 1] == 0)		
-       n--;		
- 		
-    if (n <= 1)		
-       fmpz_set_ui(f, c[0]);		
-    else		
-    {		
-       __mpz_struct * mpz = _fmpz_promote(f);		
- 	
-       mpz_realloc2(mpz, n*FLINT_BITS);		
- 		
-       mpn_copyi(mpz->_mp_d, c, n);		
-       mpz->_mp_size = n;		
-    }		
-
-    if (neg)		
-       fmpz_neg(f, f);
-
-    TMP_END;		
- }		
- 
 
 slong _fmpz_mpoly_pow_fps(fmpz ** poly1, ulong ** exp1, slong * alloc,
                  const fmpz * poly2, const ulong * exp2, slong len2, ulong k,
@@ -477,7 +403,7 @@ slong _fmpz_mpoly_pow_fps(fmpz ** poly1, ulong ** exp1, slong * alloc,
          if (!mpoly_monomial_gt(finalexp, exp, N, cmpmask))
          {
             mpn_sub_n(temp2, fik + x->i*N, ge + x->j*N, N);
-            fmpz_set_mpn_signed(t2, temp2, N);
+            fmpz_set_signed_ui_array(t2, temp2, N);
             fmpz_addmul(C, t1, t2);
          }
 
@@ -503,7 +429,7 @@ slong _fmpz_mpoly_pow_fps(fmpz ** poly1, ulong ** exp1, slong * alloc,
             if (!mpoly_monomial_gt(finalexp, exp, N, cmpmask))
             {
                mpn_sub_n(temp2, fik + x->i*N, ge + x->j*N, N);
-               fmpz_set_mpn_signed(t2, temp2, N);
+               fmpz_set_signed_ui_array(t2, temp2, N);
                fmpz_addmul(C, t1, t2);
             }
 
@@ -566,7 +492,7 @@ slong _fmpz_mpoly_pow_fps(fmpz ** poly1, ulong ** exp1, slong * alloc,
              mpoly_monomial_mul_ui_mp(temp2, exp2 + 0, N, k);
 
          mpn_sub_n(temp2, exp_copy, temp2, N);
-         fmpz_set_mpn_signed(t2, temp2, N);
+         fmpz_set_signed_ui_array(t2, temp2, N);
          fmpz_divexact(temp1, C, t2);
          fmpz_add(S, S, temp1);
          fmpz_divexact(gc + gnext, temp1, poly2 + 0);

--- a/ulong_extras.h
+++ b/ulong_extras.h
@@ -170,6 +170,8 @@ FLINT_DLL ulong n_flog(ulong n, ulong b);
 
 FLINT_DLL ulong n_clog(ulong n, ulong b);
 
+FLINT_DLL ulong n_clog_2exp(ulong n, ulong b);
+
 ULONG_EXTRAS_INLINE 
 double n_precompute_inverse(ulong n)
 {

--- a/ulong_extras/clog_2exp.c
+++ b/ulong_extras/clog_2exp.c
@@ -1,0 +1,80 @@
+/*
+    Copyright (C) 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <gmp.h>
+#include <mpfr.h>
+#include "flint.h"
+#include "ulong_extras.h"
+
+/* return ceil(log_b(2^n)) */
+ulong n_clog_2exp(ulong n, ulong b)
+{
+    slong prec = FLINT_BITS;
+    mpfr_t A, B, C;
+    mpz_t Z;
+    ulong r;
+
+    if (n == 0)
+        return 0;        
+
+    if ((b & (b - 1)) == 0)
+    {
+        ulong log2b = 1;
+        while (b > 2)
+        {
+            b = b >> 1;
+            log2b++;
+        }
+        return n/log2b + (n%log2b != 0);
+    }
+
+    mpfr_init2(A, prec);
+    mpfr_init2(B, prec);
+    mpfr_init2(C, prec);
+    mpz_init(Z);
+
+    do {
+        mpfr_set_prec(A, prec);
+        mpfr_set_prec(B, prec);
+        mpfr_set_prec(C, prec);
+
+        /* compute A >= n/log2(b) */
+        flint_mpz_set_ui(Z, n);
+        mpfr_set_z(C, Z, MPFR_RNDA);
+        flint_mpz_set_ui(Z, b);
+        mpfr_set_z(B, Z, MPFR_RNDZ);
+        mpfr_log2(B, B, MPFR_RNDZ);
+        mpfr_div(A, C, B, MPFR_RNDA);
+
+        mpfr_get_z(Z, A, MPFR_RNDA);
+        r = flint_mpz_get_ui(Z);
+
+        /* compute A <= n/log2(b) */
+        flint_mpz_set_ui(Z, n);
+        mpfr_set_z(C, Z, MPFR_RNDZ);
+        flint_mpz_set_ui(Z, b);
+        mpfr_set_z(B, Z, MPFR_RNDA);
+        mpfr_log2(B, B, MPFR_RNDA);
+        mpfr_div(A, C, B, MPFR_RNDZ);
+
+        mpfr_get_z(Z, A, MPFR_RNDA);
+
+        prec += FLINT_BITS;
+    } while (r != flint_mpz_get_ui(Z));
+
+    mpfr_clear(A);
+    mpfr_clear(B);
+    mpfr_clear(C);
+    mpz_clear(Z);
+
+    return r;
+}
+

--- a/ulong_extras/test/t-clog_2exp.c
+++ b/ulong_extras/test/t-clog_2exp.c
@@ -1,0 +1,65 @@
+/*
+    Copyright (C) 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <gmp.h>
+#include "flint.h"
+#include "ulong_extras.h"
+
+int main(void)
+{
+    slong i;
+    ulong t[][3] = {{1, 2, 1},
+                    {2, 2, 2},
+                    {698, 127, 100},
+                    {699, 127, 101},
+                    {700, 127, 101},
+                    {701, 127, 101},
+                    {699, 128, 100},
+                    {700, 128, 100},
+                    {701, 128, 101},
+                    {694, 129,  99},
+                    {695, 129, 100},
+                    {696, 129, 100},
+                    {697, 129, 100},
+                    {698, 129, 100},
+                    {699, 129, 100},
+                    {700, 129, 100},
+                    {701, 129, 100},
+                    {702, 129, 101},
+                    {0, UWORD_MAX, 0},
+                    {1, UWORD_MAX, 1},
+                    {2, UWORD_MAX, 1},
+                    {FLINT_BITS - 1, UWORD_MAX, 1},
+                    {FLINT_BITS, UWORD_MAX, 2}};
+
+    FLINT_TEST_INIT(state);
+
+    flint_printf("clog_2exp....");
+    fflush(stdout);
+
+    for (i = 0; i < sizeof(t)/sizeof(t[0]); i++)
+    {
+        ulong r = n_clog_2exp(t[i][0], t[i][1]);
+
+        if (r != t[i][2])
+        {
+            flint_printf("FAIL:\n");
+            flint_printf("clog_2exp(%wu, %wu) = %wu\n", t[i][0], t[i][1], t[i][2]);
+            flint_printf("but computed %wu\n", r);
+        }
+    }
+
+    FLINT_TEST_CLEANUP(state);
+
+    flint_printf("PASS\n");
+    return EXIT_SUCCESS;
+}
+


### PR DESCRIPTION
The only thing possibly bad here is the flint_mpz_add_uiui and friends in fmpz.h. I am going to need these somewhere. It is useful for fmpz arithmetic, and some of the messy code in for example, fmpz_addmul_ui, can be written in terms of it.