### PR TITLE
Faster fmpz_poly_div_series

### DIFF
--- a/fmpz_poly/div_series.c
+++ b/fmpz_poly/div_series.c
@@ -20,7 +20,7 @@ _fmpz_poly_div_series(fmpz * Q, const fmpz * A, slong Alen,
     Alen = FLINT_MIN(Alen, n);
     Blen = FLINT_MIN(Blen, n);
 
-    if (n < 32 || Blen < 20)
+    if (n < 72 || Blen < 72 || Alen == 1)
        _fmpz_poly_div_series_basecase(Q, A, Alen, B, Blen, n);
     else if (fmpz_is_pm1(B + 0))
     {

--- a/fmpz_poly/div_series_basecase.c
+++ b/fmpz_poly/div_series_basecase.c
@@ -1,6 +1,6 @@
 /*
     Copyright (C) 2010 Sebastian Pancratz
-    Copyright (C) 2014 Fredrik Johansson
+    Copyright (C) 2014, 2021 Fredrik Johansson
     Copyright (C) 2019 William Hart
 
     This file is part of FLINT.
@@ -13,13 +13,25 @@
 
 #include "fmpz_poly.h"
 
+static void
+fmpz_divexact_checked(fmpz_t Q, const fmpz_t A, const fmpz_t B)
+{
+    fmpz_t r;
+    fmpz_init(r);
+    fmpz_fdiv_qr(Q, r, A, B);
+    if (!fmpz_is_zero(r))
+    {
+        fmpz_clear(r);
+        flint_printf("Not an exact division\n");
+        flint_abort();
+    }
+    /* no need to clear r */
+}
+
 void
 _fmpz_poly_div_series_basecase(fmpz * Q, const fmpz * A, slong Alen,
     const fmpz * B, slong Blen, slong n)
 {
-    slong i;
-    fmpz_t r;
-
     Alen = FLINT_MIN(Alen, n);
     Blen = FLINT_MIN(Blen, n);
 
@@ -31,31 +43,30 @@ _fmpz_poly_div_series_basecase(fmpz * Q, const fmpz * A, slong Alen,
                 _fmpz_vec_set(Q, A, Alen);
             else
                 _fmpz_vec_neg(Q, A, Alen);
-        } else
+        }
+        else
         {
-            fmpz_init(r);
-
+            slong i;
             for (i = 0; i < Alen; i++)
-            {   
-                fmpz_fdiv_qr(Q + i, r, A + i, B + 0);
-
-                if (!fmpz_is_zero(r))
-                {
-                    fmpz_clear(r);
-
-                    flint_printf("Not an exact division\n");
-                    flint_abort();
-                }
-            }
-
-            fmpz_clear(r);
+                fmpz_divexact_checked(Q + i, A + i, B);
         }
 
         _fmpz_vec_zero(Q + Alen, n - Alen);
     }
+    else if (Alen == 1 && fmpz_is_pm1(B))
+    {
+        _fmpz_poly_inv_series_basecase(Q, B, Blen, n);
+        if (!fmpz_is_one(A))
+            _fmpz_vec_scalar_mul_fmpz(Q, Q, n, A);
+    }
     else
     {
-        slong i, j;
+        slong i, j, nsmall;
+        char *Bbits;
+        slong b, bits, Qbits;
+        TMP_INIT;
+
+        TMP_START;
 
         if (fmpz_is_pm1(B))
         {
@@ -63,27 +74,116 @@ _fmpz_poly_div_series_basecase(fmpz * Q, const fmpz * A, slong Alen,
                 fmpz_set(Q, A);
             else
                 fmpz_neg(Q, A);
-        } else
+        }
+        else
         {
-            fmpz_init(r);
+            fmpz_divexact_checked(Q, A, B);
+        }
 
-            fmpz_fdiv_qr(Q + 0, r, A + 0, B + 0);
+        /* Bbits[i] = max(bits(B[0]), ..., bits(B[i])), as long as coeffs are small */
+        Bbits = TMP_ALLOC(Blen);
+        Bbits[0] = fmpz_bits(B);
 
-            if (!fmpz_is_zero(r))
-            {
-                fmpz_clear(r);
+        /* Maximum bits of all Q coefficients encountered so far */
+        Qbits = fmpz_bits(Q);
 
-                flint_printf("Not an exact division\n");
-                flint_abort();
-            }
+        /* We have small coefficients for i < nsmall */
+        for (nsmall = 0; nsmall < Blen; nsmall++)
+        {
+            b = B[nsmall];
+
+            if (COEFF_IS_MPZ(b))
+                break;
+
+            b = FLINT_ABS(b);
+            if (nsmall == 0 || (b >> Bbits[nsmall - 1]))
+                Bbits[nsmall] = FLINT_BIT_COUNT(b);
+            else
+                Bbits[nsmall] = Bbits[nsmall - 1];
         }
 
         for (i = 1; i < n; i++)
         {
-            fmpz_mul(Q + i, B + 1, Q + i - 1);
+            if (i >= nsmall || Qbits > FLINT_BITS - 2 || Bbits[i] > FLINT_BITS - 2)
+            {
+                /* Can't use fast code. */
+                bits = WORD_MAX;
+            }
+            else
+            {
+                /* Can maybe use fast code; bound bits. */
+                b = FLINT_MIN(i, Blen - 1);
+                bits = FLINT_BIT_COUNT(b);
 
-            for (j = 2; j < FLINT_MIN(i + 1, Blen); j++)
-                fmpz_addmul(Q + i, B + j, Q + i - j);
+                /* Bit size of product. */
+                bits += Bbits[i] + Qbits;
+
+                /* Sign. */
+                bits += 1;
+            }
+
+            if (bits <= 3 * FLINT_BITS - 1)
+            {
+                if (bits <= FLINT_BITS - 1)
+                {
+                    slong s, x, y;
+
+                    s = 0;
+
+                    for (j = 1; j < FLINT_MIN(i + 1, Blen); j++)
+                    {
+                        x = B[j];
+                        y = Q[i - j];
+                        s += x * y;
+                    }
+
+                    fmpz_set_si(Q + i, s);
+                }
+                else if (bits <= 2 * FLINT_BITS - 1)
+                {
+                    mp_limb_t hi, lo, shi, slo;
+                    slong x, y;
+
+                    shi = slo = 0;
+
+                    for (j = 1; j < FLINT_MIN(i + 1, Blen); j++)
+                    {
+                        x = B[j];
+                        y = Q[i - j];
+
+                        smul_ppmm(hi, lo, x, y);
+                        add_ssaaaa(shi, slo, shi, slo, hi, lo);
+                    }
+
+                    fmpz_set_signed_uiui(Q + i, shi, slo);
+                }
+                else
+                {
+                    mp_limb_t hi, lo, cy, shh, shi, slo;
+                    slong x, y;
+
+                    shh = shi = slo = 0;
+
+                    for (j = 1; j < FLINT_MIN(i + 1, Blen); j++)
+                    {
+                        x = B[j];
+                        y = Q[i - j];
+
+                        smul_ppmm(hi, lo, x, y);
+                        add_sssaaaaaa(cy, shi, slo, 0, shi, slo, 0, hi, lo);
+                        shh += (0 <= (slong) hi) ? cy : cy - 1;
+                    }
+
+                    fmpz_set_signed_uiuiui(Q + i, shh, shi, slo);
+                }
+            }
+            else
+            {
+                fmpz_mul(Q + i, B + 1, Q + i - 1);
+
+                for (j = 2; j < FLINT_MIN(i + 1, Blen); j++)
+                    fmpz_addmul(Q + i, B + j, Q + i - j);
+            }
 
             if (i < Alen)
             {
@@ -93,45 +193,42 @@ _fmpz_poly_div_series_basecase(fmpz * Q, const fmpz * A, slong Alen,
                         fmpz_sub(Q + i, A + i, Q + i);
                     else
                         fmpz_sub(Q + i, Q + i, A + i);
-                } else
+                }
+                else
                 {
                     fmpz_sub(Q + i, A + i, Q + i);
-
-                    fmpz_fdiv_qr(Q + i, r, Q + i, B + 0);
-
-                    if (!fmpz_is_zero(r))
-                    {
-                        fmpz_clear(r);
-
-                        flint_printf("Not an exact division\n");
-                        flint_abort();
-                    }
+                    fmpz_divexact_checked(Q + i, Q + i, B);
                 }
-            } else
+            }
+            else
             {
                 if (fmpz_is_pm1(B))
                 {
                     if (fmpz_is_one(B))
                         fmpz_neg(Q + i, Q + i);
-                } else
+                }
+                else
                 {
                     fmpz_neg(Q + i, Q + i);
-
-                    fmpz_fdiv_qr(Q + i, r, Q + i, B + 0);
-
-                    if (!fmpz_is_zero(r))
-                    {
-                        fmpz_clear(r);
-
-                        flint_printf("Not an exact division\n");
-                        flint_abort();
-                    }
+                    fmpz_divexact_checked(Q + i, Q + i, B);
                 }
+            }
+
+            if (COEFF_IS_MPZ(*(Q + i)))
+            {
+                /* Will no longer use fast code */
+                nsmall = i;
+            }
+            else
+            {
+                /* Update Qbits */
+                b = FLINT_ABS(*(Q + i));
+                b = FLINT_BIT_COUNT(b);
+                Qbits = FLINT_MAX(Qbits, b);
             }
         }
 
-        if (!fmpz_is_pm1(B))
-            fmpz_clear(r);
+        TMP_END;
     }
 }
 

--- a/fmpz_poly/div_series_basecase.c
+++ b/fmpz_poly/div_series_basecase.c
@@ -37,9 +37,9 @@ _fmpz_poly_div_series_basecase(fmpz * Q, const fmpz * A, slong Alen,
 
     if (Blen == 1)
     {
-        if (fmpz_is_pm1(B))
+        if (fmpz_is_pm1(B + 0))
         {
-            if (fmpz_is_one(B))
+            if (fmpz_is_one(B + 0))
                 _fmpz_vec_set(Q, A, Alen);
             else
                 _fmpz_vec_neg(Q, A, Alen);
@@ -53,11 +53,11 @@ _fmpz_poly_div_series_basecase(fmpz * Q, const fmpz * A, slong Alen,
 
         _fmpz_vec_zero(Q + Alen, n - Alen);
     }
-    else if (Alen == 1 && fmpz_is_pm1(B))
+    else if (Alen == 1 && fmpz_is_pm1(B + 0))
     {
         _fmpz_poly_inv_series_basecase(Q, B, Blen, n);
-        if (!fmpz_is_one(A))
-            _fmpz_vec_scalar_mul_fmpz(Q, Q, n, A);
+        if (!fmpz_is_one(A + 0))
+            _fmpz_vec_scalar_mul_fmpz(Q, Q, n, A + 0);
     }
     else
     {
@@ -68,24 +68,24 @@ _fmpz_poly_div_series_basecase(fmpz * Q, const fmpz * A, slong Alen,
 
         TMP_START;
 
-        if (fmpz_is_pm1(B))
+        if (fmpz_is_pm1(B + 0))
         {
-            if (fmpz_is_one(B))
-                fmpz_set(Q, A);
+            if (fmpz_is_one(B + 0))
+                fmpz_set(Q + 0, A + 0);
             else
-                fmpz_neg(Q, A);
+                fmpz_neg(Q + 0, A + 0);
         }
         else
         {
-            fmpz_divexact_checked(Q, A, B);
+            fmpz_divexact_checked(Q + 0, A + 0, B + 0);
         }
 
         /* Bbits[i] = max(bits(B[0]), ..., bits(B[i])), as long as coeffs are small */
         Bbits = TMP_ALLOC(Blen);
-        Bbits[0] = fmpz_bits(B);
+        Bbits[0] = fmpz_bits(B + 0);
 
         /* Maximum bits of all Q coefficients encountered so far */
-        Qbits = fmpz_bits(Q);
+        Qbits = fmpz_bits(Q + 0);
 
         /* We have small coefficients for i < nsmall */
         for (nsmall = 0; nsmall < Blen; nsmall++)
@@ -96,7 +96,7 @@ _fmpz_poly_div_series_basecase(fmpz * Q, const fmpz * A, slong Alen,
                 break;
 
             b = FLINT_ABS(b);
-            if (nsmall == 0 || (b >> Bbits[nsmall - 1]))
+            if (nsmall == 0 || (b >> Bbits[nsmall - 1]) != 0)
                 Bbits[nsmall] = FLINT_BIT_COUNT(b);
             else
                 Bbits[nsmall] = Bbits[nsmall - 1];
@@ -187,9 +187,9 @@ _fmpz_poly_div_series_basecase(fmpz * Q, const fmpz * A, slong Alen,
 
             if (i < Alen)
             {
-                if (fmpz_is_pm1(B))
+                if (fmpz_is_pm1(B + 0))
                 {
-                    if (fmpz_is_one(B))
+                    if (fmpz_is_one(B + 0))
                         fmpz_sub(Q + i, A + i, Q + i);
                     else
                         fmpz_sub(Q + i, Q + i, A + i);
@@ -197,20 +197,20 @@ _fmpz_poly_div_series_basecase(fmpz * Q, const fmpz * A, slong Alen,
                 else
                 {
                     fmpz_sub(Q + i, A + i, Q + i);
-                    fmpz_divexact_checked(Q + i, Q + i, B);
+                    fmpz_divexact_checked(Q + i, Q + i, B + 0);
                 }
             }
             else
             {
-                if (fmpz_is_pm1(B))
+                if (fmpz_is_pm1(B + 0))
                 {
-                    if (fmpz_is_one(B))
+                    if (fmpz_is_one(B + 0))
                         fmpz_neg(Q + i, Q + i);
                 }
                 else
                 {
                     fmpz_neg(Q + i, Q + i);
-                    fmpz_divexact_checked(Q + i, Q + i, B);
+                    fmpz_divexact_checked(Q + i, Q + i, B + 0);
                 }
             }
 

--- a/fmpz_poly/inv_series.c
+++ b/fmpz_poly/inv_series.c
@@ -14,7 +14,7 @@
 void
 _fmpz_poly_inv_series(fmpz * Qinv, const fmpz * Q, slong Qlen, slong n)
 {
-    if (Qlen <= 8 || n <= 24)
+    if (Qlen < 64 || n < 64)
         _fmpz_poly_inv_series_basecase(Qinv, Q, Qlen, n);
     else
         _fmpz_poly_inv_series_newton(Qinv, Q, Qlen, n);

--- a/fmpz_poly/inv_series_basecase.c
+++ b/fmpz_poly/inv_series_basecase.c
@@ -17,8 +17,8 @@ _fmpz_poly_inv_series_basecase(fmpz * Qinv, const fmpz * Q, slong Qlen, slong n)
     int neg;
     Qlen = FLINT_MIN(Qlen, n);
 
-    neg = fmpz_is_one(Q);
-    fmpz_set(Qinv, Q);
+    neg = fmpz_is_one(Q + 0);
+    fmpz_set(Qinv + 0, Q + 0);
 
     if (Qlen == 1)
     {
@@ -73,7 +73,7 @@ _fmpz_poly_inv_series_basecase(fmpz * Qinv, const fmpz * Q, slong Qlen, slong n)
                 break;
 
             b = FLINT_ABS(b);
-            if (b >> Qbits[nsmall - 1])
+            if ((b >> Qbits[nsmall - 1]) != 0)
                 Qbits[nsmall] = FLINT_BIT_COUNT(b);
             else
                 Qbits[nsmall] = Qbits[nsmall - 1];

--- a/fmpz_poly/inv_series_basecase.c
+++ b/fmpz_poly/inv_series_basecase.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014 Fredrik Johansson
+    Copyright (C) 2014, 2021 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -14,27 +14,180 @@
 void
 _fmpz_poly_inv_series_basecase(fmpz * Qinv, const fmpz * Q, slong Qlen, slong n)
 {
+    int neg;
     Qlen = FLINT_MIN(Qlen, n);
 
+    neg = fmpz_is_one(Q);
     fmpz_set(Qinv, Q);
 
     if (Qlen == 1)
     {
         _fmpz_vec_zero(Qinv + 1, n - 1);
     }
+    else if (Qlen == 2 || _fmpz_vec_is_zero(Q + 1, Qlen - 2))
+    {
+        /* Special-case binomials */
+        slong i, j, step;
+
+        step = Qlen - 1;
+
+        if (neg)
+        {
+            fmpz_neg(Qinv + step, Q + step);
+            for (i = 2 * step; i < n; i += step)
+                fmpz_mul(Qinv + i, Qinv + i - step, Qinv + step);
+        }
+        else
+        {
+            fmpz_neg(Qinv + step, Q + step);
+            for (i = 2 * step; i < n; i += step)
+                fmpz_mul(Qinv + i, Qinv + i - step, Q + step);
+        }
+
+        for (i = 0; i < n; i += step)
+            for (j = i + 1; j < FLINT_MIN(n, i + step); j++)
+                fmpz_zero(Qinv + j);
+    }
     else
     {
-        slong i, j;
+        slong i, j, nsmall;
+        char * Qbits;
+        slong b, bits, Qinvbits;
+        TMP_INIT;
+
+        TMP_START;
+
+        /* Qbits[i] = max(bits(Q[0]), ..., bits(Q[i])), as long as coeffs are small */
+        Qbits = TMP_ALLOC(Qlen);
+        Qbits[0] = 1;
+
+        /* Maximum bits of all Qinv coefficients encountered so far */
+        Qinvbits = 1;
+
+        /* We have small coefficients for i < nsmall */
+        for (nsmall = 1; nsmall < Qlen; nsmall++)
+        {
+            b = Q[nsmall];
+
+            if (COEFF_IS_MPZ(b))
+                break;
+
+            b = FLINT_ABS(b);
+            if (b >> Qbits[nsmall - 1])
+                Qbits[nsmall] = FLINT_BIT_COUNT(b);
+            else
+                Qbits[nsmall] = Qbits[nsmall - 1];
+        }
 
         for (i = 1; i < n; i++)
         {
-            fmpz_mul(Qinv + i, Q + 1, Qinv + i - 1);
+            if (i >= nsmall || Qinvbits > FLINT_BITS - 2 || Qbits[i] > FLINT_BITS - 2)
+            {
+                /* Can't use fast code. */
+                bits = WORD_MAX;
+            }
+            else
+            {
+                /* Can maybe use fast code; bound bits. */
+                b = FLINT_MIN(i, Qlen - 1);
+                bits = FLINT_BIT_COUNT(b);
 
-            for (j = 2; j < FLINT_MIN(i + 1, Qlen); j++)
-                fmpz_addmul(Qinv + i, Q + j, Qinv + i - j);
+                /* Bit size of product. */
+                bits += Qbits[i] + Qinvbits;
 
-            if (fmpz_is_one(Qinv))
-                fmpz_neg(Qinv + i, Qinv + i);
+                /* Sign. */
+                bits += 1;
+            }
+
+            if (bits <= 3 * FLINT_BITS - 1)
+            {
+                if (bits <= FLINT_BITS - 1)
+                {
+                    slong s, x, y;
+
+                    s = 0;
+
+                    for (j = 1; j < FLINT_MIN(i + 1, Qlen); j++)
+                    {
+                        x = Q[j];
+                        y = Qinv[i - j];
+                        s += x * y;
+                    }
+
+                    if (neg)
+                        s = -s;
+
+                    fmpz_set_si(Qinv + i, s);
+                }
+                else if (bits <= 2 * FLINT_BITS - 1)
+                {
+                    mp_limb_t hi, lo, shi, slo;
+                    slong x, y;
+
+                    shi = slo = 0;
+
+                    for (j = 1; j < FLINT_MIN(i + 1, Qlen); j++)
+                    {
+                        x = Q[j];
+                        y = Qinv[i - j];
+
+                        smul_ppmm(hi, lo, x, y);
+                        add_ssaaaa(shi, slo, shi, slo, hi, lo);
+                    }
+
+                    if (neg)
+                        sub_ddmmss(shi, slo, 0, 0, shi, slo);
+
+                    fmpz_set_signed_uiui(Qinv + i, shi, slo);
+                }
+                else
+                {
+                    mp_limb_t hi, lo, cy, shh, shi, slo;
+                    slong x, y;
+
+                    shh = shi = slo = 0;
+
+                    for (j = 1; j < FLINT_MIN(i + 1, Qlen); j++)
+                    {
+                        x = Q[j];
+                        y = Qinv[i - j];
+
+                        smul_ppmm(hi, lo, x, y);
+                        add_sssaaaaaa(cy, shi, slo, 0, shi, slo, 0, hi, lo);
+                        shh += (0 <= (slong) hi) ? cy : cy - 1;
+                    }
+
+                    if (neg)
+                        sub_dddmmmsss(shh, shi, slo, 0, 0, 0, shh, shi, slo);
+
+                    fmpz_set_signed_uiuiui(Qinv + i, shh, shi, slo);
+                }
+
+                if (COEFF_IS_MPZ(*(Qinv + i)))
+                {
+                    /* Will no longer use fast code */
+                    nsmall = i;
+                }
+                else
+                {
+                    /* Update Qinvbits */
+                    b = FLINT_ABS(*(Qinv + i));
+                    b = FLINT_BIT_COUNT(b);
+                    Qinvbits = FLINT_MAX(Qinvbits, b);
+                }
+            }
+            else
+            {
+                fmpz_mul(Qinv + i, Q + 1, Qinv + i - 1);
+
+                for (j = 2; j < FLINT_MIN(i + 1, Qlen); j++)
+                    fmpz_addmul(Qinv + i, Q + j, Qinv + i - j);
+
+                if (neg)
+                    fmpz_neg(Qinv + i, Qinv + i);
+            }
+
+            TMP_END;
         }
     }
 }

--- a/fmpz_poly/inv_series_newton.c
+++ b/fmpz_poly/inv_series_newton.c
@@ -12,25 +12,6 @@
 
 #include "fmpz_poly.h"
 
-/* Requires 2*min(Qlen,n) + n - 1 < 3n coefficients of scratch space in W */
-static void
-_fmpz_poly_inv_series_basecase_rev(fmpz * Qinv, fmpz * W,
-    const fmpz * Q, slong Qlen, slong n)
-{
-    slong Wlen;
-    fmpz *Qrev;
-
-    Qlen = FLINT_MIN(Qlen, n);
-    Wlen = n + Qlen - 1;
-    Qrev = W + Wlen;
-
-    _fmpz_poly_reverse(Qrev, Q, Qlen, Qlen);
-    _fmpz_vec_zero(W, Wlen - 1);
-    fmpz_one(W + Wlen - 1);
-    _fmpz_poly_div_basecase(Qinv, W, W, Wlen, Qrev, Qlen, 0);
-    _fmpz_poly_reverse(Qinv, Qinv, n, n);
-}
-
 #define MULLOW(z, x, xn, y, yn, nn) \
     if ((xn) >= (yn)) \
         _fmpz_poly_mullow(z, x, xn, y, yn, nn); \
@@ -40,39 +21,43 @@ _fmpz_poly_inv_series_basecase_rev(fmpz * Qinv, fmpz * W,
 void
 _fmpz_poly_inv_series_newton(fmpz * Qinv, const fmpz * Q, slong Qlen, slong n)
 {
+    slong cutoff = 64;
+
     Qlen = FLINT_MIN(Qlen, n);
 
-    if (Qlen == 1)
+    if (Qlen < cutoff)
     {
-        fmpz_set(Qinv, Q);
-        _fmpz_vec_zero(Qinv + 1, n - 1);
+        _fmpz_poly_inv_series_basecase(Qinv, Q, Qlen, n);
     }
     else
     {
-        slong alloc, Qnlen, Wlen, W2len;
+        slong *a, i, m, Qnlen, Wlen, W2len;
         fmpz * W;
 
-        alloc = FLINT_MAX(n, 3 * FMPZ_POLY_INV_NEWTON_CUTOFF);
-        W = _fmpz_vec_init(alloc);
+        W = _fmpz_vec_init(n);
+        a = flint_malloc(sizeof(slong) * FLINT_BITS);
 
-        FLINT_NEWTON_INIT(FMPZ_POLY_INV_NEWTON_CUTOFF, n)
+        a[i = 0] = n;
+        while (n >= cutoff)
+            a[++i] = (n = (n + 1) / 2);
 
-        FLINT_NEWTON_BASECASE(n)
-        _fmpz_poly_inv_series_basecase_rev(Qinv, W, Q, Qlen, n);
-        FLINT_NEWTON_END_BASECASE
+        _fmpz_poly_inv_series_basecase(Qinv, Q, Qlen, n);
 
-        FLINT_NEWTON_LOOP(m, n)
-        Qnlen = FLINT_MIN(Qlen, n);
-        Wlen = FLINT_MIN(Qnlen + m - 1, n);
-        W2len = Wlen - m;
-        MULLOW(W, Q, Qnlen, Qinv, m, Wlen);
-        MULLOW(Qinv + m, Qinv, m, W + m, W2len, n - m);
-        _fmpz_vec_neg(Qinv + m, Qinv + m, n - m);
-        FLINT_NEWTON_END_LOOP
+        for (i--; i >= 0; i--)
+        {
+            m = n;
+            n = a[i];
 
-        FLINT_NEWTON_END
+            Qnlen = FLINT_MIN(Qlen, n);
+            Wlen = FLINT_MIN(Qnlen + m - 1, n);
+            W2len = Wlen - m;
+            MULLOW(W, Q, Qnlen, Qinv, m, Wlen);
+            MULLOW(Qinv + m, Qinv, m, W + m, W2len, n - m);
+            _fmpz_vec_neg(Qinv + m, Qinv + m, n - m);
+        }
 
-        _fmpz_vec_clear(W, alloc);
+        _fmpz_vec_clear(W, n);
+        flint_free(a);
     }
 }
 

--- a/fmpz_poly/test/t-div_series.c
+++ b/fmpz_poly/test/t-div_series.c
@@ -91,18 +91,18 @@ main(void)
     }
 
     /* Check that Q * B == A */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 300 * flint_test_multiplier(); i++)
     {
         fmpz_poly_t a, b, p, q;
-        slong n = n_randint(state, 50) + 1;
+        slong n = n_randint(state, 90) + 1;
 
         fmpz_poly_init(a);
         fmpz_poly_init(b);
         fmpz_poly_init(p);
         fmpz_poly_init(q);
 
-        fmpz_poly_randtest(a, state, n_randint(state, 50) + 1, 2 + n_randint(state, 100));
-        fmpz_poly_randtest_not_zero(b, state, n_randint(state, 50) + 1, 2 + n_randint(state, 100));
+        fmpz_poly_randtest(a, state, n_randint(state, 90) + 1, 2 + n_randint(state, 100));
+        fmpz_poly_randtest_not_zero(b, state, n_randint(state, 90) + 1, 2 + n_randint(state, 100));
         fmpz_poly_set_coeff_si(b, 0, n_randint(state, 2) ? 1 : -1);
 
         fmpz_poly_div_series(q, a, b, n);
@@ -131,19 +131,19 @@ main(void)
     for (i = 0; i < 100 * flint_test_multiplier(); i++)
     {
         fmpz_poly_t a, b, p, q;
-        slong n = n_randint(state, 50) + 1;
+        slong n = n_randint(state, 80) + 1;
 
         fmpz_poly_init(a);
         fmpz_poly_init(b);
         fmpz_poly_init(p);
         fmpz_poly_init(q);
 
-        fmpz_poly_randtest(a, state, n_randint(state, 50) + 1, 2 + n_randint(state, 100))
+        fmpz_poly_randtest(a, state, n_randint(state, 80) + 1, 2 + n_randint(state, 100))
 ;
-        fmpz_poly_randtest_not_zero(b, state, n_randint(state, 50) + 1, 2 + n_randint(state, 100));
+        fmpz_poly_randtest_not_zero(b, state, n_randint(state, 80) + 1, 2 + n_randint(state, 100));
 
         while (fmpz_is_zero(b->coeffs + 0))
-            fmpz_poly_randtest_not_zero(b, state, n_randint(state, 50) + 1, 2 + n_randint(state, 100));
+            fmpz_poly_randtest_not_zero(b, state, n_randint(state, 80) + 1, 2 + n_randint(state, 100));
 
         fmpz_poly_mullow(p, a, b, n);
 

--- a/fmpz_poly/test/t-div_series_basecase.c
+++ b/fmpz_poly/test/t-div_series_basecase.c
@@ -91,7 +91,7 @@ main(void)
     }
 
     /* Check that Q * B == A */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 500 * flint_test_multiplier(); i++)
     {
         fmpz_poly_t a, b, p, q;
         slong n = n_randint(state, 50) + 1;
@@ -128,7 +128,7 @@ main(void)
     }
 
     /* Check that (A * B)/B == A */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 500 * flint_test_multiplier(); i++)
     {
         fmpz_poly_t a, b, p, q;
         slong n = n_randint(state, 50) + 1;

--- a/fmpz_poly/test/t-inv_series_basecase.c
+++ b/fmpz_poly/test/t-inv_series_basecase.c
@@ -27,18 +27,23 @@ main(void)
     fflush(stdout);
 
     /* Check Q^{-1} * Q is congruent 1 mod t^n */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
     {
         fmpz_poly_t a, b, c, one;
-        slong n = n_randint(state, 80) + 1;
+        slong bits, n;
+
+        bits = 1 + n_randint(state, 80);
+        n = n_randint(state, 80) + 1;
 
         fmpz_poly_init(a);
         fmpz_poly_init(b);
         fmpz_poly_init(c);
         fmpz_poly_init(one);
 
-        fmpz_poly_randtest_not_zero(a, state, n_randint(state, 80) + 1, 100);
+        fmpz_poly_randtest_not_zero(a, state, n_randint(state, 100) + 1, bits);
         fmpz_poly_set_coeff_si(a, 0, n_randint(state, 2) ? 1 : -1);
+        if (n_randint(state, 2))
+            fmpz_poly_inv_series(a, a, n);
 
         fmpz_poly_set_ui(one, 1);
 


### PR DESCRIPTION
This speeds up fmpz_poly_inv_series_basecase by using single-limb arithmetic as long as coefficients fit in one limb. I have also cleaned up fmpz_poly_inv_series_newton and tweaked the cutoffs.

Speedup for fmpz_poly_inv_series over the old code:

![s64](https://user-images.githubusercontent.com/368838/113168363-e0b01680-9244-11eb-8375-f7acd766144d.png)

My test polynomials:
poly0 = [1, -1, 1, 1, -1, 1, ...]
poly1 = [1, -1, -1]
poly2 = 1/poly1 (fibonacci numbers)
poly3 = partition numbers
poly4 = 1/poly3 (eta)
poly5 = [1, 1, 2, 6, 24, 120, ...]
poly6 = [1, randbits(50), randbits(50), ...]
poly7 = [1, randbits(500), randbits(500), ...]

* With big coefficients (poly5, poly6, poly7), the Newton cutoff should actually be higher (>100), but I have not attempted to tune for this. Having a good mulmid should lower the optimal Newton cutoff somewhat.
* Adding 2x1 and 2x2 limb code is possible, but the code will be significantly more complex.
* All other fmpz_poly inverse/division functions (and maybe even basecase GCD) can be optimized similarly (but the code will be more complex than for this function).
