### PR TITLE
Fmpz mat mul blas tuning

### DIFF
--- a/nmod_mat.h
+++ b/nmod_mat.h
@@ -396,7 +396,11 @@ FLINT_DLL void nmod_mat_similarity(nmod_mat_t M, slong r, ulong d);
    moduli giving nlimbs = 2. This should hold both in the classical
    range and in Strassen blocks.
  */
+#if FLINT_USES_BLAS
+#define NMOD_MAT_OPTIMAL_MODULUS_BITS 20
+#else
 #define NMOD_MAT_OPTIMAL_MODULUS_BITS (FLINT_BITS-5)
+#endif
 
 /* Inlines *******************************************************************/
 


### PR DESCRIPTION
This:

* Switches to 20 bit primes in fmpz_mat_mul_modular when BLAS is available
* Adds fmpz_mat_mul_blas to tuning code and tunes over a more reasonable range of sizes
* Redoes the tuning for fmpz_mat_mul for the new fmpz_mat_mul_blas of @tthsqe12 when BLAS is available
* Uses strassen more when there is 1 thread

This is expected to fail until #903 is merged.

Observed speedups are up to a factor of 2, especially for high dimension (> 100) or large entry sizes (hundreds of bits).