### PR TITLE
[WIP] Swap entrywise

### DIFF
--- a/d_mat.h
+++ b/d_mat.h
@@ -58,11 +58,36 @@ double d_mat_get_entry(const d_mat_t mat, slong i, slong j)
    return mat->rows[i][j];
 }
 
+D_MAT_INLINE
+slong d_mat_nrows(const d_mat_t mat)
+{
+    return mat->r;
+}
+
+D_MAT_INLINE
+slong d_mat_ncols(const d_mat_t mat)
+{
+    return mat->c;
+}
+
 /* Memory management  ********************************************************/
 
 FLINT_DLL void d_mat_init(d_mat_t mat, slong rows, slong cols);
 
 FLINT_DLL void d_mat_swap(d_mat_t mat1, d_mat_t mat2);
+
+D_MAT_INLINE void
+d_mat_swap_entrywise(d_mat_t mat1, d_mat_t mat2)
+{
+    slong i, j;
+    for (i = 0; i < d_mat_nrows(mat1); i++)
+    {
+       double * row1 = mat1->rows[i];
+       double * row2 = mat2->rows[i];
+       for (j = 0; j < d_mat_ncols(mat1); j++)
+          DOUBLE_SWAP(row1[j], row2[j]);
+    }
+}
 
 FLINT_DLL void d_mat_set(d_mat_t mat1, const d_mat_t mat2);
 

--- a/d_mat/clear.c
+++ b/d_mat/clear.c
@@ -19,5 +19,6 @@ d_mat_clear(d_mat_t mat)
     {
         flint_free(mat->entries);   /* Clean up array of entries */
         flint_free(mat->rows);  /* Clean up row array */
-    }
+    } else if (mat->r != 0)
+	flint_free(mat->rows);
 }

--- a/d_mat/gso.c
+++ b/d_mat/gso.c
@@ -29,7 +29,7 @@ d_mat_gso(d_mat_t B, const d_mat_t A)
         d_mat_t t;
         d_mat_init(t, A->r, A->c);
         d_mat_gso(t, A);
-        d_mat_swap(B, t);
+        d_mat_swap_entrywise(B, t);
         d_mat_clear(t);
         return;
     }

--- a/d_mat/init.c
+++ b/d_mat/init.c
@@ -15,19 +15,25 @@
 void
 d_mat_init(d_mat_t mat, slong rows, slong cols)
 {
+    slong i;
+    
+    if (rows != 0)
+        mat->rows = (double **) flint_malloc(rows * sizeof(double *));
+    else
+        mat->rows = NULL;
+
     if (rows != 0 && cols != 0)       /* Allocate space for r*c small entries */
     {
-        slong i;
         mat->entries = (double *) flint_calloc(flint_mul_sizes(rows, cols), sizeof(double));
-        mat->rows = (double **) flint_malloc(rows*sizeof(double *));  /* Initialise rows */
 
         for (i = 0; i < rows; i++)
             mat->rows[i] = mat->entries + i * cols;
     }
     else
     {
-       mat->entries = NULL;
-       mat->rows = NULL;
+        mat->entries = NULL;
+        for (i = 0; i < rows; i++)
+            mat->rows[i] = NULL;
     }
 
     mat->r = rows;

--- a/d_mat/mul_classical.c
+++ b/d_mat/mul_classical.c
@@ -30,7 +30,7 @@ d_mat_mul_classical(d_mat_t C, const d_mat_t A, const d_mat_t B)
         d_mat_t t;
         d_mat_init(t, ar, bc);
         d_mat_mul_classical(t, A, B);
-        d_mat_swap(C, t);
+        d_mat_swap_entrywise(C, t);
         d_mat_clear(t);
         return;
     }

--- a/d_mat/qr.c
+++ b/d_mat/qr.c
@@ -29,7 +29,7 @@ d_mat_qr(d_mat_t Q, d_mat_t R, const d_mat_t A)
         d_mat_t t;
         d_mat_init(t, A->r, A->c);
         d_mat_qr(t, R, A);
-        d_mat_swap(Q, t);
+        d_mat_swap_entrywise(Q, t);
         d_mat_clear(t);
         return;
     }

--- a/d_mat/test/t-mul_classical.c
+++ b/d_mat/test/t-mul_classical.c
@@ -26,7 +26,7 @@ main(void)
     slong i;
     FLINT_TEST_INIT(state);
 
-    flint_printf("mul....");
+    flint_printf("mul_classical....");
     fflush(stdout);
 
     /* check associative law */
@@ -64,12 +64,15 @@ main(void)
             abort();
         }
 
-        d_mat_mul_classical(A, A, B);
-
-        if (!d_mat_equal(A, E))
+        if (n == k)
         {
-            flint_printf("FAIL: aliasing failed\n");
-            abort();
+            d_mat_mul_classical(A, A, B);
+
+            if (!d_mat_equal(A, E))
+            {
+                flint_printf("FAIL: aliasing failed\n");
+                abort();
+            }
         }
 
         d_mat_clear(A);

--- a/d_mat/transpose.c
+++ b/d_mat/transpose.c
@@ -30,7 +30,7 @@ d_mat_transpose(d_mat_t B, const d_mat_t A)
         d_mat_t t;
         d_mat_init(t, A->r, A->c);
         d_mat_transpose(t, A);
-        d_mat_swap(B, t);
+        d_mat_swap_entrywise(B, t);
         d_mat_clear(t);
         return;
     }

--- a/doc/source/d_mat.rst
+++ b/doc/source/d_mat.rst
@@ -32,6 +32,11 @@ Basic assignment and manipulation
     Swaps two matrices. The dimensions of ``mat1`` and ``mat2`` 
     are allowed to be different.
 
+.. function:: void d_mat_swap_entrywise(d_mat_t mat1, d_mat_t mat2)
+
+    Swaps two matrices by swapping the individual entries rather than swapping
+    the contents of the structs.
+
 .. function:: double d_mat_entry(d_mat_t mat, slong i, slong j)
 
     Returns the entry of ``mat`` at row `i` and column `j`.

--- a/doc/source/fmpq_mat.rst
+++ b/doc/source/fmpq_mat.rst
@@ -37,6 +37,11 @@ Memory management
     Swaps two matrices. The dimensions of ``mat1`` and ``mat2``
     are allowed to be different.
 
+.. function:: void fmpq_mat_swap_entrywise(fmpq_mat_t mat1, fmpq_mat_t mat2)
+
+    Swaps two matrices by swapping the individual entries rather than swapping
+    the contents of the structs.
+
 
 Entry access
 --------------------------------------------------------------------------------

--- a/doc/source/fmpz_mat.rst
+++ b/doc/source/fmpz_mat.rst
@@ -47,6 +47,11 @@ Basic assignment and manipulation
     Swaps two matrices. The dimensions of ``mat1`` and ``mat2`` 
     are allowed to be different.
 
+.. function:: void fmpz_mat_swap_entrywise(fmpz_mat_t mat1, fmpz_mat_t mat2)
+
+    Swaps two matrices by swapping the individual entries rather than swapping
+    the contents of the structs.
+
 .. function:: fmpz * fmpz_mat_entry(fmpz_mat_t mat, slong i, slong j)
 
     Returns a reference to the entry of ``mat`` at row `i` and column `j`.

--- a/doc/source/fmpz_mod_mat.rst
+++ b/doc/source/fmpz_mod_mat.rst
@@ -79,6 +79,11 @@ Basic manipulation                                                              
 
     Efficiently swap the matrices ``mat1`` and ``mat2``.
 
+.. function:: void fmpz_mod_mat_swap_entrywise(fmpz_mod_mat_t mat1, fmpz_mod_mat_t mat2)
+
+    Swaps two matrices by swapping the individual entries rather than swapping
+    the contents of the structs.
+
 .. function:: int fmpz_mod_mat_is_empty(const fmpz_mod_mat_t mat)
 
     Return `1` if ``mat`` has either zero rows or columns.

--- a/doc/source/fmpz_poly_mat.rst
+++ b/doc/source/fmpz_poly_mat.rst
@@ -66,6 +66,10 @@ Basic assignment and manipulation
 
     Swaps ``mat1`` and ``mat2`` efficiently.
 
+.. function:: void fmpz_poly_mat_swap_entrywise(fmpz_poly_mat_t mat1, fmpz_poly_mat_t mat2)
+
+    Swaps two matrices by swapping the individual entries rather than swapping
+    the contents of the structs.
 
 
 Input and output

--- a/doc/source/fq_mat.rst
+++ b/doc/source/fq_mat.rst
@@ -76,6 +76,10 @@ Basic properties and manipulation
 
     Sets all entries of ``mat`` to 0.
 
+.. function:: void fq_mat_one(fq_mat_t mat, const fq_ctx_t ctx)
+
+    Sets all the diagonal entries of ``mat`` to 1 and all other entries to 0.
+
 .. function:: void fq_mat_swap_rows(fq_mat_t mat, slong * perm, slong r, slong s)
     
     Swaps rows ``r`` and ``s`` of ``mat``.  If ``perm`` is non-``NULL``, the
@@ -227,6 +231,11 @@ Comparison
 
     Returns a non-zero value if all entries ``mat`` are zero, and
     otherwise returns zero.
+
+.. function:: int fq_mat_is_one(const fq_mat_t mat, const fq_ctx_t ctx)
+
+    Returns a non-zero value if all entries ``mat`` are zero except the
+    diagonal entries which must be one, otherwise returns zero..
 
 .. function:: int fq_mat_is_empty(const fq_mat_t mat, const fq_ctx_t ctx)
 

--- a/doc/source/fq_mat.rst
+++ b/doc/source/fq_mat.rst
@@ -67,6 +67,11 @@ Basic properties and manipulation
     Swaps two matrices. The dimensions of ``mat1`` and ``mat2``
     are allowed to be different.
 
+.. function:: void fq_mat_swap_entrywise(fq_mat_t mat1, fq_mat_t mat2)
+
+    Swaps two matrices by swapping the individual entries rather than swapping
+    the contents of the structs.
+
 .. function:: void fq_mat_zero(fq_mat_t mat, const fq_ctx_t ctx)
 
     Sets all entries of ``mat`` to 0.

--- a/doc/source/fq_nmod_mat.rst
+++ b/doc/source/fq_nmod_mat.rst
@@ -67,6 +67,11 @@ Basic properties and manipulation
     Swaps two matrices. The dimensions of ``mat1`` and ``mat2``
     are allowed to be different.
 
+.. function:: void fq_nmod_mat_swap_entrywise(fq_nmod_mat_t mat1, fq_nmod_mat_t mat2)
+
+    Swaps two matrices by swapping the individual entries rather than swapping
+    the contents of the structs.
+
 .. function:: void fq_nmod_mat_zero(fq_nmod_mat_t mat, const fq_nmod_ctx_t ctx)
 
     Sets all entries of ``mat`` to 0.

--- a/doc/source/fq_nmod_mat.rst
+++ b/doc/source/fq_nmod_mat.rst
@@ -76,6 +76,10 @@ Basic properties and manipulation
 
     Sets all entries of ``mat`` to 0.
 
+.. function:: void fq_nmod_mat_one(fq_nmod_mat_t mat, const fq_nmod_ctx_t ctx)
+
+    Sets all the diagonal entries of ``mat`` to 1 and all other entries to 0.
+
 .. function:: void fq_nmod_mat_swap_rows(fq_nmod_mat_t mat, slong * perm, slong r, slong s)
     
     Swaps rows ``r`` and ``s`` of ``mat``.  If ``perm`` is non-``NULL``, the
@@ -228,6 +232,11 @@ Comparison
 
     Returns a non-zero value if all entries ``mat`` are zero, and
     otherwise returns zero.
+
+.. function:: int fq_nmod_mat_is_one(const fq_nmod_mat_t mat, const fq_nmod_ctx_t ctx)
+
+    Returns a non-zero value if all entries ``mat`` are zero except the
+    diagonal entries which must be one, otherwise returns zero.
 
 .. function:: int fq_nmod_mat_is_empty(const fq_nmod_mat_t mat, const fq_nmod_ctx_t ctx)
 

--- a/doc/source/fq_zech_mat.rst
+++ b/doc/source/fq_zech_mat.rst
@@ -77,6 +77,10 @@ Basic properties and manipulation
 
     Sets all entries of ``mat`` to 0.
 
+.. function:: void fq_zech_mat_one(fq_zech_mat_t mat, const fq_zech_ctx_t ctx)
+
+    Sets all the diagonal entries of ``mat`` to 1 and all other entries to 0.
+
 
 Concatenate
 --------------------------------------------------------------------------------
@@ -206,6 +210,11 @@ Comparison
 
     Returns a non-zero value if all entries ``mat`` are zero, and
     otherwise returns zero.
+
+.. function:: int fq_zech_mat_is_one(const fq_zech_mat_t mat, const fq_zech_ctx_t ctx)
+
+    Returns a non-zero value if all entries ``mat`` are zero except the
+    diagonal entries which must be one, otherwise returns zero.
 
 .. function:: int fq_zech_mat_is_empty(const fq_zech_mat_t mat, const fq_zech_ctx_t ctx)
 

--- a/doc/source/fq_zech_mat.rst
+++ b/doc/source/fq_zech_mat.rst
@@ -68,6 +68,11 @@ Basic properties and manipulation
     Swaps two matrices. The dimensions of ``mat1`` and ``mat2``
     are allowed to be different.
 
+.. function:: void fq_zech_mat_swap_entrywise(fq_zech_mat_t mat1, fq_zech_mat_t mat2)
+
+    Swaps two matrices by swapping the individual entries rather than swapping
+    the contents of the structs.
+
 .. function:: void fq_zech_mat_zero(fq_zech_mat_t mat, const fq_zech_ctx_t ctx)
 
     Sets all entries of ``mat`` to 0.

--- a/doc/source/mpf_mat.rst
+++ b/doc/source/mpf_mat.rst
@@ -34,6 +34,11 @@ Basic assignment and manipulation
     Swaps two matrices. The dimensions of ``mat1`` and ``mat2`` 
     are allowed to be different.
 
+.. function:: void mpf_mat_swap_entrywise(mpf_mat_t mat1, mpf_mat_t mat2)
+
+    Swaps two matrices by swapping the individual entries rather than swapping
+    the contents of the structs.
+
 .. function:: mpf * mpf_mat_entry(const mpf_mat_t * mat, slong i, slong j)
 
     Returns a reference to the entry of ``mat`` at row `i` and column `j`.

--- a/doc/source/mpfr_mat.rst
+++ b/doc/source/mpfr_mat.rst
@@ -34,6 +34,11 @@ Basic manipulation
 
     Efficiently swap matrices ``mat1`` and ``mat2``.
 
+.. function:: void mpfr_mat_swap_entrywise(mpfr_mat_t mat1, mpfr_mat_t mat2)
+
+    Swaps two matrices by swapping the individual entries rather than swapping
+    the contents of the structs.
+
 .. function:: void mpfr_mat_set(mpfr_mat_t mat1, const mpfr_mat_t mat2)
 
     Set ``mat1`` to the value of ``mat2``.

--- a/doc/source/nmod_mat.rst
+++ b/doc/source/nmod_mat.rst
@@ -44,6 +44,11 @@ Memory management
 
     Exchanges ``mat1`` and ``mat2``.
 
+.. function:: void nmod_mat_swap_entrywise(nmod_mat_t mat1, nmod_mat_t mat2)
+
+    Swaps two matrices by swapping the individual entries rather than swapping
+    the contents of the structs.
+
 
 Basic properties and manipulation
 --------------------------------------------------------------------------------

--- a/doc/source/nmod_poly_mat.rst
+++ b/doc/source/nmod_poly_mat.rst
@@ -71,6 +71,10 @@ Basic assignment and manipulation
 
     Swaps ``mat1`` and ``mat2`` efficiently.
 
+.. function:: void nmod_poly_mat_swap_entrywise(nmod_poly_mat_t mat1, nmod_poly_mat_t mat2)
+
+    Swaps two matrices by swapping the individual entries rather than swapping
+    the contents of the structs.
 
 
 Input and output

--- a/doc/source/padic_mat.rst
+++ b/doc/source/padic_mat.rst
@@ -129,6 +129,11 @@ Basic assignment
     Swaps the two matrices `A` and `B`.  This is done efficiently by 
     swapping pointers.
 
+.. function:: void padic_mat_swap_entrywise(padic_mat_t mat1, padic_mat_t mat2)
+
+    Swaps two matrices by swapping the individual entries rather than swapping
+    the contents of the structs.
+
 .. function:: void padic_mat_zero(padic_mat_t A)
 
     Sets the matrix `A` to zero.

--- a/flint.h
+++ b/flint.h
@@ -322,6 +322,13 @@ typedef __mpfr_struct flint_mpfr;
         B = __t_m_p_;           \
     } while (0)
 
+#define DOUBLE_SWAP(A, B)    \
+    do {                     \
+        double __t_m_p_ = A; \
+        A = B;               \
+        B = __t_m_p_;        \
+    } while (0)
+
 #define r_shift(in, shift) \
     ((shift == FLINT_BITS) ? WORD(0) : ((in) >> (shift)))
 

--- a/fmpq_mat.h
+++ b/fmpq_mat.h
@@ -77,6 +77,16 @@ FLINT_DLL void fmpq_mat_clear(fmpq_mat_t mat);
 
 FLINT_DLL void fmpq_mat_swap(fmpq_mat_t mat1, fmpq_mat_t mat2);
 
+FMPQ_MAT_INLINE void
+fmpq_mat_swap_entrywise(fmpq_mat_t mat1, fmpq_mat_t mat2)
+{
+    slong i, j;
+
+    for (i = 0; i < fmpq_mat_nrows(mat1); i++)
+        for (j = 0; j < fmpq_mat_ncols(mat1); j++)
+            fmpq_swap(fmpq_mat_entry(mat2, i, j), fmpq_mat_entry(mat1, i, j));
+}
+
 /* Windows and concatenation */
 
 FLINT_DLL void fmpq_mat_window_init(fmpq_mat_t window, const fmpq_mat_t mat, slong r1,

--- a/fmpq_mat/gso.c
+++ b/fmpq_mat/gso.c
@@ -28,7 +28,7 @@ fmpq_mat_gso(fmpq_mat_t B, const fmpq_mat_t A)
         fmpq_mat_t t;
         fmpq_mat_init(t, B->r, B->c);
         fmpq_mat_gso(t, A);
-        fmpq_mat_swap(B, t);
+        fmpq_mat_swap_entrywise(B, t);
         fmpq_mat_clear(t);
         return;
     }

--- a/fmpq_mat/test/t-mul.c
+++ b/fmpq_mat/test/t-mul.c
@@ -71,6 +71,35 @@ main(void)
         fmpq_mat_clear(D);
     }
 
+    /* Test aliasing with windows */
+    {
+        fmpq_mat_t A, B, A_window;
+
+        fmpq_mat_init(A, 2, 2);
+        fmpq_mat_init(B, 2, 2);
+
+        fmpq_mat_window_init(A_window, A, 0, 0, 2, 2);
+
+        fmpq_mat_one(A);
+        fmpq_mat_one(B);
+        fmpq_set_ui(fmpq_mat_entry(B, 0, 1), 1, 1);
+        fmpq_set_ui(fmpq_mat_entry(B, 1, 0), 1, 1);
+
+        fmpq_mat_mul(A_window, B, A_window);
+
+        if (!fmpq_mat_equal(A, B))
+        {
+            flint_printf("FAIL: window aliasing failed\n");
+            fmpq_mat_print(A); flint_printf("\n\n");
+            fmpq_mat_print(B); flint_printf("\n\n");
+            flint_abort();
+        }
+
+        fmpq_mat_window_clear(A_window);
+        fmpq_mat_clear(A);
+        fmpq_mat_clear(B);
+    }
+
     FLINT_TEST_CLEANUP(state);
     
     flint_printf("PASS\n");

--- a/fmpz_mat.h
+++ b/fmpz_mat.h
@@ -78,7 +78,19 @@ slong fmpz_mat_ncols(const fmpz_mat_t mat)
 
 FLINT_DLL void fmpz_mat_init(fmpz_mat_t mat, slong rows, slong cols);
 FLINT_DLL void fmpz_mat_init_set(fmpz_mat_t mat, const fmpz_mat_t src);
+
 FLINT_DLL void fmpz_mat_swap(fmpz_mat_t mat1, fmpz_mat_t mat2);
+
+FMPZ_MAT_INLINE void
+fmpz_mat_swap_entrywise(fmpz_mat_t mat1, fmpz_mat_t mat2)
+{
+    slong i, j;
+
+    for (i = 0; i < fmpz_mat_nrows(mat1); i++)
+        for (j = 0; j < fmpz_mat_ncols(mat1); j++)
+            fmpz_swap(fmpz_mat_entry(mat2, i, j), fmpz_mat_entry(mat1, i, j));
+}
+
 FLINT_DLL void fmpz_mat_set(fmpz_mat_t mat1, const fmpz_mat_t mat2);
 FLINT_DLL void fmpz_mat_clear(fmpz_mat_t mat);
 

--- a/fmpz_mat/gram.c
+++ b/fmpz_mat/gram.c
@@ -24,7 +24,7 @@ void fmpz_mat_gram(fmpz_mat_t B, const fmpz_mat_t A)
 		fmpz_mat_t t;
 		fmpz_mat_init(t, B->r, B->c);
 		fmpz_mat_gram(t, A);
-		fmpz_mat_swap(B, t);
+		fmpz_mat_swap_entrywise(B, t);
 		fmpz_mat_clear(t);
 		return;
 	}

--- a/fmpz_mat/mul.c
+++ b/fmpz_mat/mul.c
@@ -124,7 +124,7 @@ fmpz_mat_mul(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B)
         fmpz_mat_t T;
         fmpz_mat_init(T, ar, bc);
         fmpz_mat_mul(T, A, B);
-        fmpz_mat_swap(C, T);
+        fmpz_mat_swap_entrywise(C, T);
         fmpz_mat_clear(T);
         return;
     }

--- a/fmpz_mat/solve_cramer.c
+++ b/fmpz_mat/solve_cramer.c
@@ -144,7 +144,7 @@ fmpz_mat_solve_cramer(fmpz_mat_t X, fmpz_t den,
             fmpz_mat_t T;
             fmpz_mat_init(T, 3, 3);
             success = _fmpz_mat_solve_cramer_3x3(T, den, A, B);
-            fmpz_mat_swap(T, X);
+            fmpz_mat_swap_entrywise(T, X);
             fmpz_mat_clear(T);
             return success;
         }

--- a/fmpz_mat/sqr.c
+++ b/fmpz_mat/sqr.c
@@ -24,7 +24,7 @@ fmpz_mat_sqr(fmpz_mat_t B, const fmpz_mat_t A)
         fmpz_mat_t t;
         fmpz_mat_init(t, n, n);
         fmpz_mat_sqr(t, A);
-        fmpz_mat_swap(B, t);
+        fmpz_mat_swap_entrywise(B, t);
         fmpz_mat_clear(t);
         return;
     }

--- a/fmpz_mat/test/t-mul.c
+++ b/fmpz_mat/test/t-mul.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2010 Fredrik Johansson
+    Copyright (C) 2021 William Hart
 
     This file is part of FLINT.
 
@@ -150,6 +151,35 @@ int main(void)
         fmpz_mat_clear(B);
         fmpz_mat_clear(C);
         fmpz_mat_clear(D);
+    }
+
+    /* Test aliasing with windows */
+    {
+        fmpz_mat_t A, B, A_window;
+
+        fmpz_mat_init(A, 2, 2);
+        fmpz_mat_init(B, 2, 2);
+
+        fmpz_mat_window_init(A_window, A, 0, 0, 2, 2);
+
+        fmpz_mat_one(A);
+        fmpz_mat_one(B);
+        fmpz_set_ui(fmpz_mat_entry(B, 0, 1), 1);
+        fmpz_set_ui(fmpz_mat_entry(B, 1, 0), 1);
+
+        fmpz_mat_mul(A_window, B, A_window);
+
+        if (!fmpz_mat_equal(A, B))
+        {
+            flint_printf("FAIL: window aliasing failed\n");
+	    fmpz_mat_print(A); flint_printf("\n\n");
+	    fmpz_mat_print(B); flint_printf("\n\n");
+            flint_abort();
+        }
+
+        fmpz_mat_window_clear(A_window);
+        fmpz_mat_clear(A);
+        fmpz_mat_clear(B);
     }
 
     FLINT_TEST_CLEANUP(state);

--- a/fmpz_mod_mat.h
+++ b/fmpz_mod_mat.h
@@ -61,7 +61,8 @@ FLINT_DLL void fmpz_mod_mat_clear(fmpz_mod_mat_t mat);
 
 /* Basic manipulation  ********************************************************/
 
-FMPZ_MOD_MAT_INLINE                                                                      slong fmpz_mod_mat_nrows(const fmpz_mod_mat_t mat)
+FMPZ_MOD_MAT_INLINE
+slong fmpz_mod_mat_nrows(const fmpz_mod_mat_t mat)
 {
     return fmpz_mat_nrows(mat->mat);
 }
@@ -113,6 +114,16 @@ void fmpz_mod_mat_swap(fmpz_mod_mat_t mat1, fmpz_mod_mat_t mat2)
         *mat1 = *mat2;
         *mat2 = tmp;
     }
+}
+
+FMPZ_MOD_MAT_INLINE void
+fmpz_mod_mat_swap_entrywise(fmpz_mod_mat_t mat1, fmpz_mod_mat_t mat2)
+{
+    slong i, j;
+
+    for (i = 0; i < fmpz_mod_mat_nrows(mat1); i++)
+        for (j = 0; j < fmpz_mod_mat_ncols(mat1); j++)
+            fmpz_swap(fmpz_mod_mat_entry(mat2, i, j), fmpz_mod_mat_entry(mat1, i, j));
 }
 
 FMPZ_MOD_MAT_INLINE

--- a/fmpz_mod_mat/test/t-mul.c
+++ b/fmpz_mod_mat/test/t-mul.c
@@ -108,6 +108,39 @@ int main(void)
         fmpz_clear(mod);
     }
 
+    /* Test aliasing with windows */
+    {
+        fmpz_mod_mat_t A, B, A_window;
+        fmpz_t p;
+
+        fmpz_init_set_ui(p, 3);
+
+        fmpz_mod_mat_init(A, 2, 2, p);
+        fmpz_mod_mat_init(B, 2, 2, p);
+
+        fmpz_mod_mat_window_init(A_window, A, 0, 0, 2, 2);
+
+        fmpz_mod_mat_one(A);
+        fmpz_mod_mat_one(B);
+        fmpz_set_ui(fmpz_mod_mat_entry(B, 0, 1), 1);
+        fmpz_set_ui(fmpz_mod_mat_entry(B, 1, 0), 1);
+
+        fmpz_mod_mat_mul(A_window, B, A_window);
+
+        if (!fmpz_mod_mat_equal(A, B))
+        {
+            flint_printf("FAIL: window aliasing failed\n");
+            fmpz_mod_mat_print_pretty(A); flint_printf("\n\n");
+            fmpz_mod_mat_print_pretty(B); flint_printf("\n\n");
+            flint_abort();
+        }
+
+        fmpz_clear(p);
+        fmpz_mod_mat_window_clear(A_window);
+        fmpz_mod_mat_clear(A);
+        fmpz_mod_mat_clear(B);
+    }
+
     FLINT_TEST_CLEANUP(state);
     
     flint_printf("PASS\n");

--- a/fmpz_poly/test/t-evaluate_horner_d_2exp.c
+++ b/fmpz_poly/test/t-evaluate_horner_d_2exp.c
@@ -20,7 +20,7 @@
 int
 main(void)
 {
-    int i, result;
+    int i;
     FLINT_TEST_INIT(state);
 
     flint_printf("evaluate_horner_d_2exp....");
@@ -30,7 +30,7 @@ main(void)
     {
         fmpz_poly_t f;
         double x, y, z, t;
-        slong xexp, yexp, zexp;
+        slong xexp, yexp;
 
         x = d_randtest(state);
         xexp = n_randint(state, 20) - 10;

--- a/fmpz_poly_mat.h
+++ b/fmpz_poly_mat.h
@@ -46,20 +46,6 @@ fmpz_poly_struct * fmpz_poly_mat_entry(const fmpz_poly_mat_t mat, slong i, slong
    return mat->rows[i] + j;
 }
 
-/* Memory management *********************************************************/
-
-FLINT_DLL void fmpz_poly_mat_init(fmpz_poly_mat_t mat, slong rows, slong cols);
-
-FLINT_DLL void fmpz_poly_mat_init_set(fmpz_poly_mat_t mat, const fmpz_poly_mat_t src);
-
-FLINT_DLL void fmpz_poly_mat_swap(fmpz_poly_mat_t mat1, fmpz_poly_mat_t mat2);
-
-FLINT_DLL void fmpz_poly_mat_set(fmpz_poly_mat_t mat1, const fmpz_poly_mat_t mat2);
-
-FLINT_DLL void fmpz_poly_mat_clear(fmpz_poly_mat_t mat);
-
-/* Basic properties **********************************************************/
-
 FMPZ_POLY_MAT_INLINE
 slong fmpz_poly_mat_nrows(const fmpz_poly_mat_t mat)
 {
@@ -71,6 +57,28 @@ slong fmpz_poly_mat_ncols(const fmpz_poly_mat_t mat)
 {
     return mat->c;
 }
+
+/* Memory management *********************************************************/
+
+FLINT_DLL void fmpz_poly_mat_init(fmpz_poly_mat_t mat, slong rows, slong cols);
+
+FLINT_DLL void fmpz_poly_mat_init_set(fmpz_poly_mat_t mat, const fmpz_poly_mat_t src);
+
+FLINT_DLL void fmpz_poly_mat_swap(fmpz_poly_mat_t mat1, fmpz_poly_mat_t mat2);
+
+FMPZ_POLY_MAT_INLINE void
+fmpz_poly_mat_swap_entrywise(fmpz_poly_mat_t mat1, fmpz_poly_mat_t mat2)
+{
+    slong i, j;
+
+    for (i = 0; i < fmpz_poly_mat_nrows(mat1); i++)
+        for (j = 0; j < fmpz_poly_mat_ncols(mat1); j++)
+            fmpz_poly_swap(fmpz_poly_mat_entry(mat2, i, j), fmpz_poly_mat_entry(mat1, i, j));
+}
+
+FLINT_DLL void fmpz_poly_mat_set(fmpz_poly_mat_t mat1, const fmpz_poly_mat_t mat2);
+
+FLINT_DLL void fmpz_poly_mat_clear(fmpz_poly_mat_t mat);
 
 /* Comparison ****************************************************************/
 

--- a/fmpz_poly_mat/mul_classical.c
+++ b/fmpz_poly_mat/mul_classical.c
@@ -37,7 +37,7 @@ fmpz_poly_mat_mul_classical(fmpz_poly_mat_t C, const fmpz_poly_mat_t A,
         fmpz_poly_mat_t T;
         fmpz_poly_mat_init(T, ar, bc);
         fmpz_poly_mat_mul_classical(T, A, B);
-        fmpz_poly_mat_swap(C, T);
+        fmpz_poly_mat_swap_entrywise(C, T);
         fmpz_poly_mat_clear(T);
         return;
     }

--- a/fmpz_poly_mat/mullow.c
+++ b/fmpz_poly_mat/mullow.c
@@ -37,7 +37,7 @@ fmpz_poly_mat_mullow(fmpz_poly_mat_t C, const fmpz_poly_mat_t A,
         fmpz_poly_mat_t T;
         fmpz_poly_mat_init(T, ar, bc);
         fmpz_poly_mat_mullow(T, A, B, len);
-        fmpz_poly_mat_swap(C, T);
+        fmpz_poly_mat_swap_entrywise(C, T);
         fmpz_poly_mat_clear(T);
         return;
     }

--- a/fq_mat/is_one.c
+++ b/fq_mat/is_one.c
@@ -1,0 +1,22 @@
+/*
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fq_mat.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq
+#define CAP_T FQ
+#include "fq_mat_templates/is_one.c"
+#undef CAP_T
+#undef T

--- a/fq_mat/one.c
+++ b/fq_mat/one.c
@@ -1,0 +1,22 @@
+/*
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fq_mat.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq
+#define CAP_T FQ
+#include "fq_mat_templates/one.c"
+#undef CAP_T
+#undef T

--- a/fq_mat/test/t-one.c
+++ b/fq_mat/test/t-one.c
@@ -1,0 +1,22 @@
+/*
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fq_mat.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq
+#define CAP_T FQ
+#include "fq_mat_templates/test/t-one.c"
+#undef CAP_T
+#undef T

--- a/fq_mat_templates.h
+++ b/fq_mat_templates.h
@@ -93,6 +93,9 @@ FLINT_DLL int TEMPLATE(T, mat_equal)(const TEMPLATE(T, mat_t) mat1,
 FLINT_DLL int TEMPLATE(T, mat_is_zero)(const TEMPLATE(T, mat_t) mat,
                          const TEMPLATE(T, ctx_t) ctx);
 
+FLINT_DLL int TEMPLATE(T, mat_is_one)(const TEMPLATE(T, mat_t) mat,
+		                         const TEMPLATE(T, ctx_t) ctx);
+
 FQ_MAT_TEMPLATES_INLINE int
 TEMPLATE(T, mat_is_empty)(const TEMPLATE(T, mat_t) mat,
                           const TEMPLATE(T, ctx_t) ctx)
@@ -191,6 +194,8 @@ TEMPLATE(T, mat_invert_cols)(TEMPLATE(T, mat_t) mat, slong * perm, const TEMPLAT
 /* Assignment  ***************************************************************/
 
 FLINT_DLL void TEMPLATE(T, mat_zero)(TEMPLATE(T, mat_t) A, const TEMPLATE(T, ctx_t) ctx);
+
+FLINT_DLL void TEMPLATE(T, mat_one)(TEMPLATE(T, mat_t) A, const TEMPLATE(T, ctx_t) ctx);
 
 /* Windows and concatenation */
 

--- a/fq_mat_templates.h
+++ b/fq_mat_templates.h
@@ -38,8 +38,48 @@ FLINT_DLL void TEMPLATE(T, mat_init)(TEMPLATE(T, mat_t) mat, slong rows, slong c
 FLINT_DLL void TEMPLATE(T, mat_init_set)(TEMPLATE(T, mat_t) mat, const TEMPLATE(T, mat_t) src,
                           const TEMPLATE(T, ctx_t) ctx);
 
+FQ_MAT_TEMPLATES_INLINE slong
+TEMPLATE(T, mat_nrows)(const TEMPLATE(T, mat_t) mat ,
+                       const TEMPLATE(T, ctx_t) ctx)
+{
+    return mat->r;
+}
+
+FQ_MAT_TEMPLATES_INLINE slong
+TEMPLATE(T, mat_ncols)(const TEMPLATE(T, mat_t) mat,
+                       const TEMPLATE(T, ctx_t) ctx)
+{
+    return mat->c;
+}
+
+FQ_MAT_TEMPLATES_INLINE TEMPLATE(T, struct) *
+TEMPLATE(T, mat_entry)(const TEMPLATE(T, mat_t) mat, slong i, slong j)
+{
+    return mat->rows[i] + j;
+}
+
+FQ_MAT_TEMPLATES_INLINE void
+TEMPLATE(T, mat_entry_set)(TEMPLATE(T, mat_t) mat, slong i, slong j,
+                           const TEMPLATE(T, t) x,
+                           const TEMPLATE(T, ctx_t) ctx)
+{
+    TEMPLATE(T, set)(TEMPLATE(T, mat_entry)(mat, i, j), x, ctx);
+}
+
 FLINT_DLL void TEMPLATE(T, mat_swap)(TEMPLATE(T, mat_t) mat1, TEMPLATE(T, mat_t) mat2,
                       const TEMPLATE(T, ctx_t) ctx);
+
+FQ_MAT_TEMPLATES_INLINE void
+TEMPLATE(T, mat_swap_entrywise)(TEMPLATE(T, mat_t) mat1,
+		         TEMPLATE(T, mat_t) mat2, const TEMPLATE(T, ctx_t) ctx)
+{
+    slong i, j;
+
+    for (i = 0; i < TEMPLATE(T, mat_nrows)(mat1, ctx); i++)
+        for (j = 0; j < TEMPLATE(T, mat_ncols)(mat1, ctx); j++)
+            TEMPLATE(T, swap)(TEMPLATE(T, mat_entry)(mat2, i, j),
+			      TEMPLATE(T, mat_entry)(mat1, i, j), ctx);
+}
 
 FLINT_DLL void TEMPLATE(T, mat_set)(TEMPLATE(T, mat_t) mat1, const TEMPLATE(T, mat_t) mat2,
                      const TEMPLATE(T, ctx_t) ctx);
@@ -65,34 +105,6 @@ TEMPLATE(T, mat_is_square)(const TEMPLATE(T, mat_t) mat,
                            const TEMPLATE(T, ctx_t) ctx)
 {
     return (mat->r == mat->c);
-}
-
-FQ_MAT_TEMPLATES_INLINE TEMPLATE(T, struct) *
-TEMPLATE(T, mat_entry)(const TEMPLATE(T, mat_t) mat, slong i, slong j)
-{
-    return mat->rows[i] + j;
-}
-
-FQ_MAT_TEMPLATES_INLINE void
-TEMPLATE(T, mat_entry_set)(TEMPLATE(T, mat_t) mat, slong i, slong j,
-                           const TEMPLATE(T, t) x,
-                           const TEMPLATE(T, ctx_t) ctx)
-{
-    TEMPLATE(T, set)(TEMPLATE(T, mat_entry)(mat, i, j), x, ctx);
-}
-
-FQ_MAT_TEMPLATES_INLINE slong
-TEMPLATE(T, mat_nrows)(const TEMPLATE(T, mat_t) mat ,
-                       const TEMPLATE(T, ctx_t) ctx)
-{
-    return mat->r;
-}
-
-FQ_MAT_TEMPLATES_INLINE slong
-TEMPLATE(T, mat_ncols)(const TEMPLATE(T, mat_t) mat,
-                       const TEMPLATE(T, ctx_t) ctx)
-{
-    return mat->c;
 }
 
 FQ_MAT_TEMPLATES_INLINE void

--- a/fq_mat_templates/is_one.c
+++ b/fq_mat_templates/is_one.c
@@ -1,0 +1,46 @@
+/*
+    Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#ifdef T
+
+#include "templates.h"
+
+int
+TEMPLATE(T, mat_is_one) (const TEMPLATE(T, mat_t) mat,
+                          const TEMPLATE(T, ctx_t) ctx)
+{
+    slong i, j;
+
+    if (mat->r == 0 || mat->c == 0)
+        return 1;
+
+    for (i = 0; i < mat->r; i++)
+    {
+        for (j = 0; j < mat->c; j++)
+	{
+            if (i == j)
+            {
+                if (!TEMPLATE(T, is_one)(TEMPLATE(T, mat_entry)(mat, i, j), ctx))
+                    return 0;
+            } else
+            {
+                if (!TEMPLATE(T, is_zero)(TEMPLATE(T, mat_entry)(mat, i, j), ctx))
+                    return 0;
+            }
+        }
+    }
+
+    return 1;
+}
+
+
+#endif

--- a/fq_mat_templates/minpoly.c
+++ b/fq_mat_templates/minpoly.c
@@ -18,7 +18,7 @@ TEMPLATE(T, mat_minpoly) (TEMPLATE(T, poly_t) p,
 {
    slong n = X->r, i, j, c, c1, c2, r1, r2;
    slong  * P1, * P2, * L1, * L2;
-   TEMPLATE(T, mat_t) A, B, v, w;
+   TEMPLATE(T, mat_t) A, B, v;
    int first_poly = 1, indep = 1;
    TEMPLATE(T, poly_t) b, g, r;
    TEMPLATE(T, t) t, h;
@@ -59,7 +59,6 @@ TEMPLATE(T, mat_minpoly) (TEMPLATE(T, poly_t) p,
    TEMPLATE(T, mat_init) (A, n + 1, 2*n + 1, ctx);
    TEMPLATE(T, mat_init) (B, n, n, ctx);
    TEMPLATE(T, mat_init) (v, n, 1, ctx);
-   TEMPLATE(T, mat_init) (w, n, 1, ctx);
  
    L1 = (slong *) TMP_ALLOC((n + 1)*sizeof(slong));
    L2 = (slong *) TMP_ALLOC(n*sizeof(slong));
@@ -109,9 +108,7 @@ TEMPLATE(T, mat_minpoly) (TEMPLATE(T, poly_t) p,
          r1++;
          r2 = indep ? r2 + 1 : r2;
          
-         /* fq_mat_mul does not support aliasing, so mul and swap */
-         TEMPLATE(T, mat_mul) (w, X, v, ctx);
-         TEMPLATE(T, mat_swap) (v, w, ctx);
+         TEMPLATE(T, mat_mul) (v, X, v, ctx);
          
          for (i = 0; i < n; i++)
             TEMPLATE(T, set) (TEMPLATE(T, mat_entry) (A, r1, i), TEMPLATE(T, mat_entry) (v, i, 0), ctx);
@@ -185,7 +182,6 @@ TEMPLATE(T, mat_minpoly) (TEMPLATE(T, poly_t) p,
    TEMPLATE(T, mat_clear) (A, ctx);
    TEMPLATE(T, mat_clear) (B, ctx);
    TEMPLATE(T, mat_clear) (v, ctx);
-   TEMPLATE(T, mat_clear) (w, ctx);
 
    TEMPLATE(T, poly_clear) (b, ctx);
    TEMPLATE(T, poly_clear) (g, ctx);

--- a/fq_mat_templates/mul.c
+++ b/fq_mat_templates/mul.c
@@ -23,7 +23,7 @@ TEMPLATE(T, mat_mul) (TEMPLATE(T, mat_t) C,
         TEMPLATE(T, mat_t) TT;
         TEMPLATE(T, mat_init) (TT, A->r, B->c, ctx);
         TEMPLATE(T, mat_mul) (TT, A, B, ctx);
-        TEMPLATE(T, mat_swap) (TT, C, ctx);
+        TEMPLATE(T, mat_swap_entrywise) (TT, C, ctx);
         TEMPLATE(T, mat_clear) (TT, ctx);
         return;
     }

--- a/fq_mat_templates/mul_classical.c
+++ b/fq_mat_templates/mul_classical.c
@@ -40,7 +40,7 @@ TEMPLATE(T, mat_mul_classical) (TEMPLATE(T, mat_t) C,
         TEMPLATE(T, mat_t) T;
         TEMPLATE(T, mat_init) (T, ar, bc, ctx);
         TEMPLATE(T, mat_mul_classical) (T, A, B, ctx);
-        TEMPLATE(T, mat_swap) (C, T, ctx);
+        TEMPLATE(T, mat_swap_entrywise) (C, T, ctx);
         TEMPLATE(T, mat_clear) (T, ctx);
         return;
     }

--- a/fq_mat_templates/one.c
+++ b/fq_mat_templates/one.c
@@ -1,0 +1,30 @@
+/*
+    Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2021 William Hart
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#ifdef T
+
+#include "templates.h"
+
+void
+TEMPLATE(T, mat_one)(TEMPLATE(T, mat_t) mat, const TEMPLATE(T, ctx_t) ctx)
+{
+    slong i, n;
+
+    TEMPLATE(T, mat_zero)(mat, ctx);
+    n = FLINT_MIN(mat->r, mat->c);
+
+    for (i = 0; i < n; i++)
+        TEMPLATE(T, one)(TEMPLATE(T, mat_entry)(mat, i, i), ctx);
+}
+
+#endif
+

--- a/fq_mat_templates/test/t-mul.c
+++ b/fq_mat_templates/test/t-mul.c
@@ -1,6 +1,7 @@
 /*
     Copyright (C) 2011 Fredrik Johansson
     Copyright (C) 2013 Mike Hansen
+    Copyright (C) 2021 William Hart
 
     This file is part of FLINT.
 
@@ -120,6 +121,39 @@ main(void)
         TEMPLATE(T, mat_clear) (B, ctx);
         TEMPLATE(T, mat_clear) (C, ctx);
 
+        TEMPLATE(T, ctx_clear) (ctx);
+    }
+
+    /* Test aliasing with windows */
+    {
+        TEMPLATE(T, ctx_t) ctx;
+        TEMPLATE(T, mat_t) A, B, A_window;
+
+        TEMPLATE(T, ctx_randtest) (ctx, state);
+	
+	TEMPLATE(T, mat_init)(A, 2, 2, ctx);
+        TEMPLATE(T, mat_init)(B, 2, 2, ctx);
+
+        TEMPLATE(T, mat_window_init)(A_window, A, 0, 0, 2, 2, ctx);
+
+        TEMPLATE(T, mat_one)(A, ctx);
+        TEMPLATE(T, mat_one)(B, ctx);
+        TEMPLATE(T, set_ui)(TEMPLATE(T, mat_entry)(B, 0, 1), 1, ctx);
+        TEMPLATE(T, set_ui)(TEMPLATE(T, mat_entry)(B, 1, 0), 1, ctx);
+
+        TEMPLATE(T, mat_mul)(A_window, B, A_window, ctx);
+
+        if (!TEMPLATE(T, mat_equal)(A, B, ctx))
+        {
+            flint_printf("FAIL: window aliasing failed\n");
+            TEMPLATE(T, mat_print)(A, ctx); flint_printf("\n\n");
+            TEMPLATE(T, mat_print)(B, ctx); flint_printf("\n\n");
+            flint_abort();
+        }
+
+        TEMPLATE(T, mat_window_clear)(A_window, ctx);
+        TEMPLATE(T, mat_clear)(A, ctx);
+        TEMPLATE(T, mat_clear)(B, ctx);
         TEMPLATE(T, ctx_clear) (ctx);
     }
 

--- a/fq_mat_templates/test/t-one.c
+++ b/fq_mat_templates/test/t-one.c
@@ -1,0 +1,60 @@
+/*
+    Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2013 Mike Hansen
+    Copyright (C) 2021 William Hart
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#ifdef T
+
+#include "templates.h"
+
+#include <stdio.h>
+
+int
+main(void)
+{
+    int iter;
+    FLINT_TEST_INIT(state);
+
+    printf("one/is_one....");
+    fflush(stdout);
+
+    for (iter = 0; iter < 10 * flint_test_multiplier(); iter++)
+    {
+        TEMPLATE(T, ctx_t) ctx;
+        TEMPLATE(T, mat_t) A;
+        slong m, n;
+
+        TEMPLATE(T, ctx_randtest) (ctx, state);
+
+        m = n_randint(state, 10);
+        n = n_randint(state, 10);
+
+        TEMPLATE(T, mat_init) (A, m, n, ctx);
+        TEMPLATE(T, mat_randtest) (A, state, ctx);
+        TEMPLATE(T, mat_one) (A, ctx);
+
+        if (!TEMPLATE(T, mat_is_one) (A, ctx))
+        {
+            printf("FAIL: expected matrix to be one\n");
+            abort();
+        }
+
+        TEMPLATE(T, mat_clear) (A, ctx);
+        TEMPLATE(T, ctx_clear) (ctx);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+    printf("PASS\n");
+    return 0;
+}
+
+
+#endif

--- a/fq_nmod_mat/is_one.c
+++ b/fq_nmod_mat/is_one.c
@@ -1,0 +1,22 @@
+/*
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fq_nmod_mat.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq_nmod
+#define CAP_T FQ_NMOD
+#include "fq_mat_templates/is_one.c"
+#undef CAP_T
+#undef T

--- a/fq_nmod_mat/one.c
+++ b/fq_nmod_mat/one.c
@@ -1,0 +1,22 @@
+/*
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fq_nmod_mat.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq_nmod
+#define CAP_T FQ_NMOD
+#include "fq_mat_templates/one.c"
+#undef CAP_T
+#undef T

--- a/fq_nmod_mat/test/t-one.c
+++ b/fq_nmod_mat/test/t-one.c
@@ -1,0 +1,22 @@
+/*
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fq_nmod_mat.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq_nmod
+#define CAP_T FQ_NMOD
+#include "fq_mat_templates/test/t-one.c"
+#undef CAP_T
+#undef T

--- a/fq_zech_mat/is_one.c
+++ b/fq_zech_mat/is_one.c
@@ -1,0 +1,22 @@
+/*
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fq_zech_mat.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq_zech
+#define CAP_T FQ_ZECH
+#include "fq_mat_templates/is_one.c"
+#undef CAP_T
+#undef T

--- a/fq_zech_mat/one.c
+++ b/fq_zech_mat/one.c
@@ -1,0 +1,22 @@
+/*
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fq_zech_mat.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq_zech
+#define CAP_T FQ_ZECH
+#include "fq_mat_templates/one.c"
+#undef CAP_T
+#undef T

--- a/fq_zech_mat/test/t-one.c
+++ b/fq_zech_mat/test/t-one.c
@@ -1,0 +1,22 @@
+/*
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fq_zech_mat.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq_zech
+#define CAP_T FQ_ZECH
+#include "fq_mat_templates/test/t-one.c"
+#undef CAP_T
+#undef T

--- a/mpf_mat.h
+++ b/mpf_mat.h
@@ -44,11 +44,33 @@ mpf * mpf_mat_entry(const mpf_mat_t mat, slong i, slong j)
    return mat->rows[i] + j;
 }
 
+MPF_MAT_INLINE
+slong mpf_mat_nrows(const mpf_mat_t mat)
+{
+    return mat->r;
+}
+
+MPF_MAT_INLINE
+slong mpf_mat_ncols(const mpf_mat_t mat)
+{
+    return mat->c;
+}
+
 /* Memory management  ********************************************************/
 
 FLINT_DLL void mpf_mat_init(mpf_mat_t mat, slong rows, slong cols, flint_bitcnt_t prec);
 
 FLINT_DLL void mpf_mat_swap(mpf_mat_t mat1, mpf_mat_t mat2);
+
+MPF_MAT_INLINE void
+mpf_mat_swap_entrywise(mpf_mat_t mat1, mpf_mat_t mat2)
+{
+    slong i, j;
+
+    for (i = 0; i < mpf_mat_nrows(mat1); i++)
+        for (j = 0; j < mpf_mat_ncols(mat1); j++)
+            mpf_swap(mpf_mat_entry(mat2, i, j), mpf_mat_entry(mat1, i, j));
+}
 
 FLINT_DLL void mpf_mat_set(mpf_mat_t mat1, const mpf_mat_t mat2);
 

--- a/mpf_mat/gso.c
+++ b/mpf_mat/gso.c
@@ -30,7 +30,7 @@ mpf_mat_gso(mpf_mat_t B, const mpf_mat_t A)
         mpf_mat_t T;
         mpf_mat_init(T, A->r, A->c, B->prec);
         mpf_mat_gso(T, A);
-        mpf_mat_swap(B, T);
+        mpf_mat_swap_entrywise(B, T);
         mpf_mat_clear(T);
         return;
     }

--- a/mpf_mat/mul.c
+++ b/mpf_mat/mul.c
@@ -28,7 +28,7 @@ mpf_mat_mul(mpf_mat_t C, const mpf_mat_t A, const mpf_mat_t B)
         mpf_mat_t t;
         mpf_mat_init(t, ar, bc, C->prec);
         mpf_mat_mul(t, A, B);
-        mpf_mat_swap(C, t);
+        mpf_mat_swap_entrywise(C, t);
         mpf_mat_clear(t);
         return;
     }

--- a/mpf_mat/qr.c
+++ b/mpf_mat/qr.c
@@ -30,7 +30,7 @@ mpf_mat_qr(mpf_mat_t Q, mpf_mat_t R, const mpf_mat_t A)
         mpf_mat_t T;
         mpf_mat_init(T, A->r, A->c, Q->prec);
         mpf_mat_qr(T, R, A);
-        mpf_mat_swap(Q, T);
+        mpf_mat_swap_entrywise(Q, T);
         mpf_mat_clear(T);
         return;
     }

--- a/mpf_mat/test/t-mul.c
+++ b/mpf_mat/test/t-mul.c
@@ -65,12 +65,15 @@ main(void)
             abort();
         }
 
-        mpf_mat_mul(A, A, B);
+        if (n == k)
+	{
+            mpf_mat_mul(A, A, B);
 
-        if (!mpf_mat_equal(A, E))
-        {
-            flint_printf("FAIL: aliasing failed\n");
-            abort();
+            if (!mpf_mat_equal(A, E))
+            {
+                flint_printf("FAIL: aliasing failed\n");
+                abort();
+            }
         }
 
         mpf_mat_clear(A);

--- a/mpfr_mat.h
+++ b/mpfr_mat.h
@@ -43,9 +43,31 @@ __mpfr_struct * mpfr_mat_entry(const mpfr_mat_t mat, slong i, slong j)
    return mat->rows[i] + j;
 }
 
+MPFR_MAT_INLINE
+slong mpfr_mat_nrows(const mpfr_mat_t mat)
+{
+    return mat->r;
+}
+
+MPFR_MAT_INLINE
+slong mpfr_mat_ncols(const mpfr_mat_t mat)
+{
+    return mat->c;
+}
+
 FLINT_DLL void mpfr_mat_init(mpfr_mat_t mat, slong rows, slong cols, mpfr_prec_t prec);
 
 FLINT_DLL void mpfr_mat_swap(mpfr_mat_t mat1, mpfr_mat_t mat2);
+
+MPFR_MAT_INLINE void
+mpfr_mat_swap_entrywise(mpfr_mat_t mat1, mpfr_mat_t mat2)
+{
+    slong i, j;
+
+    for (i = 0; i < mpfr_mat_nrows(mat1); i++)
+        for (j = 0; j < mpfr_mat_ncols(mat1); j++)
+            mpfr_swap(mpfr_mat_entry(mat2, i, j), mpfr_mat_entry(mat1, i, j));
+}
 
 FLINT_DLL void mpfr_mat_set(mpfr_mat_t mat1, const mpfr_mat_t mat2);
 

--- a/mpfr_mat/mul_classical.c
+++ b/mpfr_mat/mul_classical.c
@@ -30,7 +30,7 @@ mpfr_mat_mul_classical(mpfr_mat_t C, const mpfr_mat_t A, const mpfr_mat_t B,
         mpfr_mat_t t;
         mpfr_mat_init(t, ar, bc, C->prec);
         mpfr_mat_mul_classical(t, A, B, rnd);
-        mpfr_mat_swap(C, t);
+        mpfr_mat_swap_entrywise(C, t);
         mpfr_mat_clear(t);
         return;
     }

--- a/mpfr_mat/test/t-mul_classical.c
+++ b/mpfr_mat/test/t-mul_classical.c
@@ -66,8 +66,8 @@ main(void)
         m = n_randint(state, 10);
         n = n_randint(state, 10);
 
-        mpfr_mat_init(A, m, n, 200);
-        mpfr_mat_init(B, n, n, 200);
+        mpfr_mat_init(A, m, m, 200);
+        mpfr_mat_init(B, m, n, 200);
         mpfr_mat_init(C, m, n, 200);
 
         mpfr_mat_randtest(A, state);

--- a/nmod_mat.h
+++ b/nmod_mat.h
@@ -92,7 +92,21 @@ FLINT_DLL void nmod_mat_init(nmod_mat_t mat, slong rows, slong cols, mp_limb_t n
 FLINT_DLL void nmod_mat_init_set(nmod_mat_t mat, const nmod_mat_t src);
 FLINT_DLL void nmod_mat_clear(nmod_mat_t mat);
 FLINT_DLL void nmod_mat_one(nmod_mat_t mat);
+
 FLINT_DLL void nmod_mat_swap(nmod_mat_t mat1, nmod_mat_t mat2);
+
+NMOD_MAT_INLINE void
+nmod_mat_swap_entrywise(nmod_mat_t mat1, nmod_mat_t mat2)
+{
+    slong i, j;
+    for (i = 0; i < nmod_mat_nrows(mat1); i++)
+    {
+       mp_limb_t * row1 = mat1->rows[i];
+       mp_limb_t * row2 = mat2->rows[i];
+       for (j = 0; j < nmod_mat_ncols(mat1); j++)
+          MP_LIMB_SWAP(row1[j], row2[j]);
+    }
+}
 
 /* Windows and concatenation */
 

--- a/nmod_mat/minpoly.c
+++ b/nmod_mat/minpoly.c
@@ -21,7 +21,7 @@ void nmod_mat_minpoly_with_gens(nmod_poly_t p, const nmod_mat_t X, ulong * P)
    slong n = X->r, i, j, c, c1, c2, r1, r2;
    ulong ** A, ** B, ** v, t, h;
    slong  * P1, * P2, * L1, * L2;
-   nmod_mat_t matA, matB, matv, matw;
+   nmod_mat_t matA, matB, matv;
    int first_poly = 1, indep = 1;
    nmod_poly_t b, g;
    TMP_INIT;
@@ -56,7 +56,6 @@ void nmod_mat_minpoly_with_gens(nmod_poly_t p, const nmod_mat_t X, ulong * P)
    nmod_mat_init(matA, n + 1, 2*n + 1, p->mod.n);
    nmod_mat_init(matB, n, n, p->mod.n);
    nmod_mat_init(matv, n, 1, p->mod.n);
-   nmod_mat_init(matw, n, 1, p->mod.n);
 
    A = matA->rows;
    B = matB->rows;
@@ -112,9 +111,7 @@ void nmod_mat_minpoly_with_gens(nmod_poly_t p, const nmod_mat_t X, ulong * P)
          r1++;
          r2 = indep ? r2 + 1 : r2;
          
-         /* nmod_mat_mul does not support aliasing, so mul and swap */
-         nmod_mat_mul(matw, X, matv);
-         nmod_mat_swap(matv, matw);
+         nmod_mat_mul(matv, X, matv);
          v = matv->rows;
 
          for (i = 0; i < n; i++)
@@ -189,7 +186,6 @@ void nmod_mat_minpoly_with_gens(nmod_poly_t p, const nmod_mat_t X, ulong * P)
    nmod_mat_clear(matA);
    nmod_mat_clear(matB);
    nmod_mat_clear(matv);
-   nmod_mat_clear(matw);
 
    nmod_poly_clear(b);
    nmod_poly_clear(g);

--- a/nmod_mat/mul.c
+++ b/nmod_mat/mul.c
@@ -74,7 +74,7 @@ nmod_mat_mul(nmod_mat_t C, const nmod_mat_t A, const nmod_mat_t B)
         nmod_mat_t T;
         nmod_mat_init(T, m, n, A->mod.n);
         nmod_mat_mul(T, A, B);
-        nmod_mat_swap(C, T);
+        nmod_mat_swap_entrywise(C, T);
         nmod_mat_clear(T);
         return;
     }

--- a/nmod_mat/pow.c
+++ b/nmod_mat/pow.c
@@ -55,12 +55,12 @@ _nmod_mat_pow(nmod_mat_t dest, const nmod_mat_t mat, ulong pow)
         if(pow%2 == 1)
         {
             nmod_mat_mul(temp1, dest, temp2);
-            nmod_mat_swap(temp1, dest);
+            nmod_mat_swap_entrywise(temp1, dest);
         }
         if (pow > 1)
         {
             nmod_mat_mul(temp1, temp2, temp2);
-            nmod_mat_swap(temp1, temp2);
+            nmod_mat_swap_entrywise(temp1, temp2);
         }
         pow /= 2;
     }

--- a/nmod_mat/test/t-mul.c
+++ b/nmod_mat/test/t-mul.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2010 Fredrik Johansson
+    Copyright (C) 2021 William Hart
 
     This file is part of FLINT.
 
@@ -125,6 +126,35 @@ main(void)
         nmod_mat_clear(B);
         nmod_mat_clear(C);
         nmod_mat_clear(D);
+    }
+
+    /* Test aliasing with windows */
+    {
+        nmod_mat_t A, B, A_window;
+
+        nmod_mat_init(A, 2, 2, 3);
+        nmod_mat_init(B, 2, 2, 3);
+
+        nmod_mat_window_init(A_window, A, 0, 0, 2, 2);
+
+        nmod_mat_one(A);
+        nmod_mat_one(B);
+        nmod_mat_entry(B, 0, 1) = 1;
+        nmod_mat_entry(B, 1, 0) = 1;
+
+        nmod_mat_mul(A_window, B, A_window);
+
+        if (!nmod_mat_equal(A, B))
+        {
+            flint_printf("FAIL: window aliasing failed\n");
+            nmod_mat_print_pretty(A); flint_printf("\n\n");
+            nmod_mat_print_pretty(B); flint_printf("\n\n");
+            flint_abort();
+        }
+
+        nmod_mat_window_clear(A_window);
+        nmod_mat_clear(A);
+        nmod_mat_clear(B);
     }
 
     FLINT_TEST_CLEANUP(state);

--- a/nmod_poly_mat.h
+++ b/nmod_poly_mat.h
@@ -48,20 +48,6 @@ nmod_poly_struct * nmod_poly_mat_entry(const nmod_poly_mat_t mat, slong i, slong
     return mat->rows[i] + j;
 }
 
-/* Memory management *********************************************************/
-
-FLINT_DLL void nmod_poly_mat_init(nmod_poly_mat_t mat, slong rows, slong cols, mp_limb_t n);
-
-FLINT_DLL void nmod_poly_mat_init_set(nmod_poly_mat_t mat, const nmod_poly_mat_t src);
-
-FLINT_DLL void nmod_poly_mat_swap(nmod_poly_mat_t mat1, nmod_poly_mat_t mat2);
-
-FLINT_DLL void nmod_poly_mat_set(nmod_poly_mat_t mat1, const nmod_poly_mat_t mat2);
-
-FLINT_DLL void nmod_poly_mat_clear(nmod_poly_mat_t mat);
-
-/* Basic properties **********************************************************/
-
 NMOD_POLY_MAT_INLINE slong
 nmod_poly_mat_nrows(const nmod_poly_mat_t mat)
 {
@@ -73,6 +59,30 @@ nmod_poly_mat_ncols(const nmod_poly_mat_t mat)
 {
     return mat->c;
 }
+
+/* Memory management *********************************************************/
+
+FLINT_DLL void nmod_poly_mat_init(nmod_poly_mat_t mat, slong rows, slong cols, mp_limb_t n);
+
+FLINT_DLL void nmod_poly_mat_init_set(nmod_poly_mat_t mat, const nmod_poly_mat_t src);
+
+FLINT_DLL void nmod_poly_mat_swap(nmod_poly_mat_t mat1, nmod_poly_mat_t mat2);
+
+NMOD_POLY_MAT_INLINE void
+nmod_poly_mat_swap_entrywise(nmod_poly_mat_t mat1, nmod_poly_mat_t mat2)
+{
+    slong i, j;
+
+    for (i = 0; i < nmod_poly_mat_nrows(mat1); i++)
+        for (j = 0; j < nmod_poly_mat_ncols(mat1); j++)
+            nmod_poly_swap(nmod_poly_mat_entry(mat2, i, j), nmod_poly_mat_entry(mat1, i, j));
+}
+
+FLINT_DLL void nmod_poly_mat_set(nmod_poly_mat_t mat1, const nmod_poly_mat_t mat2);
+
+FLINT_DLL void nmod_poly_mat_clear(nmod_poly_mat_t mat);
+
+/* Basic properties **********************************************************/
 
 NMOD_POLY_MAT_INLINE mp_limb_t
 nmod_poly_mat_modulus(const nmod_poly_mat_t mat)

--- a/nmod_poly_mat/mul_classical.c
+++ b/nmod_poly_mat/mul_classical.c
@@ -36,7 +36,7 @@ nmod_poly_mat_mul_classical(nmod_poly_mat_t C, const nmod_poly_mat_t A,
         nmod_poly_mat_t T;
         nmod_poly_mat_init(T, ar, bc, nmod_poly_mat_modulus(A));
         nmod_poly_mat_mul_classical(T, A, B);
-        nmod_poly_mat_swap(C, T);
+        nmod_poly_mat_swap_entrywise(C, T);
         nmod_poly_mat_clear(T);
         return;
     }

--- a/padic_mat.h
+++ b/padic_mat.h
@@ -188,7 +188,7 @@ padic_mat_swap_entrywise(padic_mat_t mat1, padic_mat_t mat2)
 
     for (i = 0; i < padic_mat_nrows(mat1); i++)
         for (j = 0; j < padic_mat_ncols(mat1); j++)
-            padic_swap(padic_mat_entry(mat2, i, j), padic_mat_entry(mat1, i, j));
+            fmpz_swap(padic_mat_entry(mat2, i, j), padic_mat_entry(mat1, i, j));
 }
 
 FLINT_DLL void padic_mat_zero(padic_mat_t A);

--- a/padic_mat.h
+++ b/padic_mat.h
@@ -181,6 +181,16 @@ FLINT_DLL void padic_mat_set(padic_mat_t B, const padic_mat_t A, const padic_ctx
 
 FLINT_DLL void padic_mat_swap(padic_mat_t A, padic_mat_t B);
 
+PADIC_MAT_INLINE void
+padic_mat_swap_entrywise(padic_mat_t mat1, padic_mat_t mat2)
+{
+    slong i, j;
+
+    for (i = 0; i < padic_mat_nrows(mat1); i++)
+        for (j = 0; j < padic_mat_ncols(mat1); j++)
+            padic_swap(padic_mat_entry(mat2, i, j), padic_mat_entry(mat1, i, j));
+}
+
 FLINT_DLL void padic_mat_zero(padic_mat_t A);
 
 FLINT_DLL void padic_mat_one(padic_mat_t A);


### PR DESCRIPTION
This adds blah_mat_swap_entrywise (and occasional missing nrows/ncols) for all our matrix types, and implements the solution mentioned on https://github.com/wbhart/flint2/issues/891 to the aliasing/window issue for matrix multiplication.