### PR TITLE
Faster fmpz_poly_taylor_shift

### DIFF
--- a/fmpz_poly/taylor_shift_divconquer.c
+++ b/fmpz_poly/taylor_shift_divconquer.c
@@ -54,21 +54,18 @@ _fmpz_poly_taylor_shift_divconquer(fmpz * poly, const fmpz_t c, slong len)
 
     nt = flint_get_num_threads();
 
-    if (fmpz_is_one(c))
+    cutoff = 100 + 10 * n_sqrt(FLINT_MAX(bits - FLINT_BITS, 0));
+
+    /* Parallel cutoff is set lower since shift_horner is serial. */
+    if (nt == 1)
+        cutoff = FLINT_MIN(cutoff, 1000);
+    else
+        cutoff = FLINT_MIN(cutoff, 300);
+
+    if (len < cutoff)
     {
-        cutoff = 100 + 10 * n_sqrt(FLINT_MAX(bits - FLINT_BITS, 0));
-
-        /* Parallel cutoff is set lower since shift_horner is serial. */
-        if (nt == 1)
-            cutoff = FLINT_MIN(cutoff, 1000);
-        else
-            cutoff = FLINT_MIN(cutoff, 300);
-
-        if (len < cutoff)
-        {
-            _fmpz_poly_taylor_shift_horner(poly, c, len);
-            return;
-        }
+        _fmpz_poly_taylor_shift_horner(poly, c, len);
+        return;
     }
 
     len1 = len / 2;

--- a/fmpz_poly/taylor_shift_divconquer.c
+++ b/fmpz_poly/taylor_shift_divconquer.c
@@ -38,12 +38,12 @@ _fmpz_poly_taylor_shift_divconquer(fmpz * poly, const fmpz_t c, slong len)
 {
     fmpz *tmp, *tmp2;
     slong k, len1, len2;
-    slong bits, max_horner;
+    slong bits, cutoff;
     slong nt, nw;
     thread_pool_handle * threads;
     worker_t args[2];
 
-    if (len < 64 || fmpz_is_zero(c))
+    if (len < 50 || fmpz_is_zero(c))
     {
         _fmpz_poly_taylor_shift_horner(poly, c, len);
         return;
@@ -54,22 +54,21 @@ _fmpz_poly_taylor_shift_divconquer(fmpz * poly, const fmpz_t c, slong len)
 
     nt = flint_get_num_threads();
 
-    /* A big problem for parallel tuning is that we have no
-       multithreading in shift_horner. Moreover, shift_horner is
-       currently implemented without good cache locality, which makes
-       it perform much worse when run on several instances in parallel.
-       Therefore, only use it for smaller lengths. */
-    if (nt == 1)
-        max_horner = 3000;
-    else
-        max_horner = 200;
-
-    /* Horner is faster with huge coefficients. */
-    if (len < max_horner && bits > pow(2.0, 7.0 + len * 0.005))
+    if (fmpz_is_one(c))
     {
-        _fmpz_poly_taylor_shift_horner(poly, c, len);
+        cutoff = 100 + 10 * n_sqrt(FLINT_MAX(bits - FLINT_BITS, 0));
 
-        return;
+        /* Parallel cutoff is set lower since shift_horner is serial. */
+        if (nt == 1)
+            cutoff = FLINT_MIN(cutoff, 1000);
+        else
+            cutoff = FLINT_MIN(cutoff, 300);
+
+        if (len < cutoff)
+        {
+            _fmpz_poly_taylor_shift_horner(poly, c, len);
+            return;
+        }
     }
 
     len1 = len / 2;

--- a/fmpz_poly/taylor_shift_horner.c
+++ b/fmpz_poly/taylor_shift_horner.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2012 Fredrik Johansson
+    Copyright (C) 2012, 2021 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -14,16 +14,165 @@
 #include "fmpz.h"
 #include "fmpz_poly.h"
 
+static void fmpz_get_signed_ui_array(mp_limb_t * r, slong n, const fmpz_t x)
+{
+    int neg;
+    slong i, sz;
+
+    FLINT_ASSERT(n > 0);
+
+    if (!COEFF_IS_MPZ(*x))
+    {
+        neg = *x < 0;
+        r[0] = FLINT_ABS(*x);
+        i = 1;
+    }
+    else
+    {
+        __mpz_struct * p = COEFF_TO_PTR(*x);
+        neg = p->_mp_size < 0;
+        sz = FLINT_ABS(p->_mp_size);
+
+        for (i = 0; i < n && i < sz; i++)
+            r[i] = p->_mp_d[i];
+    }
+
+    for ( ; i < n; i++)
+        r[i] = 0;
+
+    if (neg)
+        mpn_neg(r, r, n);
+}
+
+static void fmpz_get_signed_uiui(mp_limb_t * r, const fmpz_t x)
+{
+    ulong r0, r1, s;
+
+    if (!COEFF_IS_MPZ(*x))
+    {
+        r0 = *x;
+        r1 = FLINT_SIGN_EXT(r0);
+    }
+    else
+    {
+        __mpz_struct * p = COEFF_TO_PTR(*x);
+        s = -(ulong)(p->_mp_size < 0);
+        r0 = p->_mp_d[0];
+        if (p->_mp_size == 2 || p->_mp_size == -2)
+            r1 = p->_mp_d[1];
+        else
+            r1 = 0;
+
+        sub_ddmmss(r1, r0, r1^s, r0^s, s, s);
+    }
+
+    r[0] = r0;
+    r[1] = r1;
+}
+
+/* Improve cache locality with huge coefficients */
+#define BLOCK_SIZE 32
+
 void
 _fmpz_poly_taylor_shift_horner(fmpz * poly, const fmpz_t c, slong n)
 {
-    slong i, j;
+    slong i, j, bits, out_bits;
+
+    if (n <= 1)
+        return;
+
+    bits = _fmpz_vec_max_bits(poly, n);
+    bits = FLINT_ABS(bits);
+    out_bits = bits + n + 1;
 
     if (*c == WORD(1))
     {
-        for (i = n - 2; i >= 0; i--)
-            for (j = i; j < n - 1; j++)
-                fmpz_add(poly + j, poly + j, poly + j + 1);
+        if (out_bits <= FLINT_BITS - 2)
+        {
+            for (i = n - 2; i >= 0; i--)
+                for (j = i; j < n - 1; j++)
+                    poly[j] += poly[j + 1];
+        }
+        else if (n >= 5 && out_bits < 2 * FLINT_BITS)
+        {
+            mp_ptr t;
+            TMP_INIT;
+            TMP_START;
+
+            t = TMP_ALLOC(2 * n * sizeof(mp_limb_t));
+
+            for (i = 0; i < n; i++)
+                fmpz_get_signed_uiui(t + 2 * i, poly + i);
+
+            for (i = n - 2; i >= 0; i--)
+                for (j = i; j < n - 1; j++)
+                    add_ssaaaa(t[2 * j + 1], t[2 * j], t[2 * j + 1], t[2 * j], t[2 * (j + 1) + 1], t[2 * (j + 1)]);
+
+            for (i = 0; i < n; i++)
+                fmpz_set_signed_uiui(poly + i, t[2 * i + 1], t[2 * i]);
+
+            TMP_END;
+        }
+        else if (n >= 3 + FLINT_BIT_COUNT(bits) && bits <= 100 * FLINT_BITS)
+        {
+            slong B = BLOCK_SIZE, ii, jj, d;
+            mp_ptr t;
+            TMP_INIT;
+            TMP_START;
+
+            d = (out_bits + FLINT_BITS - 1) / FLINT_BITS;
+            t = TMP_ALLOC(d * n * sizeof(mp_limb_t));
+
+            for (i = 0; i < n; i++)
+                fmpz_get_signed_ui_array(t + d * i, d, poly + i);
+
+            if (d == 3)
+            {
+                for (i = n - 2; i >= 0; i--)
+                    for (j = i; j < n - 1; j++)
+                        add_sssaaaaaa(t[3 * j + 2], t[3 * j + 1], t[3 * j],
+                                      t[3 * j + 2], t[3 * j + 1], t[3 * j],
+                                      t[3 * (j + 1) + 2], t[3 * (j + 1) + 1], t[3 * (j + 1)]);
+            }
+            else if (n < 2 * B)
+            {
+                for (i = n - 2; i >= 0; i--)
+                    for (j = i; j < n - 1; j++)
+                        mpn_add_n(t + d * j, t + d * j, t + d * (j + 1), d);
+            }
+            else
+            {
+                for (ii = n - 2; ii >= 0; ii -= B)
+                    for (jj = 0; jj < n - ii - 1; jj += B)
+                        for (i = ii; i >= FLINT_MAX(ii - B + 1, 0); i--)
+                            for (j = jj; j < FLINT_MIN(jj + B, n - i - 1); j++)
+                                mpn_add_n(t + d * (i + j), t + d * (i + j), t + d * (i + j + 1), d);
+            }
+
+            for (i = 0; i < n; i++)
+                fmpz_set_signed_ui_array(poly + i, t + d * i, d);
+
+            TMP_END;
+        }
+        else
+        {
+            slong B = BLOCK_SIZE, ii, jj;
+
+            if (n < 2 * B)
+            {
+                for (i = n - 2; i >= 0; i--)
+                    for (j = i; j < n - 1; j++)
+                        fmpz_add(poly + j, poly + j, poly + j + 1);
+            }
+            else
+            {
+                for (ii = n - 2; ii >= 0; ii -= B)
+                    for (jj = 0; jj < n - ii - 1; jj += B)
+                        for (i = ii; i >= FLINT_MAX(ii - B + 1, 0); i--)
+                            for (j = jj; j < FLINT_MIN(jj + B, n - i - 1); j++)
+                                fmpz_add(poly + i + j, poly + i + j, poly + i + j + 1);
+            }
+        }
     }
     else if (*c == WORD(-1))
     {

--- a/fmpz_poly/taylor_shift_horner.c
+++ b/fmpz_poly/taylor_shift_horner.c
@@ -78,113 +78,164 @@ _fmpz_poly_taylor_shift_horner(fmpz * poly, const fmpz_t c, slong n)
 {
     slong i, j, bits, out_bits;
 
-    if (n <= 1)
+    if (n <= 1 || fmpz_is_zero(c))
         return;
+
+    if (!fmpz_is_one(c))
+    {
+        if (n <= 4 || (*c != WORD(-1) && n <= 10))
+        {
+            if (*c == WORD(-1))
+            {
+                for (i = n - 2; i >= 0; i--)
+                    for (j = i; j < n - 1; j++)
+                        fmpz_sub(poly + j, poly + j, poly + j + 1);
+            }
+            else
+            {
+                for (i = n - 2; i >= 0; i--)
+                    for (j = i; j < n - 1; j++)
+                        fmpz_addmul(poly + j, poly + j + 1, c);
+            }
+        }
+        else
+        {
+            slong i;
+            fmpz_t d, one;
+            *one = 1;
+
+            if (*c == WORD(-1))
+            {
+                for (i = 1; i < n; i += 2)
+                    fmpz_neg(poly + i, poly + i);
+
+                _fmpz_poly_taylor_shift_horner(poly, one, n);
+
+                for (i = 1; i < n; i += 2)
+                    fmpz_neg(poly + i, poly + i);
+            }
+            else
+            {
+                fmpz_init(d);
+
+                for (i = 1; i < n; i++)
+                {
+                    if (i == 1)
+                        fmpz_set(d, c);
+                    else
+                        fmpz_mul(d, d, c);
+
+                    fmpz_mul(poly + i, poly + i, d);
+                }
+
+                _fmpz_poly_taylor_shift_horner(poly, one, n);
+
+                for (i = n - 1; i >= 1; i--)
+                {
+                    fmpz_divexact(poly + i, poly + i, d);
+
+                    if (i >= 3)
+                        fmpz_divexact(d, d, c);
+                    else if (i == 2)
+                        fmpz_set(d, c);
+                }
+
+                fmpz_clear(d);
+            }
+        }
+
+        return;
+    }
 
     bits = _fmpz_vec_max_bits(poly, n);
     bits = FLINT_ABS(bits);
     out_bits = bits + n + 1;
 
-    if (*c == WORD(1))
+    if (out_bits <= FLINT_BITS - 2)
     {
-        if (out_bits <= FLINT_BITS - 2)
+        for (i = n - 2; i >= 0; i--)
+            for (j = i; j < n - 1; j++)
+                poly[j] += poly[j + 1];
+    }
+    else if (n >= 5 && out_bits < 2 * FLINT_BITS)
+    {
+        mp_ptr t;
+        TMP_INIT;
+        TMP_START;
+
+        t = TMP_ALLOC(2 * n * sizeof(mp_limb_t));
+
+        for (i = 0; i < n; i++)
+            fmpz_get_signed_uiui(t + 2 * i, poly + i);
+
+        for (i = n - 2; i >= 0; i--)
+            for (j = i; j < n - 1; j++)
+                add_ssaaaa(t[2 * j + 1], t[2 * j], t[2 * j + 1], t[2 * j], t[2 * (j + 1) + 1], t[2 * (j + 1)]);
+
+        for (i = 0; i < n; i++)
+            fmpz_set_signed_uiui(poly + i, t[2 * i + 1], t[2 * i]);
+
+        TMP_END;
+    }
+    else if (n >= 3 + FLINT_BIT_COUNT(bits) && bits <= 100 * FLINT_BITS)
+    {
+        slong B = BLOCK_SIZE, ii, jj, d;
+        mp_ptr t;
+        TMP_INIT;
+        TMP_START;
+
+        d = (out_bits + FLINT_BITS - 1) / FLINT_BITS;
+        t = TMP_ALLOC(d * n * sizeof(mp_limb_t));
+
+        for (i = 0; i < n; i++)
+            fmpz_get_signed_ui_array(t + d * i, d, poly + i);
+
+        if (d == 3)
         {
             for (i = n - 2; i >= 0; i--)
                 for (j = i; j < n - 1; j++)
-                    poly[j] += poly[j + 1];
+                    add_sssaaaaaa(t[3 * j + 2], t[3 * j + 1], t[3 * j],
+                                  t[3 * j + 2], t[3 * j + 1], t[3 * j],
+                                  t[3 * (j + 1) + 2], t[3 * (j + 1) + 1], t[3 * (j + 1)]);
         }
-        else if (n >= 5 && out_bits < 2 * FLINT_BITS)
+        else if (n < 2 * B)
         {
-            mp_ptr t;
-            TMP_INIT;
-            TMP_START;
-
-            t = TMP_ALLOC(2 * n * sizeof(mp_limb_t));
-
-            for (i = 0; i < n; i++)
-                fmpz_get_signed_uiui(t + 2 * i, poly + i);
-
             for (i = n - 2; i >= 0; i--)
                 for (j = i; j < n - 1; j++)
-                    add_ssaaaa(t[2 * j + 1], t[2 * j], t[2 * j + 1], t[2 * j], t[2 * (j + 1) + 1], t[2 * (j + 1)]);
-
-            for (i = 0; i < n; i++)
-                fmpz_set_signed_uiui(poly + i, t[2 * i + 1], t[2 * i]);
-
-            TMP_END;
-        }
-        else if (n >= 3 + FLINT_BIT_COUNT(bits) && bits <= 100 * FLINT_BITS)
-        {
-            slong B = BLOCK_SIZE, ii, jj, d;
-            mp_ptr t;
-            TMP_INIT;
-            TMP_START;
-
-            d = (out_bits + FLINT_BITS - 1) / FLINT_BITS;
-            t = TMP_ALLOC(d * n * sizeof(mp_limb_t));
-
-            for (i = 0; i < n; i++)
-                fmpz_get_signed_ui_array(t + d * i, d, poly + i);
-
-            if (d == 3)
-            {
-                for (i = n - 2; i >= 0; i--)
-                    for (j = i; j < n - 1; j++)
-                        add_sssaaaaaa(t[3 * j + 2], t[3 * j + 1], t[3 * j],
-                                      t[3 * j + 2], t[3 * j + 1], t[3 * j],
-                                      t[3 * (j + 1) + 2], t[3 * (j + 1) + 1], t[3 * (j + 1)]);
-            }
-            else if (n < 2 * B)
-            {
-                for (i = n - 2; i >= 0; i--)
-                    for (j = i; j < n - 1; j++)
-                        mpn_add_n(t + d * j, t + d * j, t + d * (j + 1), d);
-            }
-            else
-            {
-                for (ii = n - 2; ii >= 0; ii -= B)
-                    for (jj = 0; jj < n - ii - 1; jj += B)
-                        for (i = ii; i >= FLINT_MAX(ii - B + 1, 0); i--)
-                            for (j = jj; j < FLINT_MIN(jj + B, n - i - 1); j++)
-                                mpn_add_n(t + d * (i + j), t + d * (i + j), t + d * (i + j + 1), d);
-            }
-
-            for (i = 0; i < n; i++)
-                fmpz_set_signed_ui_array(poly + i, t + d * i, d);
-
-            TMP_END;
+                    mpn_add_n(t + d * j, t + d * j, t + d * (j + 1), d);
         }
         else
         {
-            slong B = BLOCK_SIZE, ii, jj;
-
-            if (n < 2 * B)
-            {
-                for (i = n - 2; i >= 0; i--)
-                    for (j = i; j < n - 1; j++)
-                        fmpz_add(poly + j, poly + j, poly + j + 1);
-            }
-            else
-            {
-                for (ii = n - 2; ii >= 0; ii -= B)
-                    for (jj = 0; jj < n - ii - 1; jj += B)
-                        for (i = ii; i >= FLINT_MAX(ii - B + 1, 0); i--)
-                            for (j = jj; j < FLINT_MIN(jj + B, n - i - 1); j++)
-                                fmpz_add(poly + i + j, poly + i + j, poly + i + j + 1);
-            }
+            for (ii = n - 2; ii >= 0; ii -= B)
+                for (jj = 0; jj < n - ii - 1; jj += B)
+                    for (i = ii; i >= FLINT_MAX(ii - B + 1, 0); i--)
+                        for (j = jj; j < FLINT_MIN(jj + B, n - i - 1); j++)
+                            mpn_add_n(t + d * (i + j), t + d * (i + j), t + d * (i + j + 1), d);
         }
+
+        for (i = 0; i < n; i++)
+            fmpz_set_signed_ui_array(poly + i, t + d * i, d);
+
+        TMP_END;
     }
-    else if (*c == WORD(-1))
+    else
     {
-        for (i = n - 2; i >= 0; i--)
-            for (j = i; j < n - 1; j++)
-                fmpz_sub(poly + j, poly + j, poly + j + 1);
-    }
-    else if (*c != WORD(0))
-    {
-        for (i = n - 2; i >= 0; i--)
-            for (j = i; j < n - 1; j++)
-                fmpz_addmul(poly + j, poly + j + 1, c);
+        slong B = BLOCK_SIZE, ii, jj;
+
+        if (n < 2 * B)
+        {
+            for (i = n - 2; i >= 0; i--)
+                for (j = i; j < n - 1; j++)
+                    fmpz_add(poly + j, poly + j, poly + j + 1);
+        }
+        else
+        {
+            for (ii = n - 2; ii >= 0; ii -= B)
+                for (jj = 0; jj < n - ii - 1; jj += B)
+                    for (i = ii; i >= FLINT_MAX(ii - B + 1, 0); i--)
+                        for (j = jj; j < FLINT_MIN(jj + B, n - i - 1); j++)
+                            fmpz_add(poly + i + j, poly + i + j, poly + i + j + 1);
+        }
     }
 }
 

--- a/fmpz_poly/test/t-taylor_shift_horner.c
+++ b/fmpz_poly/test/t-taylor_shift_horner.c
@@ -17,6 +17,24 @@
 #include "fmpz_poly.h"
 #include "ulong_extras.h"
 
+static void
+_taylor_simple(fmpz * poly, const fmpz_t c, slong n)
+{
+    slong i, j;
+
+    for (i = n - 2; i >= 0; i--)
+        for (j = i; j < n - 1; j++)
+            fmpz_addmul(poly + j, poly + j + 1, c);
+}
+
+static void
+taylor_simple(fmpz_poly_t g, const fmpz_poly_t f, const fmpz_t c)
+{
+    if (f != g)
+        fmpz_poly_set(g, f);
+    _taylor_simple(g->coeffs, c, g->length);
+}
+
 int
 main(void)
 {
@@ -123,7 +141,7 @@ main(void)
         fmpz_set_si(c, n_randint(state, 2) ? 1 : -1);
         fmpz_poly_taylor_shift_horner(h1, f, c);
         fmpz_neg(c, c);
-        fmpz_poly_taylor_shift_horner(h2, h1, c);
+        taylor_simple(h2, h1, c);
 
         if (!fmpz_poly_equal(f, h2))
         {

--- a/fmpz_poly/test/t-taylor_shift_horner.c
+++ b/fmpz_poly/test/t-taylor_shift_horner.c
@@ -100,6 +100,46 @@ main(void)
         fmpz_clear(c);
     }
 
+    /* Shift by 1 and -1 */
+    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
+    {
+        fmpz_poly_t f, h1, h2;
+        fmpz_t c;
+
+        fmpz_poly_init(f);
+        fmpz_poly_init(h1);
+        fmpz_poly_init(h2);
+
+        fmpz_init(c);
+
+
+        if (n_randint(state, 30))
+            fmpz_poly_randtest(f, state, 1 + n_randint(state, 100),
+                                         1 + n_randint(state, 10000));
+        else
+            fmpz_poly_randtest(f, state, 1 + n_randint(state, 100),
+                                         1 + n_randint(state, 200));
+
+        fmpz_set_si(c, n_randint(state, 2) ? 1 : -1);
+        fmpz_poly_taylor_shift_horner(h1, f, c);
+        fmpz_neg(c, c);
+        fmpz_poly_taylor_shift_horner(h2, h1, c);
+
+        if (!fmpz_poly_equal(f, h2))
+        {
+            flint_printf("FAIL\n");
+            fmpz_poly_print(f); flint_printf("\n");
+            fmpz_poly_print(h1); flint_printf("\n");
+            fmpz_poly_print(h2); flint_printf("\n");
+            abort();
+        }
+
+        fmpz_poly_clear(f);
+        fmpz_poly_clear(h1);
+        fmpz_poly_clear(h2);
+        fmpz_clear(c);
+    }
+
     FLINT_TEST_CLEANUP(state);
     
     flint_printf("PASS\n");


### PR DESCRIPTION
This improves fmpz_poly_taylor_shift (with a shift of 1) by using limb and mpn arithmetic in the basecase code, and looping in blocks to improve locality when n is large. The cutoffs in the divide and conquer algorithm have also been re-tuned. Speedup of fmpz_poly_taylor_shift over the old code:

![taylor1speedup](https://user-images.githubusercontent.com/368838/112671765-e384c300-8e62-11eb-801c-3a59530ddb6c.png)

There's still a lot to improve if someone really cares:

* The basecase code could be parallelized.
* The blocking strategy can be improved (necessary for parallelizing it).
* I have not optimized the cutoffs with multiple threads (I can only test two threads on my computer).
* With small input coefficients, the number of limbs could be increased gradually instead of being set to the size of the output.
* A truly advanced implementation could repack the limbs to delay carries and vectorize the additions.

Anyway, this should be ready to merge. I stole some fmpz helper methods from @tthsqe12's in-progress matrix multiplication code; when that gets merged, they can be removed from fmpz_poly/taylor_shift_horner.c.