### PR TITLE
fix fmpz_jacobi so that it compute the jacobi symbol

### DIFF
--- a/doc/source/fmpz.rst
+++ b/doc/source/fmpz.rst
@@ -1073,10 +1073,9 @@ Modular arithmetic
 
     Sets `f` to `-g \pmod{h}`, assuming `g` is reduced modulo `h`.
 
-.. function:: int fmpz_jacobi(const fmpz_t a, const fmpz_t p)
+.. function:: int fmpz_jacobi(const fmpz_t a, const fmpz_t n)
 
-    Computes the Jacobi symbol of `a` modulo `p`, where `p` is a prime
-    and `a` is reduced modulo `p`.
+    Computes the Jacobi symbol `\left(\frac{a}{n}\right)` for any `a` and odd positive `n`.
 
 .. function:: void fmpz_divides_mod_list(fmpz_t xstart, fmpz_t xstride, fmpz_t xlength, const fmpz_t a, const fmpz_t b, const fmpz_t n)
 

--- a/doc/source/ulong_extras.rst
+++ b/doc/source/ulong_extras.rst
@@ -388,8 +388,7 @@ Jacobi and Kronecker symbols
 
 .. function:: int n_jacobi(mp_limb_signed_t x, ulong y)
 
-    Computes the Jacobi symbol of `x \bmod{y}`.  Assumes that `y` is positive 
-    and odd, and for performance reasons that `\gcd(x, y) = 1`.
+    Computes the Jacobi symbol of `x \bmod{y}` for any x and odd `y`.
 
     This is just a straightforward application of the law of quadratic
     reciprocity. For performance, divisions are replaced with some 

--- a/fmpz/jacobi.c
+++ b/fmpz/jacobi.c
@@ -22,17 +22,14 @@ fmpz_jacobi(const fmpz_t a, const fmpz_t p)
     mpz_t t, u;
     int r;
 
-    if (d == 0)
-       return 0;
-
-    if (c == 2)
-        return 1;
-
     if (!COEFF_IS_MPZ(c) && !COEFF_IS_MPZ(d))
         return n_jacobi(d, c);
 
     if (COEFF_IS_MPZ(c) && COEFF_IS_MPZ(d))
         return mpz_jacobi(COEFF_TO_PTR(d), COEFF_TO_PTR(c));
+
+    if (d == 0)
+        return 0; /* a is zero and p is large */
 
     flint_mpz_init_set_readonly(t, a);
     flint_mpz_init_set_readonly(u, p);

--- a/fmpz/test/t-jacobi.c
+++ b/fmpz/test/t-jacobi.c
@@ -19,57 +19,43 @@
 int
 main(void)
 {
-    int i, result;
+    slong i, j;
     FLINT_TEST_INIT(state);
 
     flint_printf("jacobi....");
     fflush(stdout);
 
-    
-    _flint_rand_init_gmp(state);
-
     for (i = 0; i < 3000 * flint_test_multiplier(); i++)
     {
-        fmpz_t a, p;
-        mpz_t b, q;
-        int r1, r2;
+        fmpz_t a, n;
+        mpz_t aa, nn;
 
         fmpz_init(a);
-        fmpz_init(p);
+        fmpz_init(n);
+        mpz_init(aa);
+        mpz_init(nn);
 
-        mpz_init(b);
-        mpz_init(q);
-
-        mpz_rrandomb(q, state->gmp_state, n_randint(state, 200) + 1);
-#ifdef mpz_next_likely_prime
-        mpz_next_likely_prime(q, q, state->gmp_state);
-#else
-        mpz_nextprime(q, q);
-#endif
-        fmpz_set_mpz(p, q);
-
-        mpz_rrandomb(b, state->gmp_state, n_randint(state, 200) + 1);
-        mpz_mod(b, b, q);
-        if (n_randint(state, 2))
-            mpz_neg(b, b);
-        fmpz_set_mpz(a, b);
-
-        r1 = fmpz_jacobi(a, p);
-        r2 = mpz_jacobi(b, q);
-        result = (r1 == r2);
-
-        if (!result)
+        for (j = 0; j < 100; j++)
         {
-            flint_printf("FAIL:\n");
-            gmp_printf("b = %Zd, q = %Zd\n", b, q);
-            abort();
+            fmpz_randtest(a, state, 150);
+            fmpz_randtest_unsigned(n, state, 150);
+            fmpz_setbit(n, 0);
+
+            fmpz_get_mpz(aa, a);
+            fmpz_get_mpz(nn, n);
+
+            if (mpz_jacobi(aa, nn) != fmpz_jacobi(a, n))
+            {
+                flint_printf("FAIL:\n");
+                gmp_printf("a = %Zd, n = %Zd\n", aa, nn);
+                flint_abort();
+            }
         }
 
         fmpz_clear(a);
-        fmpz_clear(p);
-
-        mpz_clear(b);
-        mpz_clear(q);
+        fmpz_clear(n);
+        mpz_clear(aa);
+        mpz_clear(nn);
     }
 
     FLINT_TEST_CLEANUP(state);


### PR DESCRIPTION
resolves #895 
Can we add this to 2.7 to make a 2.7.2, and then use 2.7.2 in nemo? Nemo is still stuck on the buggy 2.7.0
The new fmpz_jacobi actually computes the jacobi_symbol, so it is backward compatible with the previous incomplete behavior.
Please check my work here ....
