### PR TITLE
Improve fmpz_poly_evaluate_horner_d_2exp2

### DIFF
--- a/doc/source/fmpz_poly.rst
+++ b/doc/source/fmpz_poly.rst
@@ -2224,14 +2224,13 @@ Evaluation
     Flint for quick and dirty evaluations of polynomials with all coefficients
     positive.
 
-.. function:: double _fmpz_poly_evaluate_horner_d_2exp2(slong * exp, const fmpz * poly, slong n, double d, slong dexp, ulong prec_in) 
+.. function:: double _fmpz_poly_evaluate_horner_d_2exp2(slong * exp, const fmpz * poly, slong n, double d, slong dexp)
 
     Evaluate ``poly`` at ``d*2^dexp``. Return the result as a double
     and an exponent ``exp`` combination. No attempt is made to do this
     efficiently or in a numerically stable way. It is currently only used in
     Flint for quick and dirty evaluations of polynomials with all coefficients
-    positive. If ``prec_in`` is not set to `0` the evaluation will be done to
-    the supplied precision only.
+    positive.
 
 
 Newton basis

--- a/fmpz_poly.h
+++ b/fmpz_poly.h
@@ -993,10 +993,10 @@ FLINT_DLL double fmpz_poly_evaluate_horner_d_2exp(slong * exp,
                                              const fmpz_poly_t poly, double d);
 
 FLINT_DLL double _fmpz_poly_evaluate_horner_d_2exp2(slong * exp, const fmpz * poly,
-                                      slong n, double d, slong dexp, ulong prec_in);
+                                      slong n, double d, slong dexp);
 
 FLINT_DLL double fmpz_poly_evaluate_horner_d_2exp2(slong * exp,
-		     const fmpz_poly_t poly, double d, slong dexp, ulong prec);
+		     const fmpz_poly_t poly, double d, slong dexp);
 
 /*  Composition  *************************************************************/
 

--- a/fmpz_poly/CLD_bound.c
+++ b/fmpz_poly/CLD_bound.c
@@ -127,8 +127,8 @@ void fmpz_poly_CLD_bound(fmpz_t res, const fmpz_poly_t f, slong n)
       {
          /* r is really 2^rpow * 2^rexp */
          double r = pow(2.0, rpow);
-         hi_eval = fmpz_poly_evaluate_horner_d_2exp2(&hi_exp, hi, r, rexp, 100);
-         lo_eval = fmpz_poly_evaluate_horner_d_2exp2(&lo_exp, lo, 1/r, -rexp, 100);
+         hi_eval = fmpz_poly_evaluate_horner_d_2exp2(&hi_exp, hi, r, rexp);
+         lo_eval = fmpz_poly_evaluate_horner_d_2exp2(&lo_exp, lo, 1/r, -rexp);
       }  /* if max exponent may overwhelm a double (with safety margin) */
       else if (max_exp > 950 || too_much) /* result of eval has large exponent */
       {

--- a/fmpz_poly/test/t-evaluate_horner_d_2exp.c
+++ b/fmpz_poly/test/t-evaluate_horner_d_2exp.c
@@ -1,0 +1,131 @@
+/*
+    Copyright (C) 2021 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <gmp.h>
+#include "flint.h"
+#include "fmpz.h"
+#include "fmpz_poly.h"
+#include "ulong_extras.h"
+
+int
+main(void)
+{
+    int i, result;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("evaluate_horner_d_2exp....");
+    fflush(stdout);
+
+    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
+    {
+        fmpz_poly_t f;
+        double x, y, z, t;
+        slong xexp, yexp, zexp;
+
+        x = d_randtest(state);
+        xexp = n_randint(state, 20) - 10;
+
+        fmpz_poly_init(f);
+        fmpz_poly_randtest(f, state, 1 + n_randint(state, 40), 1 + n_randint(state, 100));
+        fmpz_poly_scalar_abs(f, f);
+
+        y = fmpz_poly_evaluate_horner_d_2exp2(&yexp, f, x, xexp);
+        z = fmpz_poly_evaluate_horner_d(f, ldexp(x, xexp));
+        t = ldexp(y, yexp);
+
+        if (fabs(t - z) > 1e-13 * fabs(z))
+        {
+            flint_printf("FAIL:\n");
+            fmpz_poly_print(f), flint_printf("\n\n");
+            flint_printf("x, xexp = %.20g  %wd\n\n", x, xexp);
+            flint_printf("y, yexp = %.20g  %wd\n\n", y, yexp);
+            flint_printf("z = %.20g\n\n", z);
+            flint_printf("y = %.20g\n\n", t);
+            abort();
+        }
+
+        fmpz_poly_clear(f);
+    }
+
+    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
+    {
+        fmpz_poly_t f;
+        double x, y;
+        slong xexp, yexp, i;
+        mpfr_t z, s, t, u, v, w, e;
+
+        x = d_randtest(state);
+        xexp = n_randint(state, 2000) - 1000;
+
+        fmpz_poly_init(f);
+        fmpz_poly_randtest(f, state, 1 + n_randint(state, 100), 1 + n_randint(state, 1000));
+        fmpz_poly_scalar_abs(f, f);
+        mpfr_init2(z, 64);
+        mpfr_init2(s, 64);
+        mpfr_init2(t, 64);
+        mpfr_init2(u, 64);
+        mpfr_init2(v, 64);
+        mpfr_init2(w, 64);
+        mpfr_init2(e, 64);
+
+        y = fmpz_poly_evaluate_horner_d_2exp2(&yexp, f, x, xexp);
+
+        mpfr_set_d(z, x, MPFR_RNDN);
+        mpfr_mul_2si(z, z, xexp, MPFR_RNDN);
+        mpfr_set_ui(s, 0, MPFR_RNDN);
+        mpfr_set_ui(t, 1, MPFR_RNDN);
+
+        for (i = 0; i < f->length; i++)
+        {
+            fmpz_get_mpfr(u, f->coeffs + i, MPFR_RNDN);
+            mpfr_mul(u, u, t, MPFR_RNDN);
+            mpfr_add(s, s, u, MPFR_RNDN);
+            mpfr_mul(t, t, z, MPFR_RNDN);
+        }
+
+        mpfr_set_d(v, y, MPFR_RNDN);
+        mpfr_mul_2si(v, v, yexp, MPFR_RNDN);
+
+        mpfr_sub(e, s, v, MPFR_RNDN);
+        mpfr_abs(e, e, MPFR_RNDN);
+
+        mpfr_abs(w, s, MPFR_RNDN);
+        mpfr_mul_ui(w, w, f->length + 1, MPFR_RNDN);
+        mpfr_mul_2si(w, w, -51, MPFR_RNDN);
+
+        if (mpfr_cmp(e, w) > 0)
+        {
+            flint_printf("FAIL:\n");
+            fmpz_poly_print(f), flint_printf("\n\n");
+            mpfr_printf("%.17Rg\n", s);
+            mpfr_printf("%.17Rg\n", v);
+            mpfr_printf("%.17Rg\n", e);
+            mpfr_printf("%.17Rg\n\n", w);
+            abort();
+        }
+
+        mpfr_clear(z);
+        mpfr_clear(s);
+        mpfr_clear(t);
+        mpfr_clear(u);
+        mpfr_clear(v);
+        mpfr_clear(w);
+        mpfr_clear(e);
+        fmpz_poly_clear(f);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+    
+    flint_printf("PASS\n");
+    return 0;
+}


### PR DESCRIPTION
The CLD bound calculation often seems to be a bottleneck in fmpz_poly_factor. This patch improves the slow path (double+exponent) for the polynomial evaluation by using double+exponent arithmetic instead of mpf arithmetic internally. It also adds test code for the double+exponent polynomial evaluation, which was missing.

There are no doubt other improvements that can be done to the CLD bound calculation, but they will be more invasive.

This patch gives an immediate improvement on some qqbar benchmark problems in Calcium. Before:

    fredrik@agm:~/src/calcium$ build/examples/huge_expr
    Evaluating N...
    cpu/wall(s): 11.218 11.218
    Evaluating M...
    cpu/wall(s): 4.949 4.949
    Evaluating E = -(1-|M|^2)^2...
    cpu/wall(s): 0.584 0.584
    N ~ -0.16190853053311203695842869991458578203473645660641
    E ~ -0.16190853053311203695842869991458578203473645660641
    Testing E = N...
    cpu/wall(s): 0 0

    Equal = T_TRUE

    Total: cpu/wall(s): 16.751 16.751
    virt/peak/res/peak(MB): 55.91 63.24 26.27 33.74


With this patch:

    fredrik@agm:~/src/calcium$ build/examples/huge_expr
    Evaluating N...
    cpu/wall(s): 8.585 8.585
    Evaluating M...
    cpu/wall(s): 4.6 4.6
    Evaluating E = -(1-|M|^2)^2...
    cpu/wall(s): 0.587 0.588
    N ~ -0.16190853053311203695842869991458578203473645660641
    E ~ -0.16190853053311203695842869991458578203473645660641
    Testing E = N...
    cpu/wall(s): 0 0

    Equal = T_TRUE

    Total: cpu/wall(s): 13.772 13.773
    virt/peak/res/peak(MB): 55.91 63.24 26.34 33.81
