### PR TITLE
Add fmpz kronecker

### DIFF
--- a/doc/source/fmpz.rst
+++ b/doc/source/fmpz.rst
@@ -1077,6 +1077,10 @@ Modular arithmetic
 
     Computes the Jacobi symbol `\left(\frac{a}{n}\right)` for any `a` and odd positive `n`.
 
+.. function:: int fmpz_kronecker(const fmpz_t a, const fmpz_t n)
+
+    Computes the Kronecker symbol `\left(\frac{a}{n}\right)` for any `a` and any `n`.
+
 .. function:: void fmpz_divides_mod_list(fmpz_t xstart, fmpz_t xstride, fmpz_t xlength, const fmpz_t a, const fmpz_t b, const fmpz_t n)
 
     Set `xstart`, `xstride`, and `xlength` so that the solution set for x modulo `n` in `a x = b mod n` is exactly `\{xstart + xstride i | 0 \le i < xlength\}`.

--- a/doc/source/fmpz.rst
+++ b/doc/source/fmpz.rst
@@ -1073,10 +1073,9 @@ Modular arithmetic
 
     Sets `f` to `-g \pmod{h}`, assuming `g` is reduced modulo `h`.
 
-.. function:: int fmpz_jacobi(const fmpz_t a, const fmpz_t p)
+.. function:: int fmpz_jacobi(const fmpz_t a, const fmpz_t n)
 
-    Computes the Jacobi symbol of `a` modulo `p`, where `p` is a prime
-    and `a` is reduced modulo `p`.
+    Computes the Jacobi symbol `\left(\frac{a}{n}\right)` for any `a` and odd positive `n`.
 
 .. function:: void fmpz_divides_mod_list(fmpz_t xstart, fmpz_t xstride, fmpz_t xlength, const fmpz_t a, const fmpz_t b, const fmpz_t n)
 

--- a/doc/source/long_extras.rst
+++ b/doc/source/long_extras.rst
@@ -46,3 +46,11 @@ Random functions
     Returns a pseudo random number of absolute value less than 
     ``limit``.  If ``limit`` is zero or exceeds ``WORD_MAX``, 
     it is interpreted as ``WORD_MAX``.
+
+
+Modular arithmetic
+--------------------------------------------------------------------------------
+
+.. function:: int z_kronecker(slong a, slong n)
+
+    Return the Kronecker symbol `\left(\frac{a}{n}\right)` for any `a` and any `n`.

--- a/doc/source/ulong_extras.rst
+++ b/doc/source/ulong_extras.rst
@@ -388,8 +388,7 @@ Jacobi and Kronecker symbols
 
 .. function:: int n_jacobi(mp_limb_signed_t x, ulong y)
 
-    Computes the Jacobi symbol of `x \bmod{y}`.  Assumes that `y` is positive 
-    and odd, and for performance reasons that `\gcd(x, y) = 1`.
+    Computes the Jacobi symbol of `x \bmod{y}` for any x and odd `y`.
 
     This is just a straightforward application of the law of quadratic
     reciprocity. For performance, divisions are replaced with some 

--- a/doc/source/ulong_extras.rst
+++ b/doc/source/ulong_extras.rst
@@ -388,11 +388,7 @@ Jacobi and Kronecker symbols
 
 .. function:: int n_jacobi(mp_limb_signed_t x, ulong y)
 
-    Computes the Jacobi symbol of `x \bmod{y}` for any x and odd `y`.
-
-    This is just a straightforward application of the law of quadratic
-    reciprocity. For performance, divisions are replaced with some 
-    comparisons and subtractions where possible.
+    Computes the Jacobi symbol `\left(\frac{x}{y}\right)` for any x and odd `y`.
 
 .. function:: int n_jacobi_unsigned(ulong x, ulong y)
 

--- a/fmpz.h
+++ b/fmpz.h
@@ -630,6 +630,8 @@ FLINT_DLL int fmpz_invmod(fmpz_t f, const fmpz_t g, const fmpz_t h);
 
 FLINT_DLL int fmpz_jacobi(const fmpz_t a, const fmpz_t p);
 
+FLINT_DLL int fmpz_kronecker(const fmpz_t a, const fmpz_t n);
+
 FLINT_DLL void fmpz_divides_mod_list(fmpz_t xstart, fmpz_t xstride,
                fmpz_t xlength, const fmpz_t a, const fmpz_t b, const fmpz_t n);
 

--- a/fmpz/jacobi.c
+++ b/fmpz/jacobi.c
@@ -22,17 +22,14 @@ fmpz_jacobi(const fmpz_t a, const fmpz_t p)
     mpz_t t, u;
     int r;
 
-    if (d == 0)
-       return 0;
-
-    if (c == 2)
-        return 1;
-
     if (!COEFF_IS_MPZ(c) && !COEFF_IS_MPZ(d))
         return n_jacobi(d, c);
 
     if (COEFF_IS_MPZ(c) && COEFF_IS_MPZ(d))
         return mpz_jacobi(COEFF_TO_PTR(d), COEFF_TO_PTR(c));
+
+    if (d == 0)
+        return 0; /* a is zero and p is large */
 
     flint_mpz_init_set_readonly(t, a);
     flint_mpz_init_set_readonly(u, p);

--- a/fmpz/kronecker.c
+++ b/fmpz/kronecker.c
@@ -1,0 +1,40 @@
+/*
+    Copyright (C) 2021 Dnaiel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <gmp.h>
+#include "flint.h"
+#include "long_extras.h"
+#include "fmpz.h"
+
+int fmpz_kronecker(const fmpz_t a, const fmpz_t n)
+{
+    fmpz A = *a;
+    fmpz N = *n;
+    mpz_t aa, nn;
+    int r;
+
+    if (!COEFF_IS_MPZ(A) && !COEFF_IS_MPZ(N))
+        return z_kronecker(A, N);
+
+    if (COEFF_IS_MPZ(A) && COEFF_IS_MPZ(N))
+        return mpz_kronecker(COEFF_TO_PTR(A), COEFF_TO_PTR(N));
+
+    flint_mpz_init_set_readonly(aa, a);
+    flint_mpz_init_set_readonly(nn, n);
+
+    r = mpz_jacobi(aa, nn);
+
+    flint_mpz_clear_readonly(aa);
+    flint_mpz_clear_readonly(nn);
+
+    return r;
+}
+

--- a/fmpz/test/t-jacobi.c
+++ b/fmpz/test/t-jacobi.c
@@ -19,57 +19,43 @@
 int
 main(void)
 {
-    int i, result;
+    slong i, j;
     FLINT_TEST_INIT(state);
 
     flint_printf("jacobi....");
     fflush(stdout);
 
-    
-    _flint_rand_init_gmp(state);
-
     for (i = 0; i < 3000 * flint_test_multiplier(); i++)
     {
-        fmpz_t a, p;
-        mpz_t b, q;
-        int r1, r2;
+        fmpz_t a, n;
+        mpz_t aa, nn;
 
         fmpz_init(a);
-        fmpz_init(p);
+        fmpz_init(n);
+        mpz_init(aa);
+        mpz_init(nn);
 
-        mpz_init(b);
-        mpz_init(q);
-
-        mpz_rrandomb(q, state->gmp_state, n_randint(state, 200) + 1);
-#ifdef mpz_next_likely_prime
-        mpz_next_likely_prime(q, q, state->gmp_state);
-#else
-        mpz_nextprime(q, q);
-#endif
-        fmpz_set_mpz(p, q);
-
-        mpz_rrandomb(b, state->gmp_state, n_randint(state, 200) + 1);
-        mpz_mod(b, b, q);
-        if (n_randint(state, 2))
-            mpz_neg(b, b);
-        fmpz_set_mpz(a, b);
-
-        r1 = fmpz_jacobi(a, p);
-        r2 = mpz_jacobi(b, q);
-        result = (r1 == r2);
-
-        if (!result)
+        for (j = 0; j < 100; j++)
         {
-            flint_printf("FAIL:\n");
-            gmp_printf("b = %Zd, q = %Zd\n", b, q);
-            abort();
+            fmpz_randtest(a, state, 150);
+            fmpz_randtest_unsigned(n, state, 150);
+            fmpz_setbit(n, 0);
+
+            fmpz_get_mpz(aa, a);
+            fmpz_get_mpz(nn, n);
+
+            if (mpz_jacobi(aa, nn) != fmpz_jacobi(a, n))
+            {
+                flint_printf("FAIL:\n");
+                gmp_printf("a = %Zd, n = %Zd\n", aa, nn);
+                flint_abort();
+            }
         }
 
         fmpz_clear(a);
-        fmpz_clear(p);
-
-        mpz_clear(b);
-        mpz_clear(q);
+        fmpz_clear(n);
+        mpz_clear(aa);
+        mpz_clear(nn);
     }
 
     FLINT_TEST_CLEANUP(state);

--- a/fmpz/test/t-kronecker.c
+++ b/fmpz/test/t-kronecker.c
@@ -1,0 +1,64 @@
+/*
+    Copyright (C) 2009 William Hart
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <gmp.h>
+#include "flint.h"
+#include "ulong_extras.h"
+#include "fmpz.h"
+
+int
+main(void)
+{
+    slong i, j;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("kronecker....");
+    fflush(stdout);
+
+    for (i = 0; i < 3000 * flint_test_multiplier(); i++)
+    {
+        fmpz_t a, n;
+        mpz_t aa, nn;
+
+        fmpz_init(a);
+        fmpz_init(n);
+        mpz_init(aa);
+        mpz_init(nn);
+
+        for (j = 0; j < 100; j++)
+        {
+            fmpz_randtest(a, state, 150);
+            fmpz_randtest(n, state, 150);
+
+            fmpz_get_mpz(aa, a);
+            fmpz_get_mpz(nn, n);
+
+            if (mpz_kronecker(aa, nn) != fmpz_kronecker(a, n))
+            {
+                flint_printf("FAIL:\n");
+                gmp_printf("a = %Zd, n = %Zd\n", aa, nn);
+                flint_abort();
+            }
+        }
+
+        fmpz_clear(a);
+        fmpz_clear(n);
+        mpz_clear(aa);
+        mpz_clear(nn);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+
+    flint_printf("PASS\n");
+    return 0;
+}

--- a/long_extras.h
+++ b/long_extras.h
@@ -67,6 +67,10 @@ FLINT_DLL mp_limb_signed_t z_randtest_not_zero(flint_rand_t state);
 
 FLINT_DLL mp_limb_signed_t z_randint(flint_rand_t state, mp_limb_t limit);
 
+/*****************************************************************************/
+
+FLINT_DLL int z_kronecker(slong a, slong n);
+
 #ifdef __cplusplus
 }
 #endif

--- a/long_extras/kronecker.c
+++ b/long_extras/kronecker.c
@@ -1,0 +1,48 @@
+/*
+    Copyright (C) 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "flint.h"
+#include "long_extras.h"
+#include "ulong_extras.h"
+
+int z_kronecker(slong a, slong n)
+{
+    ulong sa = FLINT_SIGN_EXT(a);
+    ulong ua = FLINT_ABS(a);
+    ulong sn = FLINT_SIGN_EXT(n);
+    ulong un = FLINT_ABS(n);
+    int en;
+    unsigned int r;
+
+    if (a == 0)
+        return un == 1;
+
+    if (un == 0)
+        return ua == 1;
+
+    count_trailing_zeros(en, un);
+
+    /* make denominator positive */
+    r = sa & sn;
+
+    /* make denominator odd */
+    un >>= en;
+    r ^= (ua ^ (ua>>1)) & (2*en);
+
+    if (en > 0 && !(ua & 1))
+        return 0; /* a and n both even */
+
+    /* make numerator positive */
+    r ^= (sa & un);
+
+    return _n_jacobi_unsigned(ua, un, r);
+}
+

--- a/long_extras/test/t-kronecker.c
+++ b/long_extras/test/t-kronecker.c
@@ -1,0 +1,60 @@
+/*
+    Copyright (C) 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <gmp.h>
+#include "flint.h"
+#include "long_extras.h"
+#include "ulong_extras.h"
+
+int main(void)
+{
+    slong i;
+    mpz_t aa, nn;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("kronecker....");
+    fflush(stdout);
+
+    mpz_init(aa);
+    mpz_init(nn);
+
+    for (i = 0; i < 300000 * flint_test_multiplier(); i++)
+    {
+        slong a = z_randtest(state);
+        slong n = z_randtest(state);
+
+        if (n_randlimb(state) & 1)
+            a = -a;
+
+        if (n_randlimb(state) & 1)
+            n = -n;
+
+        flint_mpz_set_si(aa, a);
+        flint_mpz_set_si(nn, n);
+
+        if (mpz_kronecker(aa, nn) != z_kronecker(a, n))
+        {
+            flint_printf("FAIL:\n");
+            flint_printf("a = %wd, n = %wd\n", a, n);
+            flint_abort();
+        }
+    }
+
+    mpz_clear(aa);
+    mpz_clear(nn);
+
+    FLINT_TEST_CLEANUP(state);
+
+    flint_printf("PASS\n");
+    return 0;
+}

--- a/ulong_extras.h
+++ b/ulong_extras.h
@@ -340,6 +340,8 @@ FLINT_DLL int n_jacobi(slong x, ulong y);
 
 FLINT_DLL int n_jacobi_unsigned(ulong x, ulong y);
 
+FLINT_DLL int _n_jacobi_unsigned(ulong x, ulong y, unsigned int r);
+
 FLINT_DLL ulong n_sqrt(ulong a);
 
 FLINT_DLL ulong n_sqrtrem(ulong * r, ulong a);


### PR DESCRIPTION
This builds on `fix fmpz_jacobi so that it compute the jacobi symbol` to also add the kronecker symbol.
Also, the n_jacobi was not "insanely fast", so I replaced it with a faster and simpler version.