### PR TITLE
Add fmpz mpoly gcd hensel

### DIFF
--- a/doc/source/fmpz_mpoly.rst
+++ b/doc/source/fmpz_mpoly.rst
@@ -601,14 +601,11 @@ Greatest Common Divisor
     Do the operation of :func:`fmpz_mpoly_gcd` and also compute ``Abar = A/G`` and ``Bbar = B/G`` if successful.
 
 .. function:: int fmpz_mpoly_gcd_brown(fmpz_mpoly_t G, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx)
-              int fmpz_mpoly_gcd_brown_threaded(fmpz_mpoly_t G, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx)
+              int fmpz_mpoly_gcd_hensel(fmpz_mpoly_t G, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx)
+              int fmpz_mpoly_gcd_zippel(fmpz_mpoly_t G, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx)
+              int fmpz_mpoly_gcd_zippel2(fmpz_mpoly_t G, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx)
 
-    Try to set ``G`` to the GCD of ``A`` and ``B`` using Brown's algorithm.
-    The first version always uses one thread.
-
-.. function:: int fmpz_mpoly_gcd_zippel(fmpz_mpoly_t G, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx)
-
-    Try to set ``G`` to the GCD of ``A`` and ``B`` using Zippel's interpolation algorithm to interpolate coefficients from univariate images in the most significant variable.
+    Try to set ``G`` to the GCD of ``A`` and ``B`` using various algorithms.
 
 
 Square Root

--- a/fmpz_mod_vec.h
+++ b/fmpz_mod_vec.h
@@ -32,6 +32,9 @@ FLINT_DLL void _fmpz_mod_vec_set_fmpz_vec(fmpz * A, const fmpz * B, slong len,
 FLINT_DLL void _fmpz_mod_vec_neg(fmpz * A, const fmpz * B, slong len,
                                                      const fmpz_mod_ctx_t ctx);
 
+FLINT_DLL void _fmpz_mod_vec_sub(fmpz * a, const fmpz * b, const fmpz * c,
+                                            slong n, const fmpz_mod_ctx_t ctx);
+
 FLINT_DLL void _fmpz_mod_vec_scalar_mul_fmpz_mod(fmpz * A, const fmpz * B,
                           slong len, const fmpz_t c, const fmpz_mod_ctx_t ctx);
 

--- a/fmpz_mod_vec/sub.c
+++ b/fmpz_mod_vec/sub.c
@@ -1,0 +1,19 @@
+/*
+    Copyright (C) 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz_mod_vec.h"
+
+void _fmpz_mod_vec_sub(fmpz * a, const fmpz * b, const fmpz * c,
+                                             slong n, const fmpz_mod_ctx_t ctx)
+{
+    while (--n >= 0)
+        fmpz_mod_sub(a + n, b + n, c + n, ctx);
+}

--- a/fmpz_mpoly.h
+++ b/fmpz_mpoly.h
@@ -977,7 +977,7 @@ FLINT_DLL void fmpz_mpoly_deflate(fmpz_mpoly_t A, const fmpz_mpoly_t B,
 FLINT_DLL void fmpz_mpoly_inflate(fmpz_mpoly_t A, const fmpz_mpoly_t B,
           const fmpz * shift, const fmpz * stride, const fmpz_mpoly_ctx_t ctx);
 
-FLINT_DLL int fmpz_mpoly_gcd_prs(fmpz_mpoly_t G,
+FLINT_DLL int fmpz_mpoly_gcd_hensel(fmpz_mpoly_t G,
        const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
 
 FLINT_DLL int fmpz_mpoly_gcd_brown(fmpz_mpoly_t G,

--- a/fmpz_mpoly/gcd_hensel.c
+++ b/fmpz_mpoly/gcd_hensel.c
@@ -1,0 +1,26 @@
+/*
+    Copyright (C) 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz_mpoly.h"
+#include "fmpz_mpoly_factor.h"
+
+int fmpz_mpoly_gcd_hensel(
+    fmpz_mpoly_t G,
+    const fmpz_mpoly_t A,
+    const fmpz_mpoly_t B,
+    const fmpz_mpoly_ctx_t ctx)
+{
+    if (fmpz_mpoly_is_zero(A, ctx) || fmpz_mpoly_is_zero(B, ctx))
+        return fmpz_mpoly_gcd(G, A, B, ctx);
+
+    return _fmpz_mpoly_gcd_algo(G, NULL, NULL, A, B, ctx, MPOLY_GCD_USE_HENSEL);
+}
+

--- a/fmpz_mpoly/test/t-gcd_hensel.c
+++ b/fmpz_mpoly/test/t-gcd_hensel.c
@@ -1,0 +1,190 @@
+/*
+    Copyright (C) 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz_mpoly.h"
+
+void gcd_check(
+    fmpz_mpoly_t g,
+    fmpz_mpoly_t a,
+    fmpz_mpoly_t b,
+    fmpz_mpoly_t t,
+    fmpz_mpoly_ctx_t ctx,
+    slong i,
+    slong j,
+    const char * name)
+{
+    fmpz_mpoly_t ca, cb, cg;
+
+    fmpz_mpoly_init(ca, ctx);
+    fmpz_mpoly_init(cb, ctx);
+    fmpz_mpoly_init(cg, ctx);
+
+    if (!fmpz_mpoly_gcd_hensel(g, a, b, ctx))
+    {
+        flint_printf("FAIL: check gcd can be computed\n");
+        flint_printf("i = %wd, j = %wd, %s\n", i, j, name);
+        flint_abort();
+    }
+
+    fmpz_mpoly_assert_canonical(g, ctx);
+
+    if (fmpz_mpoly_is_zero(g, ctx))
+    {
+        if (!fmpz_mpoly_is_zero(a, ctx) || !fmpz_mpoly_is_zero(b, ctx))
+        {
+            flint_printf("FAIL: check zero gcd\n");
+            flint_printf("i = %wd, j = %wd, %s\n", i, j, name);
+            flint_abort();
+        }
+        goto cleanup;
+    }
+
+    if (fmpz_sgn(g->coeffs + 0) <= 0)
+    {
+        flint_printf("FAIL: check gcd is unit normal\n");
+        flint_printf("i = %wd, j = %wd, %s\n", i, j, name);
+        flint_abort();
+    }
+
+    if (!fmpz_mpoly_is_zero(t, ctx) && !fmpz_mpoly_divides(cg, g, t, ctx))
+    {
+        flint_printf("FAIL: check gcd divisor\n");
+        flint_printf("i = %wd, j = %wd, %s\n", i, j, name);
+        flint_abort();
+    }
+
+    if (!fmpz_mpoly_divides(ca, a, g, ctx) ||
+        !fmpz_mpoly_divides(cb, b, g, ctx))
+    {
+        flint_printf("FAIL: check divisibility\n");
+        flint_printf("i = %wd, j = %wd, %s\n", i, j, name);
+        flint_abort();
+    }
+
+    if (!fmpz_mpoly_gcd_hensel(cg, ca, cb, ctx))
+    {
+        flint_printf("FAIL: check cofactor gcd can be computed\n");
+        flint_printf("i = %wd, j = %wd, %s\n", i, j, name);
+        flint_abort();
+    }
+
+    fmpz_mpoly_assert_canonical(cg, ctx);
+
+    if (!fmpz_mpoly_is_one(cg, ctx))
+    {
+        flint_printf("FAIL: check gcd of cofactors is one\n");
+        flint_printf("i = %wd, j = %wd, %s\n", i, j, name);
+        flint_abort();
+    }
+
+cleanup:
+
+    fmpz_mpoly_clear(ca, ctx);
+    fmpz_mpoly_clear(cb, ctx);
+    fmpz_mpoly_clear(cg, ctx);
+}
+
+
+int
+main(void)
+{
+    slong i, j, tmul = 20;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("gcd_hensel....");
+    fflush(stdout);
+
+    for (i = 0; i < tmul * flint_test_multiplier(); i++)
+    {
+        fmpz_mpoly_ctx_t ctx;
+        fmpz_mpoly_t a, b, g, t1, t2, t3;
+        slong len, len1, len2;
+        ulong degbound;
+        ulong * degbounds, * degbounds1, * degbounds2;
+        flint_bitcnt_t coeff_bits;
+
+        fmpz_mpoly_ctx_init_rand(ctx, state, 5);
+
+        fmpz_mpoly_init(g, ctx);
+        fmpz_mpoly_init(a, ctx);
+        fmpz_mpoly_init(b, ctx);
+        fmpz_mpoly_init(t1, ctx);
+        fmpz_mpoly_init(t2, ctx);
+        fmpz_mpoly_init(t3, ctx);
+
+        degbound = 42/(2*ctx->minfo->nvars - 1);
+        degbounds = FLINT_ARRAY_ALLOC(ctx->minfo->nvars, ulong);
+        degbounds1 = FLINT_ARRAY_ALLOC(ctx->minfo->nvars, ulong);
+        degbounds2 = FLINT_ARRAY_ALLOC(ctx->minfo->nvars, ulong);
+
+        for (j = 0; j < ctx->minfo->nvars; j++)
+        {
+            degbounds[j] = n_randint(state, degbound + 1) + 1;
+            degbounds1[j] = n_randint(state, degbound + 1) + 1;
+            degbounds2[j] = n_randint(state, degbound + 1) + 1;
+        }
+
+        for (j = 0; j < 6; j++)
+        {
+            len = n_randint(state, 10) + 1;
+            len1 = n_randint(state, 10);
+            len2 = n_randint(state, 15);
+
+            coeff_bits = n_randint(state, 200) + 10;
+            fmpz_mpoly_randtest_bounds(t1, state, coeff_bits, len, degbounds, ctx);
+            coeff_bits = n_randint(state, 200) + 10;
+            fmpz_mpoly_randtest_bounds(t2, state, coeff_bits, len1, degbounds1, ctx);
+            coeff_bits = n_randint(state, 200) + 10;
+            fmpz_mpoly_randtest_bounds(t3, state, coeff_bits, len2, degbounds2, ctx);
+
+            switch (n_randint(state, 4))
+            {
+                case 3:
+                    fmpz_mpoly_mul(t3, t1, t2, ctx);
+                    break;
+                case 2:
+                    fmpz_mpoly_mul(t3, t3, t1, ctx);
+                    break;
+                case 1:
+                    fmpz_mpoly_mul(t3, t3, t2, ctx);
+                    break;
+                default:
+                    break;
+            }
+
+            fmpz_mpoly_mul(a, t1, t3, ctx);
+            fmpz_mpoly_mul(b, t2, t3, ctx);
+
+            coeff_bits = n_randint(state, 300) + 10;
+            fmpz_mpoly_randtest_bits(g, state, coeff_bits, len, FLINT_BITS, ctx);
+
+            if (a->length < 4000 && b->length < 4000)
+                gcd_check(g, a, b, t3, ctx, i, j, "random");
+        }
+
+        flint_free(degbounds);
+        flint_free(degbounds1);
+        flint_free(degbounds2);
+
+        fmpz_mpoly_clear(g, ctx);
+        fmpz_mpoly_clear(a, ctx);
+        fmpz_mpoly_clear(b, ctx);
+        fmpz_mpoly_clear(t1, ctx);
+        fmpz_mpoly_clear(t2, ctx);
+        fmpz_mpoly_clear(t3, ctx);
+        fmpz_mpoly_ctx_clear(ctx);
+    }
+
+    flint_printf("PASS\n");
+    FLINT_TEST_CLEANUP(state);
+
+    return 0;
+}

--- a/fmpz_mpoly_factor.h
+++ b/fmpz_mpoly_factor.h
@@ -319,11 +319,39 @@ FLINT_DLL int fmpz_mpolyl_gcd_zippel2(fmpz_mpoly_t G, fmpz_mpoly_t Abar,
 /*****************************************************************************/
 
 typedef struct {
+    slong r;
+    flint_bitcnt_t * bits;
+    fmpz_poly_t a;
+    fmpz_poly_t newa;
+    fmpz_poly_t t;
+    fmpz_poly_struct * b, * bprod;
+    fmpz_t old_pk;
+    fmpz_t pk;
+    fmpz_t p;
+    fmpz_t halfpk;
+    fmpz_mod_ctx_t ctx;
+    fmpz_mod_poly_t T;
+    fmpz_mod_poly_t R;
+    fmpz_mod_poly_t Q;
+    fmpz_mod_poly_struct * B, * invBprod, * inwBprod, * B_inv;
+} fmpz_poly_pfrac_struct;
+
+typedef fmpz_poly_pfrac_struct fmpz_poly_pfrac_t[1];
+
+FLINT_DLL void fmpz_poly_pfrac_init(fmpz_poly_pfrac_t I);
+
+FLINT_DLL void fmpz_poly_pfrac_clear(fmpz_poly_pfrac_t I);
+
+FLINT_DLL int fmpz_poly_pfrac_precompute(fmpz_poly_pfrac_t I,
+                                          const fmpz_poly_struct * b, slong r);
+
+FLINT_DLL int fmpz_poly_pfrac_precomp(fmpz_poly_struct * c,
+                                     const fmpz_poly_t A, fmpz_poly_pfrac_t I);
+
+typedef struct {
     flint_bitcnt_t bits;
     slong w;
     slong r;
-    fmpq_poly_struct * inv_prod_dbetas;
-    fmpq_poly_struct * dbetas;
     fmpz_mpoly_struct * prod_mbetas;
     fmpz_mpolyv_struct * prod_mbetas_coeffs;
     fmpz_mpoly_struct * mbetas;
@@ -335,7 +363,9 @@ typedef struct {
     fmpz_mpoly_struct * qt;
     fmpz_mpoly_struct * newt;
     fmpz_mpolyv_struct * delta_coeffs;
-    fmpq_poly_t dtq, S, R;
+    fmpz_poly_pfrac_t uni_pfrac;
+    fmpz_poly_t uni_a;
+    fmpz_poly_struct * uni_c;
 } fmpz_mpoly_pfrac_struct;
 
 typedef fmpz_mpoly_pfrac_struct fmpz_mpoly_pfrac_t[1];

--- a/fmpz_mpoly_factor.h
+++ b/fmpz_mpoly_factor.h
@@ -328,8 +328,9 @@ typedef struct {
     fmpz_t old_pk;
     fmpz_t pk;
     fmpz_t p;
-    fmpz_t halfpk;
-    fmpz_mod_ctx_t ctx;
+    fmpz * halfpks;
+    fmpz_mod_ctx_t ctxp;
+    fmpz_mod_ctx_struct * ctxs;
     fmpz_mod_poly_t T;
     fmpz_mod_poly_t R;
     fmpz_mod_poly_t Q;

--- a/fmpz_mpoly_factor.h
+++ b/fmpz_mpoly_factor.h
@@ -316,6 +316,10 @@ FLINT_DLL int fmpz_mpolyl_gcd_zippel2(fmpz_mpoly_t G, fmpz_mpoly_t Abar,
                 fmpz_mpoly_t Bbar, const fmpz_mpoly_t A, const fmpz_mpoly_t B,
                          const fmpz_mpoly_t Gamma, const fmpz_mpoly_ctx_t ctx);
 
+FLINT_DLL int fmpz_mpolyl_gcd_hensel(fmpz_mpoly_t G, slong Gdeg,
+                fmpz_mpoly_t Abar, fmpz_mpoly_t Bbar, const fmpz_mpoly_t A,
+                             const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
+
 /*****************************************************************************/
 
 typedef struct {

--- a/fmpz_mpoly_factor/gcd_hensel.c
+++ b/fmpz_mpoly_factor/gcd_hensel.c
@@ -1,0 +1,435 @@
+/*
+    Copyright (C) 2020 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz_mpoly_factor.h"
+
+int fmpz_mpolyl_gcd_hensel(
+    fmpz_mpoly_t G, slong Gdeg, /* upperbound on deg_X(G) */
+    fmpz_mpoly_t Abar,
+    fmpz_mpoly_t Bbar,
+    const fmpz_mpoly_t A,
+    const fmpz_mpoly_t B,
+    const fmpz_mpoly_ctx_t ctx)
+{
+    int success, alpha_bits, gamma_is_one;
+    const slong n = ctx->minfo->nvars - 1;
+    slong i, k;
+    flint_bitcnt_t bits = A->bits;
+    fmpz * alphas, * prev_alphas;
+    fmpz_t q, mu1, mu2;
+    fmpq_t mu;
+    fmpz_mpoly_struct * Aevals, * Bevals, * Hevals;
+    fmpz_mpoly_struct * H; /* points to A, B, or Hevals + n */
+    fmpz_mpoly_struct * Glcs, * Hlcs;
+    fmpz_mpoly_struct Hfac[2], Htfac[2];
+    slong * Hdegs;
+    slong Adegx, Bdegx, gdegx;
+    fmpz_mpoly_t t1, t2, g, abar, bbar, hbar;
+    flint_rand_t state;
+
+    FLINT_ASSERT(n > 0);
+    FLINT_ASSERT(A->length > 0);
+    FLINT_ASSERT(B->length > 0);
+    FLINT_ASSERT(bits <= FLINT_BITS);
+    FLINT_ASSERT(A->bits == bits);
+    FLINT_ASSERT(B->bits == bits);
+    FLINT_ASSERT(ctx->minfo->ord == ORD_LEX);
+
+    flint_randinit(state);
+
+    Hdegs  = FLINT_ARRAY_ALLOC(n + 1, slong);
+
+    Glcs   = FLINT_ARRAY_ALLOC(3*(n + 1), fmpz_mpoly_struct);
+    Hlcs   = Glcs + (n + 1);
+    Hevals = Hlcs + (n + 1);
+    for (i = 0; i < n + 1; i++)
+    {
+        fmpz_mpoly_init(Glcs + i, ctx);
+        fmpz_mpoly_init(Hlcs + i, ctx);
+        fmpz_mpoly_init(Hevals + i, ctx);
+    }
+
+    alphas = _fmpz_vec_init(2*n);
+    prev_alphas = alphas + n;
+    Aevals = FLINT_ARRAY_ALLOC(2*(n + 1), fmpz_mpoly_struct);
+    Bevals = Aevals + (n + 1);
+    for (i = 0; i < n; i++)
+    {
+        fmpz_mpoly_init(Aevals + i, ctx);
+        fmpz_mpoly_init(Bevals + i, ctx);
+    }
+
+    fmpz_init(q);
+    fmpq_init(mu);
+    fmpz_init(mu1);
+    fmpz_init(mu2);
+
+    fmpz_mpoly_init(t1, ctx);
+    fmpz_mpoly_init(t2, ctx);
+    fmpz_mpoly_init(g, ctx);
+    fmpz_mpoly_init(abar, ctx);
+    fmpz_mpoly_init(bbar, ctx);
+    fmpz_mpoly_init(hbar, ctx);
+
+    fmpz_mpoly_init(Hfac + 0, ctx);
+    fmpz_mpoly_init(Hfac + 1, ctx);
+    fmpz_mpoly_init(Htfac + 0, ctx);
+    fmpz_mpoly_init(Htfac + 1, ctx);
+
+    /* init done */
+
+    alpha_bits = 0;
+
+    /* try all zeros first */
+    for (i = 0; i < n; i++)
+    {
+        fmpz_zero(prev_alphas + i);
+        fmpz_zero(alphas + i);
+    }
+
+    goto got_alpha;
+
+next_alpha:
+
+    alpha_bits++;
+    if (alpha_bits > FLINT_BITS/2)
+    {
+        success = 0;
+        goto cleanup;
+    }
+
+    success = 0;
+
+    for (i = 0; i < n; i++)
+    {
+        ulong l = n_randlimb(state);
+        ulong mask = UWORD(1) << alpha_bits;
+        if (l & mask)
+            fmpz_neg_ui(alphas + i, l & (mask - 1));
+        else
+            fmpz_set_ui(alphas + i, l & (mask - 1));
+
+        success = success || !fmpz_equal(alphas + i, prev_alphas + i);
+    }
+
+    if (!success)
+        goto next_alpha;
+
+got_alpha:
+
+    /* ensure deg_X do not drop under evaluation */
+    Adegx = fmpz_mpoly_degree_si(A, 0, ctx);
+    Bdegx = fmpz_mpoly_degree_si(B, 0, ctx);
+    for (i = n - 1; i >= 0; i--)
+    {
+        fmpz_mpoly_evaluate_one_fmpz(Aevals + i, i == n - 1 ? A :
+                                       Aevals + i + 1, i + 1, alphas + i, ctx);
+        fmpz_mpoly_evaluate_one_fmpz(Bevals + i, i == n - 1 ? B :
+                                       Bevals + i + 1, i + 1, alphas + i, ctx);
+        if (Adegx != fmpz_mpoly_degree_si(Aevals + i, 0, ctx) ||
+            Bdegx != fmpz_mpoly_degree_si(Bevals + i, 0, ctx))
+        {
+            goto next_alpha;
+        }
+    }
+
+    /* univariate gcd */
+    success = fmpz_mpoly_gcd_cofactors(g, abar, bbar, Aevals + 0, Bevals + 0, ctx) &&
+              fmpz_mpoly_gcd(t1, g, abar, ctx) &&
+              fmpz_mpoly_gcd(t2, g, bbar, ctx);
+    if (!success)
+        goto cleanup;
+
+    gdegx = fmpz_mpoly_degree_si(g, 0, ctx);
+
+    if (gdegx == 0)
+    {
+        /* G is trivial */
+        fmpz_mpoly_set(Abar, A, ctx);
+        fmpz_mpoly_set(Bbar, B, ctx);
+        fmpz_mpoly_one(G, ctx);
+        success = 1;
+        goto cleanup;
+    }
+    else if (gdegx > Gdeg)
+    {
+        goto next_alpha;
+    }
+    else if (gdegx < Gdeg)
+    {
+        Gdeg = gdegx;
+        for (i = 0; i < n; i++)
+            fmpz_set(prev_alphas + i, alphas + i);
+
+        goto next_alpha;
+    }
+
+    /* the degbound gdegx (== Gdeg) has at least two witnesses now */
+
+    if (gdegx == Adegx)
+    {
+        if (fmpz_mpoly_divides(Bbar, B, A, ctx))
+        {
+            fmpz_mpoly_set(G, A, ctx);
+            fmpz_mpoly_one(Abar, ctx);
+            success = 1;
+            goto cleanup;
+        }
+
+        goto next_alpha;
+    }
+    else if (gdegx == Bdegx)
+    {
+        if (fmpz_mpoly_divides(Abar, A, B, ctx))
+        {
+            fmpz_mpoly_set(G, B, ctx);
+            fmpz_mpoly_one(Bbar, ctx);
+            success = 1;
+            goto cleanup;
+        }
+
+        goto next_alpha;
+    }
+
+    FLINT_ASSERT(0 < gdegx && gdegx < FLINT_MIN(Adegx, Bdegx));
+
+    /* set Hlcs[n], Glcs[n] (gamma), H, and Hevals */
+    if (fmpz_mpoly_is_one(t1, ctx))
+    {
+        fmpz_one(mu1);
+        fmpz_zero(mu2);
+
+        fmpz_mpoly_swap(hbar, abar, ctx);
+
+        fmpz_mpolyl_lead_coeff(Hlcs + n, A, 1, ctx);
+        fmpz_mpolyl_lead_coeff(t2, B, 1, ctx);
+        success = fmpz_mpoly_gcd(Glcs + n, Hlcs + n, t2, ctx);
+        if (!success)
+            goto cleanup;
+
+        H = (fmpz_mpoly_struct *) A;
+
+        gamma_is_one = fmpz_mpoly_is_one(Glcs + n, ctx);
+        if (gamma_is_one)
+            for (i = 0; i < n; i++)
+                fmpz_mpoly_swap(Hevals + i, Aevals + i, ctx);
+    }
+    else if (fmpz_mpoly_is_one(t2, ctx))
+    {
+        fmpz_zero(mu1);
+        fmpz_one(mu2);
+
+        fmpz_mpoly_swap(hbar, bbar, ctx);
+
+        fmpz_mpolyl_lead_coeff(Hlcs + n, B, 1, ctx);
+        fmpz_mpolyl_lead_coeff(t2, A, 1, ctx);
+        success = fmpz_mpoly_gcd(Glcs + n, Hlcs + n, t2, ctx);
+        if (!success)
+            goto cleanup;
+
+        H = (fmpz_mpoly_struct *) B;
+
+        gamma_is_one = fmpz_mpoly_is_one(Glcs + n, ctx);
+        if (gamma_is_one)
+            for (i = 0; i < n; i++)
+                fmpz_mpoly_swap(Hevals + i, Bevals + i, ctx);
+    }
+    else
+    {
+        int mu_tries_remaining = 10;
+
+    next_mu:
+
+        if (--mu_tries_remaining < 0)
+        {
+            success = 0;
+            goto cleanup;
+        }
+
+        fmpq_next_signed_calkin_wilf(mu, mu);
+        fmpz_set(mu1, fmpq_numref(mu));
+        fmpz_set(mu2, fmpq_denref(mu));
+
+        fmpz_mpoly_scalar_fmma(hbar, abar, mu1, bbar, mu2, ctx);
+
+        /* make sure the linear combo did not drop degree */
+        if (fmpz_mpoly_degree_si(hbar, 0, ctx) != FLINT_MAX(Adegx, Bdegx) - gdegx)
+            goto next_mu;
+
+        /* make sure the linear combo is prime to g */
+        success = fmpz_mpoly_gcd(t1, hbar, g, ctx);
+        if (!success)
+            goto cleanup;
+
+        if (!fmpz_mpoly_is_fmpz(t1, ctx))
+            goto next_mu;
+
+        fmpz_mpolyl_lead_coeff(t1, A, 1, ctx);
+        fmpz_mpolyl_lead_coeff(t2, B, 1, ctx);
+        success = fmpz_mpoly_gcd(Glcs + n, t1, t2, ctx);
+        if (!success)
+            goto cleanup;
+
+        H = Hevals + n;
+        fmpz_mpoly_scalar_fmma(H, A, mu1, B, mu2, ctx);
+        fmpz_mpolyl_lead_coeff(Hlcs + n, H, 1, ctx);
+
+        gamma_is_one = fmpz_mpoly_is_one(Glcs + n, ctx);
+        if (gamma_is_one)
+            for (i = 0; i < n; i++)
+                fmpz_mpoly_scalar_fmma(Hevals + i, Aevals + i, mu1,
+                                                   Bevals + i, mu2, ctx);
+    }
+
+    if (!gamma_is_one)
+    {
+        fmpz_mpoly_mul(Hevals + n, H, Glcs + n, ctx);
+        H = Hevals + n;
+        for (i = n - 1; i >= 0; i--)
+            fmpz_mpoly_evaluate_one_fmpz(Hevals + i, Hevals + i + 1,
+                                                       i + 1, alphas + i, ctx);
+    }
+
+    success = H->bits <= FLINT_BITS ||
+              fmpz_mpoly_repack_bits_inplace(H, FLINT_BITS, ctx);
+    if (!success)
+        goto cleanup;
+
+    /* the evals should all fit in H->bits */
+    for (i = 0; i < n; i++)
+        fmpz_mpoly_repack_bits_inplace(Hevals + i, H->bits, ctx);
+
+    fmpz_mpoly_degrees_si(Hdegs, H, ctx);
+
+    /* computed evaluated leading coeffs */
+    for (i = n - 1; i >= 0; i--)
+    {
+        fmpz_mpoly_evaluate_one_fmpz(Glcs + i, Glcs + i + 1, i + 1, alphas + i, ctx);
+        fmpz_mpoly_evaluate_one_fmpz(Hlcs + i, Hlcs + i + 1, i + 1, alphas + i, ctx);
+        /* evaluation could have killed gamma */
+        if (fmpz_mpoly_is_zero(Glcs + i, ctx) ||
+            fmpz_mpoly_is_zero(Hlcs + i, ctx))
+        {
+            goto next_alpha;
+        }
+    }
+
+    /* make the lcs match Glcs[0], Hlcs[0], g & hbar not nec primitive */
+
+    fmpz_mpoly_scalar_mul_fmpz(Hfac + 0, g, Glcs[0].coeffs + 0, ctx);
+    success = fmpz_mpoly_scalar_divides_fmpz(Hfac + 0, Hfac + 0, g->coeffs + 0, ctx);
+    FLINT_ASSERT(success);
+
+    fmpz_mpoly_scalar_mul_fmpz(Hfac + 1, hbar, Hlcs[0].coeffs + 0, ctx);
+    success = fmpz_mpoly_scalar_divides_fmpz(Hfac + 1, Hfac + 1, hbar->coeffs + 0, ctx);
+    FLINT_ASSERT(success);
+
+    for (k = 1; k <= n; k++)
+    {
+        _fmpz_mpoly_set_lead0(Htfac + 0, Hfac + 0, Glcs + k, ctx);
+        _fmpz_mpoly_set_lead0(Htfac + 1, Hfac + 1, Hlcs + k, ctx);
+        success = fmpz_mpoly_hlift(k, Htfac, 2, alphas,
+                                           k < n ? Hevals + k : H, Hdegs, ctx);
+        if (!success)
+            goto next_alpha;
+
+        fmpz_mpoly_swap(Hfac + 0, Htfac + 0, ctx);
+        fmpz_mpoly_swap(Hfac + 1, Htfac + 1, ctx);
+    }
+
+    success = fmpz_mpolyl_content(t1, Hfac + 0, 1, ctx);
+    if (!success)
+        goto cleanup;
+
+    success = fmpz_mpoly_divides(G, Hfac + 0, t1, ctx);
+    FLINT_ASSERT(success);
+
+    if (fmpz_is_zero(mu2))
+    {
+        FLINT_ASSERT(fmpz_is_one(mu1));
+        /* the division by t1 should succeed, but let's be careful */
+        fmpz_mpolyl_lead_coeff(t1, G, 1, ctx);
+        success = fmpz_mpoly_divides(Abar, Hfac + 1, t1, ctx) &&
+                  fmpz_mpoly_divides(Bbar, B, G, ctx);
+    }
+    else if (fmpz_is_zero(mu1))
+    {
+        FLINT_ASSERT(fmpz_is_one(mu2));
+        /* ditto */
+        fmpz_mpolyl_lead_coeff(t1, G, 1, ctx);
+        success = fmpz_mpoly_divides(Bbar, Hfac + 1, t1, ctx) &&
+                  fmpz_mpoly_divides(Abar, A, G, ctx);
+    }
+    else
+    {
+        success = fmpz_mpoly_divides(Abar, A, G, ctx) &&
+                  fmpz_mpoly_divides(Bbar, B, G, ctx);
+    }
+
+    if (!success)
+        goto next_alpha;
+
+    success = 1;
+
+cleanup:
+
+    flint_randclear(state);
+
+    flint_free(Hdegs);
+
+    for (i = 0; i < n + 1; i++)
+    {
+        fmpz_mpoly_clear(Glcs + i, ctx);
+        fmpz_mpoly_clear(Hlcs + i, ctx);
+        fmpz_mpoly_clear(Hevals + i, ctx);
+    }
+    flint_free(Glcs);
+
+    _fmpz_vec_clear(alphas, 2*n);
+
+    for (i = 0; i < n; i++)
+    {
+        fmpz_mpoly_clear(Aevals + i, ctx);
+        fmpz_mpoly_clear(Bevals + i, ctx);
+    }
+    flint_free(Aevals);
+
+    fmpz_clear(q);
+    fmpq_clear(mu);
+    fmpz_clear(mu1);
+    fmpz_clear(mu2);
+
+    fmpz_mpoly_clear(t1, ctx);
+    fmpz_mpoly_clear(t2, ctx);
+    fmpz_mpoly_clear(g, ctx);
+    fmpz_mpoly_clear(abar, ctx);
+    fmpz_mpoly_clear(bbar, ctx);
+    fmpz_mpoly_clear(hbar, ctx);
+
+    fmpz_mpoly_clear(Hfac + 0, ctx);
+    fmpz_mpoly_clear(Hfac + 1, ctx);
+    fmpz_mpoly_clear(Htfac + 0, ctx);
+    fmpz_mpoly_clear(Htfac + 1, ctx);
+
+    if (success)
+    {
+        fmpz_mpoly_repack_bits_inplace(G, bits, ctx);
+        fmpz_mpoly_repack_bits_inplace(Abar, bits, ctx);
+        fmpz_mpoly_repack_bits_inplace(Bbar, bits, ctx);
+
+        FLINT_ASSERT(G->length > 0);
+        FLINT_ASSERT(Abar->length > 0);
+        FLINT_ASSERT(Bbar->length > 0);
+    }
+
+    return success;
+}
+

--- a/fmpz_mpoly_factor/irred_zassenhaus.c
+++ b/fmpz_mpoly_factor/irred_zassenhaus.c
@@ -306,6 +306,7 @@ got_alpha:
                 dfac->length = 2;
                 fmpz_mpoly_one(dfac->coeffs + 0, ctx);
                 fmpz_mpoly_one(dfac->coeffs + 1, ctx);
+
                 for (i = 0; i < len; i++)
                 {
                     int in = subset[i] >= 0;
@@ -324,8 +325,11 @@ got_alpha:
                     fmpz_mpoly_swap(q, tfac->coeffs + 0, ctx);
                     fmpz_mpoly_swap(p, dfac->coeffs + 0, ctx);
                     len -= k;
-                    if (!zassenhaus_subset_next_disjoint(subset, len + k))
+                    if (k > len/2 ||
+                        !zassenhaus_subset_next_disjoint(subset, len + k))
+                    {
                         break;
+                    }
                 }
                 else if (success < 0)
                 {

--- a/fmpz_mpoly_factor/mpoly_pfrac.c
+++ b/fmpz_mpoly_factor/mpoly_pfrac.c
@@ -12,94 +12,6 @@
 #include "fmpz_mpoly_factor.h"
 
 
-static void _to_polyq(
-    fmpq_poly_t A,
-    const fmpz_mpoly_t B,
-    const fmpz_mpoly_ctx_t ctx)
-{
-    slong i;
-    ulong mask;
-    slong shift, off, N;
-    slong Blen = B->length;
-    fmpz * Bcoeff = B->coeffs;
-    ulong * Bexp = B->exps;
-
-    FLINT_ASSERT(B->bits <= FLINT_BITS);
-
-    fmpq_poly_zero(A);
-
-    N = mpoly_words_per_exp_sp(B->bits, ctx->minfo);
-    mpoly_gen_offset_shift_sp(&off, &shift, 0, B->bits, ctx->minfo);
-
-    mask = (-UWORD(1)) >> (FLINT_BITS - B->bits);
-    for (i = 0; i < Blen; i++)
-        fmpq_poly_set_coeff_fmpz(A, (Bexp[N*i + off] >> shift) & mask, Bcoeff + i);
-}
-
-
-static int _from_polyq(
-    fmpz_mpoly_t A,
-    flint_bitcnt_t Abits,
-    const fmpq_poly_t B,
-    const fmpz_mpoly_ctx_t ctx)
-{
-    slong var = 0;
-    slong N;
-    slong k;
-    slong Alen;
-    fmpz * Acoeff;
-    ulong * Aexp;
-    slong Aalloc;
-    ulong * strideexp;
-    TMP_INIT;
-
-    if (B->length == 0)
-    {
-        fmpz_mpoly_zero(A, ctx);
-        return 1;
-    }
-
-    if (!fmpz_is_one(fmpq_poly_denref(B)))
-    {
-        return 0;
-    }
-
-    TMP_START;
-
-    FLINT_ASSERT(Abits <= FLINT_BITS);
-
-    N = mpoly_words_per_exp(Abits, ctx->minfo);
-    strideexp = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_gen_monomial_sp(strideexp, var, Abits, ctx->minfo);
-
-    fmpz_mpoly_fit_bits(A, Abits, ctx);
-    A->bits = Abits;
-
-    Acoeff = A->coeffs;
-    Aexp = A->exps;
-    Aalloc = A->alloc;
-    Alen = 0;
-    for (k = B->length - 1; k >= 0; k--)
-    {
-        _fmpz_mpoly_fit_length(&Acoeff, &Aexp, &Aalloc, Alen + 1, N);
-        if (!fmpz_is_zero(B->coeffs + k))
-        {
-            fmpz_swap(Acoeff + Alen, B->coeffs + k);
-            mpoly_monomial_mul_ui(Aexp + N*Alen, strideexp, N, k);
-            Alen++;
-        }
-    }
-    A->coeffs = Acoeff;
-    A->exps = Aexp;
-    A->alloc = Aalloc;
-    _fmpz_mpoly_set_length(A, Alen, ctx);
-
-    TMP_END;
-
-    return 1;
-}
-
-
 int fmpz_mpoly_pfrac_init(
     fmpz_mpoly_pfrac_t I,
     flint_bitcnt_t bits,
@@ -111,7 +23,6 @@ int fmpz_mpoly_pfrac_init(
 {
     slong success = 1;
     slong i, j, k;
-    fmpq_poly_t G, S, pq;
 
     FLINT_ASSERT(bits <= FLINT_BITS);
 
@@ -119,12 +30,6 @@ int fmpz_mpoly_pfrac_init(
     I->r = r;
     I->w = w;
 
-    fmpq_poly_init(I->dtq);
-    fmpq_poly_init(I->S);
-    fmpq_poly_init(I->R);
-
-    I->dbetas = FLINT_ARRAY_ALLOC(r, fmpq_poly_struct);
-    I->inv_prod_dbetas = FLINT_ARRAY_ALLOC(r, fmpq_poly_struct);
     I->prod_mbetas = FLINT_ARRAY_ALLOC((w + 1)*r, fmpz_mpoly_struct);
     I->prod_mbetas_coeffs = FLINT_ARRAY_ALLOC((w + 1)*r, fmpz_mpolyv_struct);
     I->mbetas = FLINT_ARRAY_ALLOC((w + 1)*r, fmpz_mpoly_struct);
@@ -159,10 +64,6 @@ int fmpz_mpoly_pfrac_init(
         fmpz_mpoly_repack_bits_inplace(I->xalpha + i, I->bits, ctx);
     }
 
-    fmpq_poly_init(G);
-    fmpq_poly_init(S);
-    fmpq_poly_init(pq);
-
     /* set betas */
     i = w;
     for (j = 0; j < r; j++)
@@ -178,11 +79,6 @@ int fmpz_mpoly_pfrac_init(
             fmpz_mpoly_evaluate_one_fmpz(I->mbetas + i*r + j,
                              I->mbetas + (i + 1)*r + j, i + 1, alpha + i, ctx);
         }
-    }
-    for (j = 0; j < r; j++)
-    {
-        fmpq_poly_init(I->dbetas + j);
-        _to_polyq(I->dbetas + j, I->mbetas + 0*r + j, ctx);
     }
 
     /* set product of betas */
@@ -208,37 +104,22 @@ int fmpz_mpoly_pfrac_init(
         }        
     }
 
+    fmpz_poly_pfrac_init(I->uni_pfrac);
+    fmpz_poly_init(I->uni_a);
+    I->uni_c = FLINT_ARRAY_ALLOC(r, fmpz_poly_struct);
     for (j = 0; j < r; j++)
-        fmpq_poly_init(I->inv_prod_dbetas + j);
-
-    for (j = 0; success && j < r; j++)
     {
-        if (fmpq_poly_degree(I->dbetas + j) !=
-                 fmpz_mpoly_degree_si(betas + j, 0, ctx))
-        {
-            success = 0;
-        }
+        fmpz_poly_init(I->uni_c + j);
+        fmpz_mpoly_get_fmpz_poly(I->uni_c + j, I->mbetas + 0*r + j, 0, ctx);
+
+        success = success && (fmpz_poly_degree(I->uni_c + j) ==
+                                      fmpz_mpoly_degree_si(betas + j, 0, ctx));
     }
 
-    for (j = 0; success && j < r; j++)
-    {
-        fmpq_poly_one(pq);
-        for (k = 0; k < r; k++)
-        {
-            if (k == j)
-                continue;
-            fmpq_poly_mul(pq, pq, I->dbetas + k);
-        }
-        fmpq_poly_xgcd(G, S, I->inv_prod_dbetas + j, I->dbetas + j, pq);
-        if (!fmpq_poly_is_one(G))
-            success = 0;
-    }
+    success = success && fmpz_poly_pfrac_precompute(I->uni_pfrac, I->uni_c, r);
 
-    fmpq_poly_clear(G);
-    fmpq_poly_clear(S);
-    fmpq_poly_clear(pq);
-
-    FLINT_ASSERT(success == 1);
+    if (!success)
+        flint_throw(FLINT_ERROR, "fmpz_mpoly_pfrac_init: internal error");
 
     return success;
 }
@@ -249,10 +130,6 @@ void fmpz_mpoly_pfrac_clear(
     const fmpz_mpoly_ctx_t ctx)
 {
     slong i, j;
-
-    fmpq_poly_clear(I->dtq);
-    fmpq_poly_clear(I->S);
-    fmpq_poly_clear(I->R);
 
     for (i = 0; i <= I->w; i++)
     {
@@ -275,8 +152,6 @@ void fmpz_mpoly_pfrac_clear(
 
     for (j = 0; j < I->r; j++)
     {
-        fmpq_poly_clear(I->inv_prod_dbetas + j);
-        fmpq_poly_clear(I->dbetas + j);
         for (i = 0; i <= I->w; i++)
         {
             fmpz_mpolyv_clear(I->prod_mbetas_coeffs + i*I->r + j, ctx);
@@ -286,12 +161,16 @@ void fmpz_mpoly_pfrac_clear(
         }
     }
 
-    flint_free(I->inv_prod_dbetas);
-    flint_free(I->dbetas);
     flint_free(I->prod_mbetas);
     flint_free(I->prod_mbetas_coeffs);
     flint_free(I->mbetas);
     flint_free(I->deltas);
+
+    fmpz_poly_pfrac_clear(I->uni_pfrac);
+    fmpz_poly_clear(I->uni_a);
+    for (j = 0; j < I->r; j++)
+        fmpz_poly_clear(I->uni_c + j);
+    flint_free(I->uni_c);
 }
 
 
@@ -320,16 +199,14 @@ int fmpz_mpoly_pfrac(
 
     if (l < 1)
     {
-        _to_polyq(I->dtq, t, ctx);
+        fmpz_mpoly_get_fmpz_poly(I->uni_a, t, 0, ctx);
 
-        success = 1;
+        if (!fmpz_poly_pfrac_precomp(I->uni_c, I->uni_a, I->uni_pfrac))
+            return 0;
+
         for (i = 0; i < I->r; i++)
-        {
-            fmpq_poly_mul(I->S, I->dtq, I->inv_prod_dbetas + i);
-            fmpq_poly_rem(I->R, I->S, I->dbetas + i);
-            if (!_from_polyq(deltas + i, I->bits, I->R, ctx))
-                return 0;
-        }
+            _fmpz_mpoly_set_fmpz_poly(deltas + i, I->bits,
+                               I->uni_c[i].coeffs, I->uni_c[i].length, 0, ctx);
         return 1;
     }
 

--- a/fmpz_mpoly_factor/poly_pfrac.c
+++ b/fmpz_mpoly_factor/poly_pfrac.c
@@ -349,8 +349,9 @@ more_prec:
     /* increase the precision of the i^th factor only */
 
     fmpz_set(I->old_pk, fmpz_mod_ctx_modulus(I->ctxs + i));
-    fmpz_mul(I->pk, fmpz_mod_ctx_modulus(I->ctxs + i), I->p);
-    fmpz_mod_ctx_set_modulus(I->ctxs + i, I->pk);
+    fmpz_pow_ui(I->pk, I->p, 1 + fmpz_bits(I->old_pk)/512);
+    fmpz_mul(I->halfpks + i, fmpz_mod_ctx_modulus(I->ctxs + i), I->pk);
+    fmpz_mod_ctx_set_modulus(I->ctxs + i, I->halfpks + i);
     fmpz_fdiv_q_2exp(I->halfpks + i, fmpz_mod_ctx_modulus(I->ctxs + i), 1);
 
     fmpz_mod_poly_set_fmpz_poly(I->T, I->bprod + i, I->ctxs + i);
@@ -371,7 +372,7 @@ more_prec:
             I->T->coeffs, I->T->length, I->B[i].coeffs, I->B[i].length,
             I->invBprod[i].coeffs, I->invBprod[i].length,
             I->inwBprod[i].coeffs, I->inwBprod[i].length,
-            I->old_pk, I->p);
+            I->old_pk, I->pk);
 
     I->invBprod[i].length = I->B[i].length - 1;
     _fmpz_mod_poly_normalise(I->invBprod + i);

--- a/fmpz_mpoly_factor/poly_pfrac.c
+++ b/fmpz_mpoly_factor/poly_pfrac.c
@@ -1,0 +1,394 @@
+/*
+    Copyright (C) 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz_poly.h"
+#include "fmpz_mod_poly.h"
+#include "fmpz_mpoly_factor.h"
+
+static int n_sub_checked(ulong * a, ulong b, ulong c)
+{
+    int of = b < c;
+    *a = b - c;
+    return of;
+}
+
+/* return n with ||a||_2 < 2^n */
+static flint_bitcnt_t fmpz_poly_norm2_bits(const fmpz_poly_t a)
+{
+    fmpz_t t;
+    flint_bitcnt_t bits;
+    fmpz_init(t);
+    _fmpz_vec_dot(t, a->coeffs, a->coeffs, a->length);
+    bits = fmpz_bits(t);
+    fmpz_clear(t);
+    return (bits + 1)/2;
+}
+
+static void _fmpz_mod_vec_sub(
+    fmpz * a,
+    const fmpz * b,
+    const fmpz * c,
+    slong n,
+    const fmpz_mod_ctx_t ctx)
+{
+    while (--n >= 0)
+        fmpz_mod_sub(a + n, b + n, c + n, ctx);
+}
+
+
+/* reduce A mod B, return new length of A */
+static slong _reduce_inplace(
+    fmpz * Acoeffs, slong Alen,
+    const fmpz_mod_poly_t B,
+    const fmpz_mod_poly_t Binv,
+    const fmpz_mod_ctx_t ctx,
+    fmpz_mod_poly_t Q,  /* temps */
+    fmpz_mod_poly_t R)
+{
+    slong Blen = B->length;
+    fmpz * Bcoeffs = B->coeffs;
+    fmpz * Qcoeffs, * Rcoeffs;
+    const fmpz * p = fmpz_mod_ctx_modulus(ctx);
+
+    if (Alen < Blen)
+        return Alen;
+
+    FLINT_ASSERT(Blen > 1);
+
+    fmpz_mod_poly_fit_length(Q, Alen - Blen + 1, ctx);
+    fmpz_mod_poly_fit_length(R, Blen - 1, ctx);
+    Qcoeffs = Q->coeffs;
+    Rcoeffs = R->coeffs;
+
+    while (Alen >= Blen)
+    {
+        slong n = FLINT_MAX(0, (Alen-1) - 2*(Blen-1) + 1);
+        slong Qlen = (Alen-1) - n - (Blen-1) + 1;
+        FLINT_ASSERT(Qlen < Blen);
+
+        _fmpz_mod_poly_div_newton_n_preinv(Qcoeffs + n, Acoeffs + n, Alen - n,
+                                 Bcoeffs, Blen, Binv->coeffs, Binv->length, p);
+
+        _fmpz_mod_poly_mullow(Rcoeffs, Bcoeffs, Blen - 1, Qcoeffs + n, Qlen,
+                                                                  p, Blen - 1);
+
+        _fmpz_mod_vec_sub(Acoeffs + n, Acoeffs + n, Rcoeffs, Blen - 1, ctx);
+
+        Alen = n + Blen - 1;
+        while (Alen > 0 && fmpz_is_zero(Acoeffs + Alen - 1))
+            Alen--;
+    }
+
+    return Alen;
+}
+
+void fmpz_poly_pfrac_init(fmpz_poly_pfrac_t I)
+{
+    I->r = 0;
+    I->bits = NULL;
+    I->b = I->bprod = NULL;
+    I->B = I->invBprod = I->inwBprod = I->B_inv = NULL;
+
+    fmpz_poly_init(I->a);
+    fmpz_poly_init(I->newa);
+    fmpz_poly_init(I->t);
+
+    fmpz_init(I->old_pk);
+    fmpz_init(I->pk);
+    fmpz_init(I->p);
+    fmpz_init(I->halfpk);
+
+    fmpz_mod_ctx_init_ui(I->ctx, 2);
+
+    fmpz_mod_poly_init(I->T, I->ctx);
+    fmpz_mod_poly_init(I->R, I->ctx);
+    fmpz_mod_poly_init(I->Q, I->ctx);
+}
+
+static void _clear_arrays(fmpz_poly_pfrac_t I)
+{
+    slong i;
+
+    for (i = 0; i < I->r; i++)
+    {
+        fmpz_poly_clear(I->b + i);
+        fmpz_poly_clear(I->bprod + i);
+        fmpz_mod_poly_clear(I->B + i, I->ctx);
+        fmpz_mod_poly_clear(I->invBprod + i, I->ctx);
+        fmpz_mod_poly_clear(I->inwBprod + i, I->ctx);
+        fmpz_mod_poly_clear(I->B_inv + i, I->ctx);
+    }
+    flint_free(I->bits);
+    flint_free(I->b);
+    flint_free(I->B);
+    I->r = 0;
+}
+
+void fmpz_poly_pfrac_clear(fmpz_poly_pfrac_t I)
+{
+    _clear_arrays(I);
+
+    fmpz_poly_clear(I->a);
+    fmpz_poly_clear(I->newa);
+    fmpz_poly_clear(I->t);
+
+    fmpz_clear(I->old_pk);
+    fmpz_clear(I->pk);
+    fmpz_clear(I->p);
+    fmpz_clear(I->halfpk);
+
+    fmpz_mod_poly_clear(I->T, I->ctx);
+    fmpz_mod_poly_clear(I->R, I->ctx);
+    fmpz_mod_poly_clear(I->Q, I->ctx);
+
+    fmpz_mod_ctx_clear(I->ctx);
+}
+
+int fmpz_poly_pfrac_precompute(
+    fmpz_poly_pfrac_t I,
+    const fmpz_poly_struct * b,
+    slong r)
+{
+    slong i;
+
+    if (r < 2)
+        return 0;
+
+    for (i = 0; i < r; i++)
+    {
+        if (fmpz_poly_degree(b + i) < 1)
+            return 0;
+    }
+
+    _clear_arrays(I);
+
+    I->r = r;
+    I->bits = FLINT_ARRAY_ALLOC(r, flint_bitcnt_t);
+
+    I->b = FLINT_ARRAY_ALLOC(2*r, fmpz_poly_struct);
+    I->bprod = I->b + r;
+    for (i = 0; i < r; i++)
+    {
+        fmpz_poly_init(I->bprod + i);
+        fmpz_poly_init(I->b + i);
+        fmpz_poly_set(I->b + i, b + i);
+    }
+
+    I->B = FLINT_ARRAY_ALLOC(4*r, fmpz_mod_poly_struct);
+    I->invBprod = I->B + r;
+    I->inwBprod = I->invBprod + r;
+    I->B_inv = I->inwBprod + r;
+
+    for (i = 0; i < r; i++)
+    {
+        fmpz_mod_poly_init(I->B + i, I->ctx);
+        fmpz_mod_poly_init(I->invBprod + i, I->ctx);
+        fmpz_mod_poly_init(I->inwBprod + i, I->ctx);
+        fmpz_mod_poly_init(I->B_inv + i, I->ctx);
+    }
+
+    /* init done */
+
+    fmpz_poly_one(I->bprod + r - 1);
+    for (i = r - 2; i >= 0; i--)
+    {
+        fmpz_poly_mul(I->bprod + i, I->bprod + i + 1, I->b + i + 1);
+        I->bits[i] = (fmpz_poly_degree(I->b + i) - 1)*
+                                            fmpz_poly_norm2_bits(I->bprod + i);
+        I->bits[i] += fmpz_poly_degree(I->bprod + i)*
+                                                fmpz_poly_norm2_bits(I->b + i);
+
+        fmpz_poly_resultant(I->pk, I->bprod + i, I->b + i);
+        if (fmpz_is_zero(I->pk))
+            return 0;
+
+        if (n_sub_checked(&I->bits[i], I->bits[i] + 2, fmpz_bits(I->pk)))
+            I->bits[i] = 1;
+    }
+
+    fmpz_set_ui(I->p, UWORD(1) << (FLINT_BITS - 2));
+
+next_p:
+
+    fmpz_nextprime(I->p, I->p, 1);
+    fmpz_mod_ctx_set_modulus(I->ctx, I->p);
+    fmpz_set(I->pk, I->p);
+    fmpz_fdiv_q_2exp(I->halfpk, fmpz_mod_ctx_modulus(I->ctx), 1);
+
+    for (i = 0; i < r; i++)
+    {
+        /* B[i] = make_monic(b[i] mod p^k) */
+        fmpz_mod_poly_set_fmpz_poly(I->B + i, I->b + i, I->ctx);
+        if (I->B[i].length != I->b[i].length)
+            goto next_p;
+
+        fmpz_mod_poly_make_monic(I->B + i, I->B + i, I->ctx);
+
+        fmpz_mod_poly_reverse(I->B_inv + i, I->B + i,
+                                                     I->B[i].length, I->ctx);
+        fmpz_mod_poly_inv_series_newton(I->B_inv + i, I->B_inv + i,
+                                                     I->B[i].length, I->ctx);
+    }
+
+    for (i = 0; i < r; i++)
+    {
+        fmpz_mod_poly_set_fmpz_poly(I->T, I->bprod + i, I->ctx);
+        fmpz_mod_poly_xgcd(I->R, I->invBprod + i, I->inwBprod + i,
+                                                   I->T, I->B + i, I->ctx);
+        if (!fmpz_mod_poly_is_one(I->R, I->ctx))
+            goto next_p;
+
+        /* now 1 = invBprod[i]*bprod[i] + inwBprod[i]*B[i] mod p^k */
+    }
+
+    return 1;
+}
+
+/*
+set di = deg(Bi)
+when solving for the Ci given A and Bi in
+    A/(B1*B2) = C1/B1 + C2/B2
+the coefficients of C2 and C1 come from a sylvester system
+with B1 in the first d2 columns and B2 in the next d1 columns and
+the coefficients of A on the rhs. Therefore cramer + hadamard
+||C2||_infty <= ||B1||_2^(d2-1) * ||B2||_2^d1 * ||A||_2 / |res(B1,B2)|
+||C1||_infty <= ||B2||_2^(d1-1) * ||B1||_2^d2 * ||A||_2 / |res(B1,B2)|
+
+suppose ||B2||_2^(d1-1) * ||B1||_2^d2 / |res(B1,B2)| < 2^n
+    and ||A||_2 < 2^a
+
+Assume fmpz_bits(p^k) > n + 1 + a. Then, p^k/2 >= 2^(n + a).
+If C1 (correct mod p^k with coeffs <= p^k/2 in abs) does not pass the
+divisibility test, then C1 does not exist.
+divisibility test is: C2 = (A - B2*C1)/B1
+*/
+int fmpz_poly_pfrac_precomp(
+    fmpz_poly_struct * c,
+    const fmpz_poly_t A,
+    fmpz_poly_pfrac_t I)
+{
+    slong i, clen;
+    const fmpz_poly_struct * a;
+
+again:
+
+    a = A;
+
+    for (i = 0; i + 1 < I->r; i++)
+    {
+        /* T = a mod B[i] */
+        fmpz_mod_poly_set_fmpz_poly(I->T, a, I->ctx);
+        I->T->length = _reduce_inplace(I->T->coeffs, I->T->length,
+                                   I->B + i, I->B_inv + i, I->ctx, I->Q, I->R);
+
+        /* c = T*invBprod[i] */
+        if (I->T->length < 1)
+        {
+            clen = 0;
+        }
+        else
+        {
+            FLINT_ASSERT(I->invBprod[i].length > 0);
+
+            clen = I->T->length + I->invBprod[i].length - 1;
+            fmpz_poly_fit_length(c + i, clen);
+            _fmpz_mod_poly_mul(c[i].coeffs, I->T->coeffs, I->T->length,
+                               I->invBprod[i].coeffs, I->invBprod[i].length,
+                                                 fmpz_mod_ctx_modulus(I->ctx));
+            while (clen > 0 && fmpz_is_zero(c[i].coeffs + clen - 1))
+                clen--;
+        }
+
+        /* c = c smod B[i] */
+        clen = _reduce_inplace(c[i].coeffs, clen,
+                                   I->B + i, I->B_inv + i, I->ctx, I->Q, I->R);
+        c[i].length = clen;
+        while (--clen >= 0)
+        {
+            if (fmpz_cmp(c[i].coeffs + clen, I->halfpk) > 0)
+            {
+                fmpz_sub(c[i].coeffs + clen, c[i].coeffs + clen,
+                                                 fmpz_mod_ctx_modulus(I->ctx));
+            }
+        }
+
+        /* now divisibility test */
+        fmpz_poly_mul(I->t, c + i, I->bprod + i);
+        fmpz_poly_sub(I->t, a, I->t);
+        if (!fmpz_poly_divides(I->newa, I->t, I->b + i))
+        {
+            flint_bitcnt_t abits = fmpz_poly_norm2_bits(a);
+            flint_bitcnt_t pkbits = fmpz_bits(fmpz_mod_ctx_modulus(I->ctx));
+
+            if (pkbits > abits && pkbits - abits > I->bits[i])
+                return 0;
+
+            goto more_prec;
+        }
+
+        a = I->a;
+        fmpz_poly_swap(I->a, I->newa);
+    }
+
+    FLINT_ASSERT(a == I->a);
+    fmpz_poly_swap(c + i, I->a);
+
+    return 1;
+
+more_prec:
+
+    fmpz_set(I->old_pk, fmpz_mod_ctx_modulus(I->ctx));
+    fmpz_mul(I->pk, fmpz_mod_ctx_modulus(I->ctx), I->p);
+    fmpz_mod_ctx_set_modulus(I->ctx, I->pk);
+    fmpz_fdiv_q_2exp(I->halfpk, fmpz_mod_ctx_modulus(I->ctx), 1);
+
+    for (i = 0; i < I->r; i++)
+    {
+        fmpz_mod_poly_set_fmpz_poly(I->T, I->bprod + i, I->ctx);
+        /* lift_only_inverses wants monic bases */
+        fmpz_mod_poly_scalar_div_fmpz(I->T, I->T,
+                                         fmpz_poly_lead(I->bprod + i), I->ctx);
+        fmpz_mod_poly_scalar_mul_fmpz(I->invBprod + i, I->invBprod + i,
+                                         fmpz_poly_lead(I->bprod + i), I->ctx);
+
+        fmpz_mod_poly_set_fmpz_poly(I->B + i, I->b + i, I->ctx);
+        fmpz_mod_poly_make_monic(I->B + i, I->B + i, I->ctx);
+
+        fmpz_mod_poly_fit_length(I->invBprod + i, I->B[i].length - 1, I->ctx);
+        fmpz_mod_poly_fit_length(I->inwBprod + i, I->T->length - 1, I->ctx);
+
+        _fmpz_poly_hensel_lift_only_inverse(
+            I->invBprod[i].coeffs, I->inwBprod[i].coeffs,
+            I->T->coeffs, I->T->length, I->B[i].coeffs, I->B[i].length,
+            I->invBprod[i].coeffs, I->invBprod[i].length,
+            I->inwBprod[i].coeffs, I->inwBprod[i].length,
+            I->old_pk, I->p);
+
+        I->invBprod[i].length = I->B[i].length - 1;
+        _fmpz_mod_poly_normalise(I->invBprod + i);
+
+        I->inwBprod[i].length = I->T->length - 1;
+        _fmpz_mod_poly_normalise(I->inwBprod + i);
+
+        /* correct monic bases */
+        fmpz_mod_poly_scalar_mul_fmpz(I->T, I->T,
+                                         fmpz_poly_lead(I->bprod + i), I->ctx);
+        fmpz_mod_poly_scalar_div_fmpz(I->invBprod + i, I->invBprod + i,
+                                         fmpz_poly_lead(I->bprod + i), I->ctx);
+
+        fmpz_mod_poly_reverse(I->B_inv + i, I->B + i, I->B[i].length, I->ctx);
+        fmpz_mod_poly_inv_series_newton(I->B_inv + i, I->B_inv + i,
+                                                       I->B[i].length, I->ctx);
+    }
+
+    goto again;
+}
+

--- a/fmpz_mpoly_factor/test/t-factor_wang.c
+++ b/fmpz_mpoly_factor/test/t-factor_wang.c
@@ -102,7 +102,7 @@ main(void)
     {
         slong lower;
         fmpz_mpoly_ctx_t ctx;
-        fmpz_mpoly_t a, t;
+        fmpz_mpoly_t a, at, t;
         flint_bitcnt_t coeff_bits;
         slong nfacs, len;
         ulong expbound, powbound, pow;
@@ -110,6 +110,7 @@ main(void)
         fmpz_mpoly_ctx_init_rand(ctx, state, 6);
 
         fmpz_mpoly_init(a, ctx);
+        fmpz_mpoly_init(at, ctx);
         fmpz_mpoly_init(t, ctx);
 
         nfacs = 1 + (4 + n_randint(state, 5))/ctx->minfo->nvars;
@@ -121,20 +122,27 @@ main(void)
         for (j = 0; j < nfacs; j++)
         {
             do {
-                len = 1 + n_randint(state, 10);
-                coeff_bits = 10 + n_randint(state, 300)/nfacs;
+                len = 2 + n_randint(state, 10);
+                coeff_bits = 100 + n_randint(state, 300)/nfacs;
                 fmpz_mpoly_randtest_bound(t, state, len, coeff_bits, expbound, ctx);
             } while (t->length == 0);
             pow = 1 + n_randint(state, powbound);
-            if (!fmpz_mpoly_is_fmpz(t, ctx))
-                lower += pow;
+
             fmpz_mpoly_pow_ui(t, t, pow, ctx);
-            fmpz_mpoly_mul(a, a, t, ctx);
+            fmpz_mpoly_mul(at, a, t, ctx);
+
+            if (t->length < 200)
+            {
+                fmpz_mpoly_swap(a, at, ctx);
+                if (!fmpz_mpoly_is_fmpz(t, ctx))
+                    lower += pow;
+            }
         }
 
         check_omega(lower, WORD_MAX, a, ctx);
 
         fmpz_mpoly_clear(t, ctx);
+        fmpz_mpoly_clear(at, ctx);
         fmpz_mpoly_clear(a, ctx);
         fmpz_mpoly_ctx_clear(ctx);
     }

--- a/fmpz_mpoly_factor/test/t-poly_pfrac.c
+++ b/fmpz_mpoly_factor/test/t-poly_pfrac.c
@@ -1,0 +1,214 @@
+/*
+    Copyright (C) 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "fmpz_mpoly_factor.h"
+
+
+void _test_pfrac(
+    fmpz_poly_struct * c,
+    fmpz_poly_pfrac_t I,
+    const fmpz_poly_struct * b,
+    slong r,
+    flint_rand_t state)
+{
+    slong i, j;
+    int success, found_bad;
+    fmpq_poly_struct * cQ, * bQ, * prod_bQ, * inv_prod_bQ;
+    fmpq_poly_t aQ, pQ, G, S;
+    fmpz_poly_t a, t, t1;
+
+    cQ = FLINT_ARRAY_ALLOC(r, fmpq_poly_struct);
+    bQ = FLINT_ARRAY_ALLOC(r, fmpq_poly_struct);
+    prod_bQ = FLINT_ARRAY_ALLOC(r, fmpq_poly_struct);
+    inv_prod_bQ = FLINT_ARRAY_ALLOC(r, fmpq_poly_struct);
+    for (i = 0; i < r; i++)
+    {
+        fmpq_poly_init(cQ + i);
+        fmpq_poly_init(bQ + i);
+        fmpq_poly_init(prod_bQ + i);
+        fmpq_poly_init(inv_prod_bQ + i);
+    }
+
+    fmpz_poly_init(a);
+    fmpz_poly_init(t);
+    fmpz_poly_init(t1);
+    fmpq_poly_init(aQ);
+    fmpq_poly_init(pQ);
+    fmpq_poly_init(G);
+    fmpq_poly_init(S);
+
+    fmpq_poly_one(pQ);
+
+    for (i = 0; i < r; i++)
+    {
+        fmpq_poly_set_fmpz_poly(bQ + i, b + i);
+        fmpq_poly_mul(pQ, pQ, bQ + i);
+    }
+
+    success = 1;
+    for (i = 0; i < r; i++)
+    {
+        fmpq_poly_divrem(prod_bQ + i, G, pQ, bQ + i);
+        fmpq_poly_xgcd(G, S, inv_prod_bQ + i, bQ + i, prod_bQ + i);
+        if (!fmpq_poly_is_one(G))
+            success = 0;
+    }
+
+    if (success != fmpz_poly_pfrac_precompute(I, b, r))
+    {
+        flint_printf("FAIL: check precompute\n");
+        flint_abort();
+    }
+
+    if (!success)
+        goto cleanup;
+
+    for (j = 0; j < 20; j++)
+    {
+        if (j % 6)
+        {
+            fmpz_poly_zero(a);
+            fmpz_poly_one(t);
+            for (i = 0; i < r; i++)
+            {
+                fmpz_poly_randtest(t1, state, fmpz_poly_degree(b + i),
+                                                    2 + n_randint(state, 200));
+                fmpz_poly_mul(t1, t1, t);
+                fmpz_poly_mul(a, a, b + i);
+                fmpz_poly_add(a, a, t1);
+                fmpz_poly_mul(t, t, b + i);
+            }
+        }
+        else
+        {
+            fmpz_poly_randtest(a, state, n_randint(state, pQ->length),
+                                                    2 + n_randint(state, 200));
+        }
+
+        FLINT_ASSERT(a->length < pQ->length);
+
+        fmpq_poly_set_fmpz_poly(aQ, a);
+
+        found_bad = 0;
+        for (i = 0; i < r; i++)
+        {
+            fmpq_poly_mul(S, aQ, inv_prod_bQ + i);
+            fmpq_poly_rem(cQ + i, S, bQ + i);
+            if (!fmpz_is_one(cQ[i].den))
+                found_bad = 1;
+        }
+
+        if (fmpz_poly_pfrac_precomp(c, a, I))
+        {
+            if (found_bad)
+            {
+                flint_printf("FAIL: precomp should have failed");
+                flint_abort();
+            }
+
+            for (i = 0; i < r; i++)
+            {
+                fmpq_poly_set_fmpz_poly(S, c + i);
+                if (!fmpq_poly_equal(S, cQ + i))
+                {
+                    flint_printf("FAIL: precomp produced wrong answer\n");
+                    flint_abort();
+                }
+            }
+        }
+        else
+        {
+            if (!found_bad)
+            {
+                flint_printf("FAIL: precomp should not have failed\n");
+                flint_abort();
+            }
+        }
+    }
+
+cleanup:
+
+    for (i = 0; i < r; i++)
+    {
+        fmpq_poly_clear(cQ + i);
+        fmpq_poly_clear(bQ + i);
+        fmpq_poly_clear(prod_bQ + i);
+        fmpq_poly_clear(inv_prod_bQ + i);
+    }
+    flint_free(cQ);
+    flint_free(bQ);
+    flint_free(prod_bQ);
+    flint_free(inv_prod_bQ);
+
+    fmpz_poly_clear(a);
+    fmpz_poly_clear(t);
+    fmpz_poly_clear(t1);
+    fmpq_poly_clear(aQ);
+    fmpq_poly_clear(pQ);
+    fmpq_poly_clear(G);
+    fmpq_poly_clear(S);
+}
+
+int
+main(void)
+{
+    slong i, j, k, tmul = 10;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("fmpz_poly_pfrac....");
+    fflush(stdout);
+
+    for (i = 0; i < tmul * flint_test_multiplier(); i++)
+    {
+        fmpz_poly_pfrac_t I;
+
+        fmpz_poly_pfrac_init(I);
+
+        for (j = 0; j < tmul; j++)
+        {
+            fmpz_poly_struct * b, * c;
+            slong n = 2 + n_randint(state, 5);
+
+            b = FLINT_ARRAY_ALLOC(n, fmpz_poly_struct);
+            c = FLINT_ARRAY_ALLOC(n, fmpz_poly_struct);
+
+            for (k = 0; k < n; k++)
+            {
+                fmpz_poly_init(c + k);
+                fmpz_poly_init(b + k);
+                do {
+                    fmpz_poly_randtest(b + k, state, 2 + n_randint(state, 5),
+                                                    2 + n_randint(state, 200));
+                } while (b[k].length < 2);
+            }
+
+            _test_pfrac(c, I, b, n, state);
+
+            for (k = 0; k < n; k++)
+            {
+                fmpz_poly_clear(c + k);
+                fmpz_poly_clear(b + k);
+            }
+            flint_free(c);
+            flint_free(b);
+        }
+
+        fmpz_poly_pfrac_clear(I);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+
+    flint_printf("PASS\n");
+    return 0;
+}
+

--- a/fmpz_mpoly_factor/test/t-poly_pfrac.c
+++ b/fmpz_mpoly_factor/test/t-poly_pfrac.c
@@ -188,7 +188,7 @@ main(void)
                 fmpz_poly_init(b + k);
                 do {
                     fmpz_poly_randtest(b + k, state, 2 + n_randint(state, 5),
-                                                    2 + n_randint(state, 200));
+                                                    2 + n_randint(state, 350));
                 } while (b[k].length < 2);
             }
 

--- a/ulong_extras.h
+++ b/ulong_extras.h
@@ -144,6 +144,13 @@ ULONG_EXTRAS_INLINE int n_add_checked(ulong * a, ulong b, ulong c)
     return of;
 }
 
+ULONG_EXTRAS_INLINE int n_sub_checked(ulong * a, ulong b, ulong c)
+{
+    int of = b < c;
+    *a = b - c;
+    return of;
+}
+
 /*****************************************************************************/
 
 FLINT_DLL ulong n_randlimb(flint_rand_t state);


### PR DESCRIPTION
Main thing here is a cool partial fraction solver [a/(b1*b2) = c1/b1 + c2/b2] for fmpz_poly that works over Z_p instead of Q to avoid coefficient blow up. Coefficient explosion was possible before (sorry), but I couldn't produce any practical examples where it was a problem.