### PR TITLE
Optimize nmod_poly multiplication

### DIFF
--- a/doc/source/nmod_vec.rst
+++ b/doc/source/nmod_vec.rst
@@ -227,6 +227,10 @@ Dot products
     0, 1, 2 or 3, specifying the number of limbs needed to represent the
     unreduced result.
 
+.. function:: mp_limb_t _nmod_vec_dot_rev(mp_srcptr vec1, mp_srcptr vec2, slong len, nmod_t mod, int nlimbs)
+
+    The same as ``_nmod_vec_dot``, but reverses ``vec2``.
+
 .. function:: mp_limb_t _nmod_vec_dot_ptr(mp_srcptr vec1, const mp_ptr * vec2, slong offset, slong len, nmod_t mod, int nlimbs)
 
     Returns the dot product of (``vec1``, ``len``) and the values at

--- a/nmod_poly/mul.c
+++ b/nmod_poly/mul.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2010 William Hart
+    Copyright (C) 2021 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -18,25 +19,25 @@
 void _nmod_poly_mul(mp_ptr res, mp_srcptr poly1, slong len1, 
                              mp_srcptr poly2, slong len2, nmod_t mod)
 {
-    slong bits, bits2;
+    slong bits, cutoff_len;
 
-    if (len1 + len2 <= 6 || len2 <= 2)
+    if (len2 <= 5)
     {
         _nmod_poly_mul_classical(res, poly1, len1, poly2, len2, mod);
         return;
     }
 
     bits = FLINT_BITS - (slong) mod.norm;
-    bits2 = FLINT_BIT_COUNT(len1);
+    cutoff_len = FLINT_MIN(len1, 2 * len2);
 
-    if (2 * bits + bits2 <= FLINT_BITS && len1 + len2 < 16)
+    if (3 * cutoff_len < 2 * FLINT_MAX(bits, 10))
         _nmod_poly_mul_classical(res, poly1, len1, poly2, len2, mod);
-    else if (bits * len2 > 2000)
-        _nmod_poly_mul_KS4(res, poly1, len1, poly2, len2, mod);
-    else if (bits * len2 > 200)
+    else if (cutoff_len * bits < 800)
+        _nmod_poly_mul_KS(res, poly1, len1, poly2, len2, 0, mod);
+    else if (cutoff_len * (bits + 1) * (bits + 1) < 100000)
         _nmod_poly_mul_KS2(res, poly1, len1, poly2, len2, mod);
     else
-        _nmod_poly_mul_KS(res, poly1, len1, poly2, len2, 0, mod);
+        _nmod_poly_mul_KS4(res, poly1, len1, poly2, len2, mod);
 }
 
 void nmod_poly_mul(nmod_poly_t res, const nmod_poly_t poly1, const nmod_poly_t poly2)

--- a/nmod_poly/mul_KS.c
+++ b/nmod_poly/mul_KS.c
@@ -21,32 +21,42 @@ _nmod_poly_mul_KS(mp_ptr out, mp_srcptr in1, slong len1,
                   mp_srcptr in2, slong len2, flint_bitcnt_t bits, nmod_t mod)
 {
     slong len_out = len1 + len2 - 1, limbs1, limbs2;
-    mp_ptr mpn1, mpn2, res;
+    mp_ptr tmp, mpn1, mpn2, res;
     int squaring;
+    TMP_INIT;
 
     squaring = (in1 == in2 && len1 == len2);
 
     if (bits == 0)
     {
         flint_bitcnt_t bits1, bits2, loglen;
-        bits1  = _nmod_vec_max_bits(in1, len1);
-        bits2  = squaring ? bits1 : _nmod_vec_max_bits(in2, len2);
+
+        /* Look at the actual bits of the input? This slows down the generic
+        case. Are there situations where we care enough about special input? */
+#if 0
+        bits1  = _nmod_vec_max_bits2(in1, len1);
+        bits2  = squaring ? bits1 : _nmod_vec_max_bits2(in2, len2);
+#else
+        bits1 = FLINT_BITS - (slong) mod.norm;
+        bits2 = bits1;
+#endif
+
         loglen = FLINT_BIT_COUNT(len2);
-        
         bits = bits1 + bits2 + loglen;
     }
 
     limbs1 = (len1 * bits - 1) / FLINT_BITS + 1;
     limbs2 = (len2 * bits - 1) / FLINT_BITS + 1;
 
-    mpn1 = (mp_ptr) flint_malloc(sizeof(mp_limb_t) * limbs1);
-    mpn2 = squaring ? mpn1 : (mp_ptr) flint_malloc(sizeof(mp_limb_t) * limbs2);
+    TMP_START;
+    tmp = TMP_ALLOC(sizeof(mp_limb_t) * (limbs1 + limbs2 + limbs1 + (squaring ? 0 : limbs2)));
+    res = tmp;
+    mpn1 = tmp + limbs1 + limbs2;
+    mpn2 = squaring ? mpn1 : (mpn1 + limbs1);
 
     _nmod_poly_bit_pack(mpn1, in1, len1, bits);
     if (!squaring)
         _nmod_poly_bit_pack(mpn2, in2, len2, bits);
-
-    res = (mp_ptr) flint_malloc(sizeof(mp_limb_t) * (limbs1 + limbs2));
 
     if (squaring)
         mpn_sqr(res, mpn1, limbs1);
@@ -54,12 +64,8 @@ _nmod_poly_mul_KS(mp_ptr out, mp_srcptr in1, slong len1,
         mpn_mul(res, mpn1, limbs1, mpn2, limbs2);
 
     _nmod_poly_bit_unpack(out, len_out, res, bits, mod);
-    
-    flint_free(mpn2);
-    if (!squaring)
-        flint_free(mpn1);
 
-    flint_free(res);
+    TMP_END;
 }
 
 void

--- a/nmod_poly/mul_KS2.c
+++ b/nmod_poly/mul_KS2.c
@@ -29,6 +29,7 @@ _nmod_poly_mul_KS2(mp_ptr res, mp_srcptr op1, slong n1,
    mp_ptr v1_buf0, v2_buf0, v1_buf1, v2_buf1, v1_buf2, v2_buf2;
    mp_ptr v1o, v1e, v1p, v1m, v2o, v2e, v2p, v2m, v3o, v3e, v3p, v3m;
    mp_ptr z;
+   TMP_INIT;
 
    if (n2 == 1)
    {
@@ -36,6 +37,8 @@ _nmod_poly_mul_KS2(mp_ptr res, mp_srcptr op1, slong n1,
       _nmod_vec_scalar_mul_nmod(res, op1, n1, op2[0], mod);
       return;
    }
+
+   TMP_START;
 
    sqr = (op1 == op2 && n1 == n2);
 
@@ -76,7 +79,7 @@ _nmod_poly_mul_KS2(mp_ptr res, mp_srcptr op1, slong n1,
    k3 = k1 + k2;
 
    /* allocate space */
-   v1_buf0 = _nmod_vec_init(3*k3); /* k1 limbs */
+   v1_buf0 = TMP_ALLOC(sizeof(mp_limb_t) * 3 * k3); /* k1 limbs */
    v2_buf0 = v1_buf0 + k1;         /* k2 limbs */
    v1_buf1 = v2_buf0 + k2;         /* k1 limbs */
    v2_buf1 = v1_buf1 + k1;         /* k2 limbs */
@@ -100,7 +103,7 @@ _nmod_poly_mul_KS2(mp_ptr res, mp_srcptr op1, slong n1,
    v3e = v1_buf2;
    v3o = v1_buf0;
    
-   z = _nmod_vec_init(w*n3e);
+   z = TMP_ALLOC(sizeof(mp_limb_t) * w * n3e);
    
    if (!sqr)
    {
@@ -187,9 +190,8 @@ _nmod_poly_mul_KS2(mp_ptr res, mp_srcptr op1, slong n1,
    _nmod_poly_KS2_unpack(z, v3o, n3o, 2 * b, b + 1);
    _nmod_poly_KS2_reduce(res + 1, 2, z, n3o, w, mod);
 
-   _nmod_vec_clear(z);
-   _nmod_vec_clear(v1_buf0);
-}                  
+   TMP_END;
+}
 
 void
 nmod_poly_mul_KS2(nmod_poly_t res,

--- a/nmod_poly/mul_KS4.c
+++ b/nmod_poly/mul_KS4.c
@@ -31,6 +31,7 @@ _nmod_poly_mul_KS4(mp_ptr res, mp_srcptr op1, slong n1,
    mp_ptr v1on, v1en, v1pn, v1mn, v2on, v2en, v2pn, v2mn, v3on, v3en, v3pn, v3mn;
    mp_ptr v1or, v1er, v1pr, v1mr, v2or, v2er, v2pr, v2mr, v3or, v3er, v3pr, v3mr;
    mp_ptr z, zn, zr;
+   TMP_INIT;
 
    if (n2 == 1)
    {
@@ -38,6 +39,8 @@ _nmod_poly_mul_KS4(mp_ptr res, mp_srcptr op1, slong n1,
       _nmod_vec_scalar_mul_nmod(res, op1, n1, op2[0], mod);
       return;
    }
+
+   TMP_START;
 
    sqr = (op1 == op2 && n1 == n2);
 
@@ -81,7 +84,7 @@ _nmod_poly_mul_KS4(mp_ptr res, mp_srcptr op1, slong n1,
    k3 = k1 + k2;
 
    /* allocate space */
-   v1_buf0 = _nmod_vec_init(5*k3); /* k1 limbs */
+   v1_buf0 = TMP_ALLOC(sizeof(mp_limb_t) * 5 * k3); /* k1 limbs */
    v2_buf0 = v1_buf0 + k1;         /* k2 limbs */
    v1_buf1 = v2_buf0 + k2;         /* k1 limbs */
    v2_buf1 = v1_buf1 + k1;         /* k2 limbs */
@@ -123,7 +126,7 @@ _nmod_poly_mul_KS4(mp_ptr res, mp_srcptr op1, slong n1,
    v3er = v1_buf2;
    v3or = v1_buf3;
    
-   z = _nmod_vec_init(2*w*(n3e + 1));
+   z = TMP_ALLOC(sizeof(mp_limb_t) * 2*w*(n3e + 1));
    zn = z;
    zr = z + w*(n3e + 1);
 
@@ -332,8 +335,7 @@ _nmod_poly_mul_KS4(mp_ptr res, mp_srcptr op1, slong n1,
    /* combine ho(B^2) and ho(1/B^2) information to get odd coefficients of h */
    _nmod_poly_KS2_recover_reduce(res + 1, 2, zn, zr, n3o, 2 * b, mod);
    
-   _nmod_vec_clear(z);
-   _nmod_vec_clear(v1_buf0);
+   TMP_END;
 }
 
 void

--- a/nmod_poly/mullow.c
+++ b/nmod_poly/mullow.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2010 William Hart
+    Copyright (C) 2021 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -18,21 +19,20 @@
 void _nmod_poly_mullow(mp_ptr res, mp_srcptr poly1, slong len1, 
                              mp_srcptr poly2, slong len2, slong n, nmod_t mod)
 {
-    slong bits, bits2;
+    slong bits;
 
     len1 = FLINT_MIN(len1, n);
     len2 = FLINT_MIN(len2, n);
 
-    if (len1 + len2 <= 6 || n <= 6)
+    if (len2 <= 5)
     {
         _nmod_poly_mullow_classical(res, poly1, len1, poly2, len2, n, mod);
         return;
     }
 
     bits = FLINT_BITS - (slong) mod.norm;
-    bits2 = FLINT_BIT_COUNT(len1);
 
-    if (2 * bits + bits2 <= FLINT_BITS && len1 + len2 < 16)
+    if (n < 10 + bits * bits / 10)
         _nmod_poly_mullow_classical(res, poly1, len1, poly2, len2, n, mod);
     else
         _nmod_poly_mullow_KS(res, poly1, len1, poly2, len2, 0, n, mod);

--- a/nmod_poly/mullow_KS.c
+++ b/nmod_poly/mullow_KS.c
@@ -21,8 +21,9 @@ _nmod_poly_mullow_KS(mp_ptr out, mp_srcptr in1, slong len1,
             mp_srcptr in2, slong len2, flint_bitcnt_t bits, slong n, nmod_t mod)
 {
     slong limbs1, limbs2;
-    mp_ptr mpn1, mpn2, res;
+    mp_ptr tmp, mpn1, mpn2, res;
     int squaring;
+    TMP_INIT;
 
     len1 = FLINT_MIN(len1, n);
     len2 = FLINT_MIN(len2, n);
@@ -32,24 +33,32 @@ _nmod_poly_mullow_KS(mp_ptr out, mp_srcptr in1, slong len1,
     if (bits == 0)
     {
         flint_bitcnt_t bits1, bits2, loglen;
-        bits1  = _nmod_vec_max_bits(in1, len1);
-        bits2  = squaring ? bits1 : _nmod_vec_max_bits(in2, len2);
+
+        /* Look at the actual bits of the input? This slows down the generic
+        case. Are there situations where we care enough about special input? */
+#if 0
+        bits1  = _nmod_vec_max_bits2(in1, len1);
+        bits2  = squaring ? bits1 : _nmod_vec_max_bits2(in2, len2);
+#else
+        bits1 = FLINT_BITS - (slong) mod.norm;
+        bits2 = bits1;
+#endif
         loglen = FLINT_BIT_COUNT(len2);
-        
         bits = bits1 + bits2 + loglen;
     }
 
     limbs1 = (len1 * bits - 1) / FLINT_BITS + 1;
     limbs2 = (len2 * bits - 1) / FLINT_BITS + 1;
 
-    mpn1 = (mp_ptr) flint_malloc(sizeof(mp_limb_t) * limbs1);
-    mpn2 = squaring ? mpn1 : (mp_ptr) flint_malloc(sizeof(mp_limb_t) * limbs2);
+    TMP_START;
+    tmp = TMP_ALLOC(sizeof(mp_limb_t) * (limbs1 + limbs2 + limbs1 + (squaring ? 0 : limbs2)));
+    res = tmp;
+    mpn1 = tmp + limbs1 + limbs2;
+    mpn2 = squaring ? mpn1 : (mpn1 + limbs1);
 
     _nmod_poly_bit_pack(mpn1, in1, len1, bits);
     if (!squaring)
         _nmod_poly_bit_pack(mpn2, in2, len2, bits);
-
-    res = (mp_ptr) flint_malloc(sizeof(mp_limb_t) * (limbs1 + limbs2));
 
     if (squaring)
         mpn_sqr(res, mpn1, limbs1);
@@ -58,11 +67,7 @@ _nmod_poly_mullow_KS(mp_ptr out, mp_srcptr in1, slong len1,
 
     _nmod_poly_bit_unpack(out, n, res, bits, mod);
     
-    flint_free(mpn2);
-    if (!squaring)
-        flint_free(mpn1);
-
-    flint_free(res);
+    TMP_END;
 }
 
 void

--- a/nmod_poly/mullow_classical.c
+++ b/nmod_poly/mullow_classical.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2008, 2009 William Hart
+    Copyright (C) 2021 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -16,64 +17,110 @@
 #include "nmod_poly.h"
 #include "ulong_extras.h"
 
-/* Assumes poly1 and poly2 are not length 0 and 0 < trunc <= len1 + len2 - 1 */
+/* Assumes poly1 and poly2 are not length 0 and 0 < n <= len1 + len2 - 1 */
 void
 _nmod_poly_mullow_classical(mp_ptr res, mp_srcptr poly1, slong len1,
-                            mp_srcptr poly2, slong len2, slong trunc, nmod_t mod)
+                            mp_srcptr poly2, slong len2, slong n, nmod_t mod)
 {
-    if (len1 == 1 || trunc == 1)    /* Special case if the length of output is 1 */
+    slong i, j, bits, log_len, nlimbs, n1, n2;
+    int squaring;
+    mp_limb_t c;
+
+    len1 = FLINT_MIN(len1, n);
+    len2 = FLINT_MIN(len2, n);
+
+    if (n == 1)
     {
-        res[0] = n_mulmod2_preinv(poly1[0], poly2[0], mod.n, mod.ninv);
+        res[0] = nmod_mul(poly1[0], poly2[0], mod);
+        return;
     }
-    else                        /* Ordinary case */
+
+    if (len2 == 1)
     {
-        slong i;
+        _nmod_vec_scalar_mul_nmod(res, poly1, len1, poly2[0], mod);
+        return;
+    }
 
-        slong bits = FLINT_BITS - (slong) mod.norm;
-        slong log_len = FLINT_BIT_COUNT(len2);
+    squaring = (poly1 == poly2 && len1 == len2);
 
-        if (2 * bits + log_len <= FLINT_BITS)
+    log_len = FLINT_BIT_COUNT(len2);
+    bits = FLINT_BITS - (slong) mod.norm;
+    bits = 2 * bits + log_len;
+
+    if (bits <= FLINT_BITS)
+    {
+        flint_mpn_zero(res, n);
+
+        if (squaring)
         {
-            /* Set res[i] = poly1[i]*poly2[0] */
-            mpn_mul_1(res, poly1, FLINT_MIN(len1, trunc), poly2[0]);
-
-            if (len2 != 1)
+            for (i = 0; i < len1; i++)
             {
-                /* Set res[i+len1-1] = in1[len1-1]*in2[i] */
-                if (trunc > len1)
-                    mpn_mul_1(res + len1, poly2 + 1, trunc - len1,
-                              poly1[len1 - 1]);
+                c = poly1[i];
 
-                /* out[i+j] += in1[i]*in2[j] */
-                for (i = 0; i < FLINT_MIN(len1, trunc) - 1; i++)
-                {
-                    FLINT_ASSERT(FLINT_MIN(len2, trunc - i) > 1);
-                    mpn_addmul_1(res + i + 1, poly2 + 1,
-                                 FLINT_MIN(len2, trunc - i) - 1, poly1[i]);
-                }
+                if (2 * i < n)
+                    res[2 * i] += c * c;
+
+                c *= 2;
+
+                for (j = i + 1; j < FLINT_MIN(len1, n - i); j++)
+                    res[i + j] += poly1[j] * c;
             }
-
-            _nmod_vec_reduce(res, res, trunc, mod);
         }
         else
         {
-            /* Set res[i] = poly1[i]*poly2[0] */
-            _nmod_vec_scalar_mul_nmod(res, poly1, FLINT_MIN(len1, trunc),
-                                 poly2[0], mod);
+            for (i = 0; i < len1; i++)
+            {
+                mp_limb_t c = poly1[i];
 
-            if (len2 == 1)
-                return;
+                for (j = 0; j < FLINT_MIN(len2, n - i); j++)
+                    res[i + j] += c * poly2[j];
+            }
+        }
 
-            /* Set res[i+len1-1] = in1[len1-1]*in2[i] */
-            if (trunc > len1)
-                _nmod_vec_scalar_mul_nmod(res + len1, poly2 + 1, trunc - len1,
-                                     poly1[len1 - 1], mod);
+        _nmod_vec_reduce(res, res, n, mod);
+        return;
+    }
 
-            /* out[i+j] += in1[i]*in2[j] */
-            for (i = 0; i < FLINT_MIN(len1, trunc) - 1; i++)
-                _nmod_vec_scalar_addmul_nmod(res + i + 1, poly2 + 1,
-                                        FLINT_MIN(len2, trunc - i) - 1, 
-                                        poly1[i], mod);
+    if (len2 == 2)
+    {
+        _nmod_vec_scalar_mul_nmod(res, poly1, len1, poly2[0], mod);
+        _nmod_vec_scalar_addmul_nmod(res + 1, poly1, len1 - 1, poly2[1], mod);
+        if (n == len1 + len2 - 1)
+            res[len1 + len2 - 2] = nmod_mul(poly1[len1 - 1], poly2[len2 - 1], mod);
+        return;
+    }
+
+    if (bits <= 2 * FLINT_BITS)
+        nlimbs = 2;
+    else
+        nlimbs = 3;
+
+    if (squaring)
+    {
+        for (i = 0; i < n; i++)
+        {
+            n1 = FLINT_MAX(0, i - len1 + 1);
+            n2 = FLINT_MIN(len1 - 1, (i + 1) / 2 - 1);
+
+            c = _nmod_vec_dot_rev(poly1 + n1, poly1 + i - n2, n2 - n1 + 1, mod, nlimbs);
+            c = nmod_add(c, c, mod);
+
+            if (i % 2 == 0 && i / 2 < len1)
+                NMOD_ADDMUL(c, poly1[i / 2], poly1[i / 2], mod);
+
+            res[i] = c;
+        }
+    }
+    else
+    {
+        for (i = 0; i < n; i++)
+        {
+            n1 = FLINT_MIN(len1 - 1, i);
+            n2 = FLINT_MIN(len2 - 1, i);
+
+            res[i] = _nmod_vec_dot_rev(poly1 + i - n2,
+                                       poly2 + i - n1,
+                                       n1 + n2 - i + 1, mod, nlimbs);
         }
     }
 }

--- a/nmod_poly/test/t-mul_classical.c
+++ b/nmod_poly/test/t-mul_classical.c
@@ -126,6 +126,40 @@ main(void)
         nmod_poly_clear(d);
     }
 
+    /* check b^2 = b*b */
+    for (i = 0; i < 200 * flint_test_multiplier(); i++)
+    {
+        nmod_poly_t a1, a2, b, c;
+
+        mp_limb_t n = n_randtest_not_zero(state);
+
+        nmod_poly_init(a1, n);
+        nmod_poly_init(a2, n);
+        nmod_poly_init(b, n);
+        nmod_poly_init(c, n);
+        nmod_poly_randtest(b, state, n_randint(state, 50));
+        nmod_poly_randtest(a1, state, n_randint(state, 50));
+        nmod_poly_randtest(a2, state, n_randint(state, 50));
+
+        nmod_poly_set(c, b);
+        nmod_poly_mul_classical(a1, b, b);
+        nmod_poly_mul_classical(a2, b, c);
+
+        result = (nmod_poly_equal(a1, a2));
+        if (!result)
+        {
+            flint_printf("FAIL (squaring):\n");
+            nmod_poly_print(a1), flint_printf("\n\n");
+            nmod_poly_print(a2), flint_printf("\n\n");
+            abort();
+        }
+
+        nmod_poly_clear(a1);
+        nmod_poly_clear(a2);
+        nmod_poly_clear(b);
+        nmod_poly_clear(c);
+    }
+
     FLINT_TEST_CLEANUP(state);
     
     flint_printf("PASS\n");

--- a/nmod_poly/test/t-mullow_classical.c
+++ b/nmod_poly/test/t-mullow_classical.c
@@ -119,9 +119,18 @@ main(void)
         else
             trunc = n_randint(state, b->length + c->length - 1);
 
-        nmod_poly_mul_classical(a, b, c);
-        nmod_poly_truncate(a, trunc);
-        nmod_poly_mullow_classical(d, b, c, trunc);
+        if (n_randint(state, 2))  /* check squaring */
+        {
+            nmod_poly_mul_classical(a, b, b);
+            nmod_poly_truncate(a, trunc);
+            nmod_poly_mullow_classical(d, b, b, trunc);
+        }
+        else
+        {
+            nmod_poly_mul_classical(a, b, c);
+            nmod_poly_truncate(a, trunc);
+            nmod_poly_mullow_classical(d, b, c, trunc);
+        }
 
         result = (nmod_poly_equal(a, d));
         if (!result)

--- a/nmod_vec.h
+++ b/nmod_vec.h
@@ -333,6 +333,9 @@ FLINT_DLL int _nmod_vec_dot_bound_limbs(slong len, nmod_t mod);
 FLINT_DLL mp_limb_t _nmod_vec_dot(mp_srcptr vec1, mp_srcptr vec2,
     slong len, nmod_t mod, int nlimbs);
 
+FLINT_DLL mp_limb_t _nmod_vec_dot_rev(mp_srcptr vec1, mp_srcptr vec2,
+    slong len, nmod_t mod, int nlimbs);
+
 FLINT_DLL mp_limb_t _nmod_vec_dot_ptr(mp_srcptr vec1, const mp_ptr * vec2, slong offset,
     slong len, nmod_t mod, int nlimbs);
 

--- a/nmod_vec/dot_rev.c
+++ b/nmod_vec/dot_rev.c
@@ -1,0 +1,43 @@
+/*
+    Copyright (C) 2011, 2021 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <gmp.h>
+#include <stdlib.h>
+#include "flint.h"
+#include "ulong_extras.h"
+#include "nmod_vec.h"
+
+static mp_limb_t
+nmod_fmma(mp_limb_t a, mp_limb_t b, mp_limb_t c, mp_limb_t d, nmod_t mod)
+{
+    a = nmod_mul(a, b, mod);
+    NMOD_ADDMUL(a, c, d, mod);
+    return a;
+}
+
+mp_limb_t
+_nmod_vec_dot_rev(mp_srcptr vec1, mp_srcptr vec2, slong len, nmod_t mod, int nlimbs)
+{
+    mp_limb_t res;
+    slong i;
+
+    if (len <= 2 && nlimbs >= 2)
+    {
+        if (len == 2)
+            return nmod_fmma(vec1[0], vec2[1], vec1[1], vec2[0], mod);
+        if (len == 1)
+            return nmod_mul(vec1[0], vec2[0], mod);
+        return 0;
+    }
+
+    NMOD_VEC_DOT(res, i, len, vec1[i], vec2[len - 1 - i], mod, nlimbs);
+    return res;
+}

--- a/nmod_vec/max_bits.c
+++ b/nmod_vec/max_bits.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2010 William Hart
+    Copyright (C) 2021 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -16,19 +17,16 @@
 
 flint_bitcnt_t _nmod_vec_max_bits(mp_srcptr vec, slong len)
 {
-    flint_bitcnt_t bits = 0;
-    mp_limb_t mask   = ~(mp_limb_t) 0;
     slong i;
+    mp_limb_t mask = 0;
 
     for (i = 0; i < len; i++)
     {
-        if (vec[i] & mask)
-        {
-            bits = FLINT_BIT_COUNT(vec[i]);
-            if (bits == FLINT_BITS) break;
-            else mask = ~(mp_limb_t) 0 - ((UWORD(1) << bits) - UWORD(1));
-        }
+        mask |= vec[i];
+
+        if (mask >= (UWORD(1) << (FLINT_BITS - 1)))
+            return FLINT_BITS;
     }
 
-    return bits;
+    return FLINT_BIT_COUNT(mask);
 }


### PR DESCRIPTION
Changes:

* I've rewritten mul_classical and mullow_classical to use a simple for-loop (small bits) and dot products (large bits).
* Squaring optimization in mul_classical and mullow_classical.
* Use TMP_ALLOC instead of three(!) mallocs in mul_KS, mullow_KS. Also use TMP_ALLOC in mul_KS2 and mul_KS4.
* Improved cutoffs between classical and KS.
* Improved cutoffs between mul_KS, mul_KS2 and mul_KS4, especially for small bits.
* Just use the size of the modulus instead of calling _nmod_vec_max_bits in mul_KS. Just in case, I rewrote _nmod_vec_max_bits to be faster in case we want to turn this back on in the future.

Some todos that I could open issues for:

* The new cutoff between mullow_classical / mullow_KS is quite high (several hundred when the modulus is large), presumably due to the fact that mullow_KS uses mpn_mul rather than a mpn_mullow. Unfortunately GMP doesn't provide a public mpn_mullow, but it's possible that we could roll our own.
* Since mullow_KS just differs from mul_KS in that it reads fewer output coefficients, it should be worthwhile to use mul_KS2 and mul_KS4 in mullow too.
* I did not bother rewriting mulhigh since it is only used in one place (sqrt -- which maybe should rewritten to use mullow instead?).
* I have not retuned other functions (division, etc.) that will benefit from faster multiplication.
* The nmod_vec dot product functions can be improved, especially for short input.

Other things to note:

* Squaring could be optimized for short input by avoiding a reduction, but this is not worth the trouble in my opinion.

Potential problems:

* The optimal cutoffs depend strongly on relative speeds of GMP functions and our dot product code. There could be regressions on other machines.

The easiest way to check the performance with the proposed changes is to run the standalone .c file https://gist.github.com/fredrik-johansson/2b8d6db8a2ffaf50c9ed97854abacd62 (without checking out this branch) which profiles the new code against the existing nmod_poly_mul / nmod_poly_mullow.

Here are the speedups on my machine:

![mullow_nxn](https://user-images.githubusercontent.com/368838/113574272-05790500-961c-11eb-93e9-b846f6bc28af.png)
![mullow_nxn2](https://user-images.githubusercontent.com/368838/113574273-06119b80-961c-11eb-9fbe-9f6d4a95db11.png)
![sqrlow](https://user-images.githubusercontent.com/368838/113574277-0873f580-961c-11eb-8473-20f44282306c.png)
![mul_nxn](https://user-images.githubusercontent.com/368838/113574274-0742c880-961c-11eb-9680-5c75adb9290c.png)
![mul_2nxn](https://user-images.githubusercontent.com/368838/113574267-03af4180-961c-11eb-95dd-1d7a32dfff3f.png)
![mul_10nxn](https://user-images.githubusercontent.com/368838/113574269-04e06e80-961c-11eb-8531-f21c9abf4a07.png)
![sqr](https://user-images.githubusercontent.com/368838/113574276-07db5f00-961c-11eb-9bd1-586e7c0b8d25.png)
