### PR TITLE
[RFC&PI] add fmpz_mat_mul_small (to replace fmpz_mat_mul_{1|2a|2b})

### DIFF
--- a/doc/source/fmpz_mat.rst
+++ b/doc/source/fmpz_mat.rst
@@ -505,6 +505,12 @@ Matrix multiplication
     The matrices must have compatible dimensions for matrix multiplication.
     No aliasing is allowed.
     
+.. function:: int fmpz_mat_mul_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B)
+
+    This internal function sets `C` to the matrix product `C = A B` computed
+    using classical matrix algorithm assuming that all entries of `A` and `B`
+    are small, that is, have bits ` \le FLINT\_BITS - 2`. No aliasing is allowed.
+
 .. function:: void fmpz_mat_mul_strassen(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B)
 
     Sets `C = AB`. Dimensions must be compatible for matrix multiplication.

--- a/fmpz_mat.h
+++ b/fmpz_mat.h
@@ -232,6 +232,8 @@ FLINT_DLL void fmpz_mat_scalar_mod_fmpz(fmpz_mat_t B, const fmpz_mat_t A, const 
 
 /* Multiplication */
 
+FLINT_DLL void fmpz_mat_mul_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B);
+
 FLINT_DLL void fmpz_mat_mul(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B);
 
 FLINT_DLL void fmpz_mat_mul_classical(fmpz_mat_t C, const fmpz_mat_t A,

--- a/fmpz_mat/mul_small.c
+++ b/fmpz_mat/mul_small.c
@@ -1,0 +1,461 @@
+/*
+    Copyright (C) 2010,2011,2018 Fredrik Johansson
+    Copyright (C) 2016 Aaditya Thakkar
+    Copyright (C) 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz_mat.h"
+
+static void _dot1(fmpz_t z, fmpz * a, slong * b, slong len)
+{
+    slong i;
+    slong s0 = 0;
+
+    for (i = 0; i < len; i++)
+        s0 += a[i]*b[i];
+
+    fmpz_set_si(z, s0);
+}
+
+static void _dot2(fmpz_t z, fmpz * a, slong * b, slong len)
+{
+    slong i;
+    ulong p1, p0, s1, s0;
+
+    s1 = s0 = 0;
+    for (i = 0; i < len; i++)
+    {
+        smul_ppmm(p1, p0, a[i], b[i]);
+        add_ssaaaa(s1, s0, s1, s0, p1, p0);
+    }
+
+    fmpz_set_signed_uiui(z, s1, s0);
+}
+
+static void _dot3(fmpz_t z, fmpz * a, slong * b, slong len)
+{
+    slong i;
+    ulong p1, p0, s2, s1, s0;
+
+    s2 = s1 = s0 = 0;
+    for (i = 0; i < len; i++)
+    {
+        smul_ppmm(p1, p0, a[i], b[i]);
+        add_sssaaaaaa(s2, s1, s0, s2, s1, s0, FLINT_SIGN_EXT(p1), p1, p0);
+    }
+
+    fmpz_set_signed_uiuiui(z, s2, s1, s0);
+}
+
+static void _dot_add1(ulong * s, fmpz * a, slong * b, slong len)
+{
+    slong i;
+    slong s0 = s[0];
+
+    for (i = 0; i < len; i++)
+        s0 += a[i]*b[i];
+
+    s[0] = s0;
+}
+
+static void _dot_add2(ulong * s, fmpz * a, slong * b, slong len)
+{
+    slong i;
+    ulong p1, p0, s1, s0, t1, t0;
+
+    FLINT_ASSERT(len > 0);
+
+    s0 = s[0];
+    s1 = s[1];
+
+    if (len & 1)
+    {
+        smul_ppmm(t1, t0, a[0], b[0]);
+        a++;
+        b++;
+    }
+    else
+    {
+        t1 = t0 = 0;
+    }
+
+    for (i = 0; i < len/2; i++)
+    {
+        smul_ppmm(p1, p0, a[2*i+0], b[2*i+0]);
+        add_ssaaaa(s1, s0, s1, s0, p1, p0);
+        smul_ppmm(p1, p0, a[2*i+1], b[2*i+1]);
+        add_ssaaaa(t1, t0, t1, t0, p1, p0);
+    }
+
+    add_ssaaaa(s1, s0, s1, s0, t1, t0);
+
+    s[0] = s0;
+    s[1] = s1;
+}
+
+static void _dot_add3(ulong * s, fmpz * a, slong * b, slong len)
+{
+    slong i;
+    ulong p1, p0, s2, s1, s0, t2, t1, t0;
+
+    FLINT_ASSERT(len > 0);
+
+    s0 = s[0];
+    s1 = s[1];
+    s2 = s[2];
+
+    if (len & 1)
+    {
+        smul_ppmm(t1, t0, a[0], b[0]);
+        t2 = FLINT_SIGN_EXT(t1);
+        a++;
+        b++;
+    }
+    else
+    {
+        t2 = t1 = t0 = 0;
+    }
+
+    for (i = 0; i < len/2; i++)
+    {
+        smul_ppmm(p1, p0, a[2*i+0], b[2*i+0]);
+        add_sssaaaaaa(s2, s1, s0, s2, s1, s0, FLINT_SIGN_EXT(p1), p1, p0);
+        smul_ppmm(p1, p0, a[2*i+1], b[2*i+1]);
+        add_sssaaaaaa(t2, t1, t0, t2, t1, t0, FLINT_SIGN_EXT(p1), p1, p0);
+    }
+
+    add_sssaaaaaa(s2, s1, s0, s2, s1, s0, t2, t1, t0);
+
+    s[0] = s0;
+    s[1] = s1;
+    s[2] = s2;
+}
+
+
+typedef struct {
+    slong Astartrow;
+    slong Astoprow;
+    slong Bstartcol;
+    slong Bstopcol;
+    slong n;
+    slong k;
+    slong m;
+    slong k_blk_sz;
+    slong m_blk_sz;
+    fmpz ** Crows;
+    fmpz ** Arows;
+    fmpz ** Brows;
+    slong * BL;
+    int words;
+} _worker_arg;
+
+static void _tr_worker(void * varg)
+{
+    _worker_arg * arg = (_worker_arg *) varg;
+    slong Bstartcol = arg->Bstartcol;
+    slong Bstopcol = arg->Bstopcol;
+    slong k = arg->k;
+    slong n = arg->n;
+    slong k_blk_sz = arg->k_blk_sz;
+    fmpz ** Brows = arg->Brows;
+    slong * BL = arg->BL;
+    slong i, iq, ir, j;
+
+    iq = ir = 0;
+    for (i = 0; i < k; i++)
+    {
+        for (j = Bstartcol; j < Bstopcol; j++)
+            BL[iq*n*k_blk_sz + j*k_blk_sz + ir] = Brows[i][j];
+
+        /* (iq, ir) = divrem(i, k_blk_sz) */
+        ir++;
+        if (ir >= k_blk_sz)
+        {
+            iq++;
+            ir = 0;
+        }
+    }
+}
+
+static void _mul_worker(void * varg)
+{
+    _worker_arg * arg = (_worker_arg *) varg;
+    slong Astartrow = arg->Astartrow;
+    slong Astoprow = arg->Astoprow;
+    slong n = arg->n;
+    slong k = arg->k;
+    slong m = arg->m;
+    slong m_blk_sz = arg->m_blk_sz;
+    slong k_blk_sz = arg->k_blk_sz;
+    fmpz ** Crows = arg->Crows;
+    fmpz ** Arows = arg->Arows;
+    slong * BL = arg->BL;
+    slong * TA;
+    ulong * TC;
+    slong h, hh, i, ii, j;
+    int words = arg->words;
+    TMP_INIT;
+
+    /* no blocking overhead when things are small */
+    if (k <= k_blk_sz || Astoprow - Astartrow < 2*m_blk_sz)
+    {
+        if (words == 1)
+        {
+            for (h = Astartrow; h < Astoprow; h++)
+                for (j = 0; j < n; j++)
+                    _dot1(&Crows[h][j], Arows[h], &BL[j*k_blk_sz], k);
+        }
+        else if (words == 2)
+        {
+            for (h = Astartrow; h < Astoprow; h++)
+                for (j = 0; j < n; j++)
+                    _dot2(&Crows[h][j], Arows[h], &BL[j*k_blk_sz], k);
+        }
+        else
+        {
+            for (h = Astartrow; h < Astoprow; h++)
+                for (j = 0; j < n; j++)
+                    _dot3(&Crows[h][j], Arows[h], &BL[j*k_blk_sz], k);
+        }
+
+        return;
+    }
+
+    TMP_START;
+
+    TA = TMP_ARRAY_ALLOC(m_blk_sz*k_blk_sz, slong);
+    TC = TMP_ARRAY_ALLOC(n*m_blk_sz*words, ulong);
+
+    for (h = Astartrow; h < Astoprow; h += m_blk_sz)
+    {
+        slong hstop = FLINT_MIN(m - h, m_blk_sz);
+
+        /* TC is a compressed block for the answer C[h:h+hhstop-1, all] */
+        for (j = 0; j < n*hstop*words; j++)
+            TC[j] = 0;
+
+        for (i = 0; i < k; i += k_blk_sz)
+        {
+            slong istop = FLINT_MIN(k_blk_sz, k - i);
+
+            /* get a compressed copy of A[h:h+hhstop, i:i+iistop] into TA */
+            for (hh = 0; hh < hstop; hh++)
+            for (ii = 0; ii < istop; ii++)
+                TA[hh*k_blk_sz + ii] = Arows[h + hh][i + ii];
+
+            /* addmul into answer block */
+            if (words == 1)
+            {
+                for (j = 0; j < n; j++)
+                for (hh = 0; hh < hstop; hh++)
+                    _dot_add1(&TC[1*(hh + hstop*j)], &TA[hh*k_blk_sz],
+                                                 &BL[i*n + j*k_blk_sz], istop);
+            }
+            else if (words == 2)
+            {
+                for (j = 0; j < n; j++)
+                for (hh = 0; hh < hstop; hh++)
+                    _dot_add2(&TC[2*(hh + hstop*j)], &TA[hh*k_blk_sz],
+                                                 &BL[i*n + j*k_blk_sz], istop);
+            }
+            else
+            {
+                for (j = 0; j < n; j++)
+                for (hh = 0; hh < hstop; hh++)
+                    _dot_add3(&TC[3*(hh + hstop*j)], &TA[hh*k_blk_sz],
+                                                 &BL[i*n + j*k_blk_sz], istop);
+            }
+        }
+
+        /* copy out answer for C[h:h+hhstop-1, all] */
+        if (words == 1)
+        {
+            for (j = 0; j < n; j++)
+            for (hh = 0; hh < hstop; hh++)
+                fmpz_set_si(&Crows[h + hh][j], (slong)TC[hh + hstop*j]);
+        }
+        else if (words == 2)
+        {
+            for (j = 0; j < n; j++)
+            for (hh = 0; hh < hstop; hh++)
+                fmpz_set_signed_uiui(&Crows[h + hh][j],
+                                     TC[2*(hh + hstop*j) + 1],
+                                     TC[2*(hh + hstop*j) + 0]);
+        }
+        else
+        {
+            for (j = 0; j < n; j++)
+            for (hh = 0; hh < hstop; hh++)
+                fmpz_set_signed_uiuiui(&Crows[h + hh][j],
+                                       TC[3*(hh + hstop*j) + 2],
+                                       TC[3*(hh + hstop*j) + 1],
+                                       TC[3*(hh + hstop*j) + 0]);
+        }
+    }
+
+    TMP_END;
+    return;
+}
+
+
+void _fmpz_mat_mul_small(
+    fmpz_mat_t C,
+    const fmpz_mat_t A,
+    const fmpz_mat_t B,
+    flint_bitcnt_t Cbits)
+{
+    slong i;
+    slong m = fmpz_mat_nrows(A);
+    slong k = fmpz_mat_nrows(B);
+    slong n = fmpz_mat_ncols(B);
+    _worker_arg mainarg;
+    thread_pool_handle * handles;
+    slong num_workers;
+    _worker_arg * args;
+    slong limit;
+    slong k_blk_ct;
+    slong k_blk_sz;
+    slong m_blk_sz;
+    TMP_INIT;
+
+    FLINT_ASSERT(m > 0 && k > 0 && n > 0);
+
+    TMP_START;
+
+    /* _dot1 moves through the data quickly, so it is worth blocking */
+
+    /* block size in the m direction */
+    m_blk_sz = 16;
+
+    /* choose a block size in the k direction */
+    if (k <= 128)
+    {
+        k_blk_sz = k;
+        k_blk_ct = 1;
+    }
+    else
+    {
+        k_blk_sz = 128;
+        k_blk_ct = (k + k_blk_sz - 1)/k_blk_sz;
+    }
+
+    mainarg.m_blk_sz = m_blk_sz;
+    mainarg.k_blk_sz = k_blk_sz;
+    mainarg.Astartrow = 0;
+    mainarg.Astoprow = m;
+    mainarg.Bstartcol = 0;
+    mainarg.Bstopcol = n;
+
+    mainarg.k = k;
+    mainarg.m = m;
+    mainarg.n = n;
+    mainarg.Crows = C->rows;
+    mainarg.Arows = A->rows;
+    mainarg.Brows = B->rows;
+    mainarg.BL = TMP_ARRAY_ALLOC(n*k_blk_ct*k_blk_sz, slong);
+
+    if (Cbits <= FLINT_BITS - 2)
+        mainarg.words = 1;
+    else if (Cbits <= 2*FLINT_BITS - 1)
+        mainarg.words = 2;
+    else
+        mainarg.words = 3;
+
+    /* limit on number of threads */
+    limit = FLINT_MAX(k, n);
+    limit = FLINT_MIN(limit, m);
+    limit = limit < 32 ? 0 : (limit - 32)/16;
+
+    if (limit < 2)
+    {
+use_one_thread:
+
+        _tr_worker(&mainarg);
+        _mul_worker(&mainarg);
+
+        TMP_END;
+        return;
+    }
+
+    num_workers = flint_request_threads(&handles, limit);
+    if (num_workers < 1)
+    {
+        flint_give_back_threads(handles, num_workers);
+        goto use_one_thread;
+    }
+
+    args = FLINT_ARRAY_ALLOC(num_workers, _worker_arg);
+
+    for (i = 0; i < num_workers; i++)
+    {
+        args[i].m_blk_sz = mainarg.m_blk_sz;
+        args[i].k_blk_sz = mainarg.k_blk_sz;
+        args[i].Astartrow = (i + 0)*m/(num_workers + 1);
+        args[i].Astoprow = (i + 1)*m/(num_workers + 1);
+        args[i].Bstartcol = (i + 0)*n/(num_workers + 1);
+        args[i].Bstopcol = (i + 1)*n/(num_workers + 1);
+        args[i].k = mainarg.k;
+        args[i].m = mainarg.m;
+        args[i].n = mainarg.n;
+        args[i].Crows = mainarg.Crows;
+        args[i].Arows = mainarg.Arows;
+        args[i].Brows = mainarg.Brows;
+        args[i].BL = mainarg.BL;
+        args[i].words = mainarg.words;
+    }
+
+    i = num_workers;
+    mainarg.Astartrow = (i + 0)*m/(num_workers + 1);
+    mainarg.Astoprow = (i + 1)*m/(num_workers + 1);
+    mainarg.Bstartcol = (i + 0)*n/(num_workers + 1);
+    mainarg.Bstopcol = (i + 1)*n/(num_workers + 1);
+
+    for (i = 0; i < num_workers; i++)
+        thread_pool_wake(global_thread_pool, handles[i], 0, _tr_worker, &args[i]);
+    _tr_worker(&mainarg);
+    for (i = 0; i < num_workers; i++)
+        thread_pool_wait(global_thread_pool, handles[i]);
+
+    for (i = 0; i < num_workers; i++)
+        thread_pool_wake(global_thread_pool, handles[i], 0, _mul_worker, &args[i]);
+    _mul_worker(&mainarg);
+    for (i = 0; i < num_workers; i++)
+        thread_pool_wait(global_thread_pool, handles[i]);
+
+    flint_give_back_threads(handles, num_workers);
+    flint_free(args);
+
+    TMP_END;
+}
+
+void fmpz_mat_mul_small(
+    fmpz_mat_t C,
+    const fmpz_mat_t A,
+    const fmpz_mat_t B)
+{
+    slong Abits, Bbits;
+    flint_bitcnt_t Cbits;
+
+    if (fmpz_mat_is_empty(A) || fmpz_mat_is_empty(B))
+    {
+        fmpz_mat_zero(C);
+        return;
+    }
+
+    Abits = fmpz_mat_max_bits(A);
+    Bbits = fmpz_mat_max_bits(B);
+    Abits = FLINT_ABS(Abits);
+    Bbits = FLINT_ABS(Bbits);
+
+    Cbits = Abits + Bbits + FLINT_BIT_COUNT(A->c);
+
+    _fmpz_mat_mul_small(C, A, B, Cbits);
+}
+

--- a/fmpz_mat/mul_small.c
+++ b/fmpz_mat/mul_small.c
@@ -191,7 +191,6 @@ static void _mul_worker(void * varg)
     slong Astoprow = arg->Astoprow;
     slong n = arg->n;
     slong k = arg->k;
-    slong m = arg->m;
     slong m_blk_sz = arg->m_blk_sz;
     slong k_blk_sz = arg->k_blk_sz;
     fmpz ** Crows = arg->Crows;
@@ -203,9 +202,9 @@ static void _mul_worker(void * varg)
     int words = arg->words;
     TMP_INIT;
 
-    /* no blocking overhead when things are small */
-    if (k <= k_blk_sz || Astoprow - Astartrow < 2*m_blk_sz)
+    if (k <= k_blk_sz)
     {
+        /* no blocking overhead: the B matrix is fully transposed in BL */
         if (words == 1)
         {
             for (h = Astartrow; h < Astoprow; h++)
@@ -235,7 +234,7 @@ static void _mul_worker(void * varg)
 
     for (h = Astartrow; h < Astoprow; h += m_blk_sz)
     {
-        slong hstop = FLINT_MIN(m - h, m_blk_sz);
+        slong hstop = FLINT_MIN(Astoprow - h, m_blk_sz);
 
         /* TC is a compressed block for the answer C[h:h+hhstop-1, all] */
         for (j = 0; j < n*hstop*words; j++)

--- a/fmpz_mat/profile/p-mul_small.c
+++ b/fmpz_mat/profile/p-mul_small.c
@@ -17,7 +17,10 @@
 
 int main(void)
 {
-    slong dim, i, reps, total, mint, maxt;
+    slong m, k, n;
+    slong dim, i, reps;
+    slong new_total, new_mint, new_maxt;
+    slong old_total, old_mint, old_maxt;
     double total_den, den;
     flint_bitcnt_t Abits, Bbits;
     timeit_t timer;
@@ -25,25 +28,97 @@ int main(void)
 
     flint_set_num_threads(1);
 
-    flint_printf("*** timings are nanoseconds per dim^3 ***\n");
+    flint_printf("(m, k, n) *** timings for mul_small nanoseconds per m*k*n (mul in parentheses) ***\n");
 
-    for (dim = 5; dim <= 2000; dim += 2 + dim/8)
+    for (m = 3; m < 10; m++)
+    for (k = 3; k < 10; k++)
+    for (n = 3; n < 10; n++)
     {
-        fmpz_mat_t A, B, C, D, E;
+        fmpz_mat_t A, B, C, D;
+
+        fmpz_mat_init(A, m, k);
+        fmpz_mat_init(B, k, n);
+        fmpz_mat_init(C, m, n);
+        fmpz_mat_init(D, m, n);
+
+        reps = 1 + 8000000/m/n/k;
+
+        den = reps*m*n*k;
+
+        total_den = 0;
+
+        new_total = 0;
+        new_mint = 10000000000;
+        new_maxt = 0;
+
+        old_total = 0;
+        old_mint = 10000000000;
+        old_maxt = 0;
+
+        for (Abits = 14; Abits <= FLINT_BITS - 2; Abits += 16)
+        for (Bbits = Abits; Bbits <= FLINT_BITS - 2; Bbits += 16)
+        {
+            fmpz_mat_randtest(A, state, Abits);
+            fmpz_mat_randtest(B, state, Bbits);
+
+            total_den += den;
+
+            timeit_start(timer);
+            for (i = reps; i > 0; i--)
+                fmpz_mat_mul_small(C, A, B);
+            timeit_stop(timer);
+
+            new_total += timer->wall;
+            new_mint = FLINT_MIN(new_mint, timer->wall);
+            new_maxt = FLINT_MAX(new_maxt, timer->wall);
+
+            timeit_start(timer);
+            for (i = reps; i > 0; i--)
+                fmpz_mat_mul(D, A, B);
+            timeit_stop(timer);
+
+            old_total += timer->wall;
+            old_mint = FLINT_MIN(old_mint, timer->wall);
+            old_maxt = FLINT_MAX(old_maxt, timer->wall);
+        }
+
+        flint_printf("(%2wd,%2wd,%2wd): min %.3f ns (%.3f)  max %.3f ns (%.3f)  aver %.3f ns (%.3f)  ratio %.3f\n",
+                     m, k, n,
+                     1000000*new_mint/den, 1000000*old_mint/den,
+                     1000000*new_maxt/den, 1000000*old_maxt/den,
+                     1000000*new_total/total_den, 1000000*old_total/total_den,
+                     (double)new_total/old_total);
+
+        fmpz_mat_clear(A);
+        fmpz_mat_clear(B);
+        fmpz_mat_clear(C);
+        fmpz_mat_clear(D);
+    }
+
+    flint_printf("*** timings for mul_small nanoseconds per dim^3 (mul in parentheses) ***\n");
+
+    for (dim = 5; dim <= 1100; dim += 2 + dim/4)
+    {
+        fmpz_mat_t A, B, C, D;
 
         fmpz_mat_init(A, dim, dim);
         fmpz_mat_init(B, dim, dim);
         fmpz_mat_init(C, dim, dim);
         fmpz_mat_init(D, dim, dim);
-        fmpz_mat_init(E, dim, dim);
 
         reps = 1 + 5000000/dim/dim/dim;
 
         den = reps*dim*dim*dim;
 
-        total = total_den = 0;
-        mint = 10000000000;
-        maxt = 0;
+        total_den = 0;
+
+        new_total = 0;
+        new_mint = 10000000000;
+        new_maxt = 0;
+
+        old_total = 0;
+        old_mint = 10000000000;
+        old_maxt = 0;
 
         for (Abits = 14; Abits <= FLINT_BITS - 2; Abits += 8)
         for (Bbits = Abits; Bbits <= FLINT_BITS - 2; Bbits += 8)
@@ -51,36 +126,44 @@ int main(void)
             fmpz_mat_randtest(A, state, Abits);
             fmpz_mat_randtest(B, state, Bbits);
 
+            total_den += den;
+
             timeit_start(timer);
             for (i = reps; i > 0; i--)
-                fmpz_mat_mul_small(E, A, B);
+                fmpz_mat_mul_small(C, A, B);
             timeit_stop(timer);
 
-            total += timer->wall;
-            total_den += ((double)reps)*dim*dim*dim;
-            mint = FLINT_MIN(mint, timer->wall);
-            maxt = FLINT_MAX(maxt, timer->wall);
+            new_total += timer->wall;
+            new_mint = FLINT_MIN(new_mint, timer->wall);
+            new_maxt = FLINT_MAX(new_maxt, timer->wall);
 
-            if (dim < 250)
+            timeit_start(timer);
+            for (i = reps; i > 0; i--)
+                fmpz_mat_mul(D, A, B);
+            timeit_stop(timer);
+
+            old_total += timer->wall;
+            old_mint = FLINT_MIN(old_mint, timer->wall);
+            old_maxt = FLINT_MAX(old_maxt, timer->wall);
+
+            if (!fmpz_mat_equal(C, D))
             {
-                fmpz_mat_mul_classical_inline(D, A, B);
-
-                if (!fmpz_mat_equal(D, E))
-                {
-                    flint_printf("oops %wu %wu\n", Abits, Bbits);
-                    flint_abort();
-                }
+                flint_printf("oops C != D %wu %wu\n", Abits, Bbits);
+                flint_abort();
             }
         }
 
-        flint_printf("dim %3wd: min %.3f ns  max %.3f ns  aver %.3f ns\n", dim,
-                     1000000*mint/den, 1000000*maxt/den, 1000000*total/total_den);
+        flint_printf("%4wd: min %.3f ns (%.3f)  max %.3f ns (%.3f)  aver %.3f ns (%.3f)  ratio %.3f\n",
+                     dim,
+                     1000000*new_mint/den, 1000000*old_mint/den,
+                     1000000*new_maxt/den, 1000000*old_maxt/den,
+                     1000000*new_total/total_den, 1000000*old_total/total_den,
+                     (double)new_total/old_total);
 
         fmpz_mat_clear(A);
         fmpz_mat_clear(B);
         fmpz_mat_clear(C);
         fmpz_mat_clear(D);
-        fmpz_mat_clear(E);
     }
 
     FLINT_TEST_CLEANUP(state);

--- a/fmpz_mat/profile/p-mul_small.c
+++ b/fmpz_mat/profile/p-mul_small.c
@@ -1,0 +1,88 @@
+/*
+    Copyright 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "flint.h"
+#include "fmpz_mat.h"
+#include "profiler.h"
+
+int main(void)
+{
+    slong dim, i, reps, total, mint, maxt;
+    double total_den, den;
+    flint_bitcnt_t Abits, Bbits;
+    timeit_t timer;
+    FLINT_TEST_INIT(state);
+
+    flint_set_num_threads(1);
+
+    flint_printf("*** timings are nanoseconds per dim^3 ***\n");
+
+    for (dim = 5; dim <= 2000; dim += 2 + dim/8)
+    {
+        fmpz_mat_t A, B, C, D, E;
+
+        fmpz_mat_init(A, dim, dim);
+        fmpz_mat_init(B, dim, dim);
+        fmpz_mat_init(C, dim, dim);
+        fmpz_mat_init(D, dim, dim);
+        fmpz_mat_init(E, dim, dim);
+
+        reps = 1 + 5000000/dim/dim/dim;
+
+        den = reps*dim*dim*dim;
+
+        total = total_den = 0;
+        mint = 10000000000;
+        maxt = 0;
+
+        for (Abits = 14; Abits <= FLINT_BITS - 2; Abits += 8)
+        for (Bbits = Abits; Bbits <= FLINT_BITS - 2; Bbits += 8)
+        {
+            fmpz_mat_randtest(A, state, Abits);
+            fmpz_mat_randtest(B, state, Bbits);
+
+            timeit_start(timer);
+            for (i = reps; i > 0; i--)
+                fmpz_mat_mul_small(E, A, B);
+            timeit_stop(timer);
+
+            total += timer->wall;
+            total_den += ((double)reps)*dim*dim*dim;
+            mint = FLINT_MIN(mint, timer->wall);
+            maxt = FLINT_MAX(maxt, timer->wall);
+
+            if (dim < 250)
+            {
+                fmpz_mat_mul_classical_inline(D, A, B);
+
+                if (!fmpz_mat_equal(D, E))
+                {
+                    flint_printf("oops %wu %wu\n", Abits, Bbits);
+                    flint_abort();
+                }
+            }
+        }
+
+        flint_printf("dim %3wd: min %.3f ns  max %.3f ns  aver %.3f ns\n", dim,
+                     1000000*mint/den, 1000000*maxt/den, 1000000*total/total_den);
+
+        fmpz_mat_clear(A);
+        fmpz_mat_clear(B);
+        fmpz_mat_clear(C);
+        fmpz_mat_clear(D);
+        fmpz_mat_clear(E);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+    return 0;
+}

--- a/fmpz_mat/test/t-mul_small.c
+++ b/fmpz_mat/test/t-mul_small.c
@@ -1,0 +1,71 @@
+/*
+    Copyright (C) 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <gmp.h>
+#include "flint.h"
+#include "fmpz.h"
+#include "fmpz_vec.h"
+#include "fmpz_mat.h"
+#include "ulong_extras.h"
+
+int main(void)
+{
+    fmpz_mat_t A, B, C, D;
+    slong i;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("mul_small....");
+    fflush(stdout);
+
+    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
+    {
+        slong m, k, n;
+
+        m = n_randint(state, 50);
+        n = n_randint(state, 50);
+        k = n_randint(state, 50);
+
+        fmpz_mat_init(A, m, k);
+        fmpz_mat_init(B, k, n);
+        fmpz_mat_init(C, m, n);
+        fmpz_mat_init(D, m, n);
+
+        fmpz_mat_randtest(A, state, n_randint(state, FLINT_BITS - 2) + 1);
+        fmpz_mat_randtest(B, state, n_randint(state, FLINT_BITS - 2) + 1);
+        fmpz_mat_randtest(C, state, n_randint(state, 200) + 1);
+        fmpz_mat_randtest(D, state, n_randint(state, 200) + 1);
+
+        fmpz_mat_mul_small(C, A, B);
+        fmpz_mat_mul_classical_inline(D, A, B);
+
+        if (!fmpz_mat_equal(C, D))
+        {
+            flint_printf("FAIL: results not equal\n\n");
+            fmpz_mat_print(A); flint_printf("\n\n");
+            fmpz_mat_print(B); flint_printf("\n\n");
+            fmpz_mat_print(C); flint_printf("\n\n");
+            fmpz_mat_print(D); flint_printf("\n\n");
+            flint_abort();
+        }
+
+        fmpz_mat_clear(A);
+        fmpz_mat_clear(B);
+        fmpz_mat_clear(C);
+        fmpz_mat_clear(D);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+
+    flint_printf("PASS\n");
+    return 0;
+}

--- a/fmpz_mat/test/t-mul_small.c
+++ b/fmpz_mat/test/t-mul_small.c
@@ -22,18 +22,28 @@ int main(void)
 {
     fmpz_mat_t A, B, C, D;
     slong i;
+    slong max_threads = 6;
     FLINT_TEST_INIT(state);
 
     flint_printf("mul_small....");
     fflush(stdout);
 
-    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * flint_test_multiplier(); i++)
     {
         slong m, k, n;
 
-        m = n_randint(state, 50);
-        n = n_randint(state, 50);
-        k = n_randint(state, 50);
+        if (flint_get_num_threads() >= max_threads - 1)
+        {
+            m = n_randint(state, 200);
+            n = n_randint(state, 200);
+            k = n_randint(state, 200);
+        }
+        else
+        {
+            m = n_randint(state, 50);
+            n = n_randint(state, 50);
+            k = n_randint(state, 50);
+        }
 
         fmpz_mat_init(A, m, k);
         fmpz_mat_init(B, k, n);
@@ -57,6 +67,8 @@ int main(void)
             fmpz_mat_print(D); flint_printf("\n\n");
             flint_abort();
         }
+
+        flint_set_num_threads(n_randint(state, max_threads) + 1);
 
         fmpz_mat_clear(A);
         fmpz_mat_clear(B);


### PR DESCRIPTION
This finishes my crusade against fmpz_mat_mul_strassen, and the fmpz_mat_mul can, in my view, be tuned now that the basecase algorithms are properly threaded.