### PR TITLE
Don't use MPFR in fmpz_lll_is_reduced

### DIFF
--- a/doc/source/fmpz_poly.rst
+++ b/doc/source/fmpz_poly.rst
@@ -2224,14 +2224,13 @@ Evaluation
     Flint for quick and dirty evaluations of polynomials with all coefficients
     positive.
 
-.. function:: double _fmpz_poly_evaluate_horner_d_2exp2(slong * exp, const fmpz * poly, slong n, double d, slong dexp, ulong prec_in) 
+.. function:: double _fmpz_poly_evaluate_horner_d_2exp2(slong * exp, const fmpz * poly, slong n, double d, slong dexp)
 
     Evaluate ``poly`` at ``d*2^dexp``. Return the result as a double
     and an exponent ``exp`` combination. No attempt is made to do this
     efficiently or in a numerically stable way. It is currently only used in
     Flint for quick and dirty evaluations of polynomials with all coefficients
-    positive. If ``prec_in`` is not set to `0` the evaluation will be done to
-    the supplied precision only.
+    positive.
 
 
 Newton basis

--- a/fmpz_lll/is_reduced.c
+++ b/fmpz_lll/is_reduced.c
@@ -13,11 +13,16 @@
 
 #include "fmpz_lll.h"
 
+#define WANT_MPFR 0
+
 int
 fmpz_lll_is_reduced(const fmpz_mat_t B, const fmpz_lll_t fl, flint_bitcnt_t prec)
 {
     return ((fmpz_lll_is_reduced_d(B, fl)
-             || fmpz_lll_is_reduced_mpfr(B, fl, prec))
+#if WANT_MPFR
+             || fmpz_lll_is_reduced_mpfr(B, fl, prec)
+#endif
+            )
             || ((fl->rt == Z_BASIS) ?
                 fmpz_mat_is_reduced(B, fl->delta,
                                     fl->eta) : fmpz_mat_is_reduced_gram(B,

--- a/fmpz_lll/is_reduced.c
+++ b/fmpz_lll/is_reduced.c
@@ -13,15 +13,23 @@
 
 #include "fmpz_lll.h"
 
-#define WANT_MPFR 0
+static int
+want_mpfr(const fmpz_mat_t A)
+{
+    slong bits;
+
+    bits = fmpz_mat_max_bits(A);
+    bits = FLINT_ABS(bits);
+
+    /* highest double exponent is 1023, with some margin */
+    return bits > 1024 - 64;
+}
 
 int
 fmpz_lll_is_reduced(const fmpz_mat_t B, const fmpz_lll_t fl, flint_bitcnt_t prec)
 {
     return ((fmpz_lll_is_reduced_d(B, fl)
-#if WANT_MPFR
-             || fmpz_lll_is_reduced_mpfr(B, fl, prec)
-#endif
+             || (want_mpfr(B) && fmpz_lll_is_reduced_mpfr(B, fl, prec))
             )
             || ((fl->rt == Z_BASIS) ?
                 fmpz_mat_is_reduced(B, fl->delta,

--- a/fmpz_lll/is_reduced.c
+++ b/fmpz_lll/is_reduced.c
@@ -21,8 +21,9 @@ want_mpfr(const fmpz_mat_t A)
     bits = fmpz_mat_max_bits(A);
     bits = FLINT_ABS(bits);
 
-    /* highest double exponent is 1023, with some margin */
-    return bits > 1024 - 64;
+    /* highest double exponent is 1023; use mpfr when products in
+       is_reduced_d could possibly have overflowed */
+    return bits > 512 - 32;
 }
 
 int

--- a/fmpz_lll/is_reduced_with_removal.c
+++ b/fmpz_lll/is_reduced_with_removal.c
@@ -13,7 +13,21 @@
 
 #include "fmpz_lll.h"
 
-#define WANT_MPFR 0
+static int
+want_mpfr(const fmpz_mat_t A, const fmpz_t b)
+{
+    slong bits, bits2;
+
+    bits = fmpz_mat_max_bits(A);
+    bits = FLINT_ABS(bits);
+    bits2 = fmpz_bits(b);
+    bits = FLINT_MAX(bits, bits2);
+
+    printf("BOUNDARIES: %ld, %ld\n", bits, bits2);
+
+    /* highest double exponent is 1023, with some margin */
+    return bits > 1024 - 64;
+}
 
 int
 fmpz_lll_is_reduced_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
@@ -21,9 +35,7 @@ fmpz_lll_is_reduced_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
 {
     return (gs_B !=
             NULL) ? ((fmpz_lll_is_reduced_d_with_removal(B, fl, gs_B, newd)
-#if WANT_MPFR
-                      || fmpz_lll_is_reduced_mpfr_with_removal(B, fl, gs_B, newd, prec)
-#endif
+                      || (want_mpfr(B, gs_B) && fmpz_lll_is_reduced_mpfr_with_removal(B, fl, gs_B, newd, prec))
                     )
                      || ((fl->rt == Z_BASIS) ?
                          fmpz_mat_is_reduced_with_removal(B, fl->delta,

--- a/fmpz_lll/is_reduced_with_removal.c
+++ b/fmpz_lll/is_reduced_with_removal.c
@@ -13,14 +13,18 @@
 
 #include "fmpz_lll.h"
 
+#define WANT_MPFR 0
+
 int
 fmpz_lll_is_reduced_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
                                  const fmpz_t gs_B, int newd, flint_bitcnt_t prec)
 {
     return (gs_B !=
             NULL) ? ((fmpz_lll_is_reduced_d_with_removal(B, fl, gs_B, newd)
-                      || fmpz_lll_is_reduced_mpfr_with_removal(B, fl, gs_B,
-                                                               newd, prec))
+#if WANT_MPFR
+                      || fmpz_lll_is_reduced_mpfr_with_removal(B, fl, gs_B, newd, prec)
+#endif
+                    )
                      || ((fl->rt == Z_BASIS) ?
                          fmpz_mat_is_reduced_with_removal(B, fl->delta,
                                                           fl->eta, gs_B,

--- a/fmpz_lll/is_reduced_with_removal.c
+++ b/fmpz_lll/is_reduced_with_removal.c
@@ -23,10 +23,9 @@ want_mpfr(const fmpz_mat_t A, const fmpz_t b)
     bits2 = fmpz_bits(b);
     bits = FLINT_MAX(bits, bits2);
 
-    printf("BOUNDARIES: %ld, %ld\n", bits, bits2);
-
-    /* highest double exponent is 1023, with some margin */
-    return bits > 1024 - 64;
+    /* highest double exponent is 1023; use mpfr when products in
+       is_reduced_d could possibly have overflowed */
+    return bits > 512 - 32;
 }
 
 int

--- a/fmpz_poly.h
+++ b/fmpz_poly.h
@@ -993,10 +993,10 @@ FLINT_DLL double fmpz_poly_evaluate_horner_d_2exp(slong * exp,
                                              const fmpz_poly_t poly, double d);
 
 FLINT_DLL double _fmpz_poly_evaluate_horner_d_2exp2(slong * exp, const fmpz * poly,
-                                      slong n, double d, slong dexp, ulong prec_in);
+                                      slong n, double d, slong dexp);
 
 FLINT_DLL double fmpz_poly_evaluate_horner_d_2exp2(slong * exp,
-		     const fmpz_poly_t poly, double d, slong dexp, ulong prec);
+		     const fmpz_poly_t poly, double d, slong dexp);
 
 /*  Composition  *************************************************************/
 

--- a/fmpz_poly/CLD_bound.c
+++ b/fmpz_poly/CLD_bound.c
@@ -127,8 +127,8 @@ void fmpz_poly_CLD_bound(fmpz_t res, const fmpz_poly_t f, slong n)
       {
          /* r is really 2^rpow * 2^rexp */
          double r = pow(2.0, rpow);
-         hi_eval = fmpz_poly_evaluate_horner_d_2exp2(&hi_exp, hi, r, rexp, 100);
-         lo_eval = fmpz_poly_evaluate_horner_d_2exp2(&lo_exp, lo, 1/r, -rexp, 100);
+         hi_eval = fmpz_poly_evaluate_horner_d_2exp2(&hi_exp, hi, r, rexp);
+         lo_eval = fmpz_poly_evaluate_horner_d_2exp2(&lo_exp, lo, 1/r, -rexp);
       }  /* if max exponent may overwhelm a double (with safety margin) */
       else if (max_exp > 950 || too_much) /* result of eval has large exponent */
       {

--- a/fmpz_poly/test/t-evaluate_horner_d_2exp.c
+++ b/fmpz_poly/test/t-evaluate_horner_d_2exp.c
@@ -1,0 +1,131 @@
+/*
+    Copyright (C) 2021 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <gmp.h>
+#include "flint.h"
+#include "fmpz.h"
+#include "fmpz_poly.h"
+#include "ulong_extras.h"
+
+int
+main(void)
+{
+    int i, result;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("evaluate_horner_d_2exp....");
+    fflush(stdout);
+
+    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
+    {
+        fmpz_poly_t f;
+        double x, y, z, t;
+        slong xexp, yexp, zexp;
+
+        x = d_randtest(state);
+        xexp = n_randint(state, 20) - 10;
+
+        fmpz_poly_init(f);
+        fmpz_poly_randtest(f, state, 1 + n_randint(state, 40), 1 + n_randint(state, 100));
+        fmpz_poly_scalar_abs(f, f);
+
+        y = fmpz_poly_evaluate_horner_d_2exp2(&yexp, f, x, xexp);
+        z = fmpz_poly_evaluate_horner_d(f, ldexp(x, xexp));
+        t = ldexp(y, yexp);
+
+        if (fabs(t - z) > 1e-13 * fabs(z))
+        {
+            flint_printf("FAIL:\n");
+            fmpz_poly_print(f), flint_printf("\n\n");
+            flint_printf("x, xexp = %.20g  %wd\n\n", x, xexp);
+            flint_printf("y, yexp = %.20g  %wd\n\n", y, yexp);
+            flint_printf("z = %.20g\n\n", z);
+            flint_printf("y = %.20g\n\n", t);
+            abort();
+        }
+
+        fmpz_poly_clear(f);
+    }
+
+    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
+    {
+        fmpz_poly_t f;
+        double x, y;
+        slong xexp, yexp, i;
+        mpfr_t z, s, t, u, v, w, e;
+
+        x = d_randtest(state);
+        xexp = n_randint(state, 2000) - 1000;
+
+        fmpz_poly_init(f);
+        fmpz_poly_randtest(f, state, 1 + n_randint(state, 100), 1 + n_randint(state, 1000));
+        fmpz_poly_scalar_abs(f, f);
+        mpfr_init2(z, 64);
+        mpfr_init2(s, 64);
+        mpfr_init2(t, 64);
+        mpfr_init2(u, 64);
+        mpfr_init2(v, 64);
+        mpfr_init2(w, 64);
+        mpfr_init2(e, 64);
+
+        y = fmpz_poly_evaluate_horner_d_2exp2(&yexp, f, x, xexp);
+
+        mpfr_set_d(z, x, MPFR_RNDN);
+        mpfr_mul_2si(z, z, xexp, MPFR_RNDN);
+        mpfr_set_ui(s, 0, MPFR_RNDN);
+        mpfr_set_ui(t, 1, MPFR_RNDN);
+
+        for (i = 0; i < f->length; i++)
+        {
+            fmpz_get_mpfr(u, f->coeffs + i, MPFR_RNDN);
+            mpfr_mul(u, u, t, MPFR_RNDN);
+            mpfr_add(s, s, u, MPFR_RNDN);
+            mpfr_mul(t, t, z, MPFR_RNDN);
+        }
+
+        mpfr_set_d(v, y, MPFR_RNDN);
+        mpfr_mul_2si(v, v, yexp, MPFR_RNDN);
+
+        mpfr_sub(e, s, v, MPFR_RNDN);
+        mpfr_abs(e, e, MPFR_RNDN);
+
+        mpfr_abs(w, s, MPFR_RNDN);
+        mpfr_mul_ui(w, w, f->length + 1, MPFR_RNDN);
+        mpfr_mul_2si(w, w, -51, MPFR_RNDN);
+
+        if (mpfr_cmp(e, w) > 0)
+        {
+            flint_printf("FAIL:\n");
+            fmpz_poly_print(f), flint_printf("\n\n");
+            mpfr_printf("%.17Rg\n", s);
+            mpfr_printf("%.17Rg\n", v);
+            mpfr_printf("%.17Rg\n", e);
+            mpfr_printf("%.17Rg\n\n", w);
+            abort();
+        }
+
+        mpfr_clear(z);
+        mpfr_clear(s);
+        mpfr_clear(t);
+        mpfr_clear(u);
+        mpfr_clear(v);
+        mpfr_clear(w);
+        mpfr_clear(e);
+        fmpz_poly_clear(f);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+    
+    flint_printf("PASS\n");
+    return 0;
+}


### PR DESCRIPTION
 fmpz_lll_is_reduced and fmpz_lll_is_reduced_with_removal try calling three consecutive algorithms to check if the matrix is LLL-reduced: using doubles,  MPFRs, and fmpqs. This patch disables the MPFR algorithm, which is slow and rarely seems to help.

I wasn't sure how to test LLL to make sure there are no regressions, so I decided to test everything: I modified Flint to dump all matrices encountered as input to LLL to a file, and then ran the Flint LLL and factoring tests and profiling programs as well as the Calcium test suite and example programs. This resulted in dump of 48721 unique test matrices. Result of this patch:

The time to LLL reduce all small matrices (n < 100 rows, >48000 matrices) is 33 seconds with MPFR and 25 without MPFR.

The time to LLL reduce large matrices (n >= 100 rows, <100 matrices) is unchanged except for a handful of instances where disabling MPFR is significantly faster (the largest instances drop from ~200 seconds to ~100 seconds).

There are no instances in this test suite where disabling MPFR is significantly slower.

I'm sure there are matrices where we need the MPFR code or something equivalent, but I would rather turn the code back on selectively when we find evidence of such instances in the wild.
