### PR TITLE
Cleanup pow fps

### DIFF
--- a/fmpz_mpoly.h
+++ b/fmpz_mpoly.h
@@ -807,9 +807,8 @@ FLINT_DLL int fmpz_mpoly_pow_ui(fmpz_mpoly_t A, const fmpz_mpoly_t B,
 FLINT_DLL void fmpz_mpoly_pow_fps(fmpz_mpoly_t A, const fmpz_mpoly_t B,
                                           ulong k, const fmpz_mpoly_ctx_t ctx);
 
-FLINT_DLL slong _fmpz_mpoly_pow_fps(fmpz ** poly1, ulong ** exp1,
-                slong * alloc, const fmpz * poly2, const ulong * exp2, 
-        slong len2, ulong k, flint_bitcnt_t bits, slong N, const ulong * cmpmask);
+FLINT_DLL slong _fmpz_mpoly_pow_fps(fmpz_mpoly_t A, const fmpz * poly2, const ulong * exp2, 
+                          slong len2, ulong k, slong N, const ulong * cmpmask);
 
 
 /* Division ******************************************************************/

--- a/fmpz_mpoly.h
+++ b/fmpz_mpoly.h
@@ -804,13 +804,6 @@ FLINT_DLL int fmpz_mpoly_pow_fmpz(fmpz_mpoly_t A, const fmpz_mpoly_t B,
 FLINT_DLL int fmpz_mpoly_pow_ui(fmpz_mpoly_t A, const fmpz_mpoly_t B,
                                           ulong k, const fmpz_mpoly_ctx_t ctx);
 
-FLINT_DLL void fmpz_mpoly_pow_fps(fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                                          ulong k, const fmpz_mpoly_ctx_t ctx);
-
-FLINT_DLL slong _fmpz_mpoly_pow_fps(fmpz_mpoly_t A, const fmpz * poly2, const ulong * exp2, 
-                          slong len2, ulong k, slong N, const ulong * cmpmask);
-
-
 /* Division ******************************************************************/
 
 FLINT_DLL int fmpz_mpoly_divides(fmpz_mpoly_t Q,
@@ -1066,6 +1059,9 @@ void fmpz_mpoly_univar_swap_term_coeff(fmpz_mpoly_t c,
    Internal functions (guaranteed to change without notice)
 
 ******************************************************************************/
+
+FLINT_DLL void fmpz_mpoly_pow_fps(fmpz_mpoly_t A, const fmpz_mpoly_t B,
+                                          ulong k, const fmpz_mpoly_ctx_t ctx);
 
 FLINT_DLL void fmpz_mpolyl_lead_coeff(fmpz_mpoly_t c, const fmpz_mpoly_t A,
                                    slong num_vars, const fmpz_mpoly_ctx_t ctx);

--- a/fmpz_mpoly/pow_fps.c
+++ b/fmpz_mpoly/pow_fps.c
@@ -15,14 +15,15 @@
 #include "fmpz_mod_mpoly.h"
 
 /*
-f = f0 + f1*x + .... + fd*x^d
+Dense algorithm for the k^th power
+
+f = f_0 + f_1*x + .... + f_d*x^d
 g = f^k
-  = g0 + g1*x +      + g_kd*x^d
+  = g_0 + g_1*x +      + g_{k*d}*x^(k*d)
 
-i*g_i*f_0 = sum_{0 <= j <= min(i,d)} ((k+1)*j-i)*f_j*g_{i-j}
+where i*g_i*f_0 = sum_{0 <= j <= min(i,d)} ((k+1)*j-i)*f_j*g_{i-j}
 
-
-g_kd = f_d^k
+g_{k*d} = f_d^k
 for i from k*d-1 to 0
     c = 0
     for 1 <= j <= min(d,k*d-i)
@@ -33,6 +34,8 @@ for i from k*d-1 to 0
 
 
 /*
+Sparse algorithm for k^th power:
+
 output g = (f1 + f2 + ... + ft)^k:
 
 g = g1^k
@@ -56,19 +59,9 @@ while #H > 0 && H1 >= f1
 end
 */
 
-
-
-
-/*
-g_{(k-1)d} = f_d^(k-1)
-for i from k*d-1 to 0
-    c = 0
-    for 1 <= j <= min(d,k*d-i)
-        c += (i+j-(d-j)*k)*g_{i+j}*f_{d-j} [*x^(i+d)]
-    end
-    g_i = c/((k*d-i)*f_d [*x^d])
-*/
 /*  
+Sparse algorithm for k^th power using the (k-1)^st power:
+
 output h = (f1 + f2 + ... + ft)^k:
 
 h = 0;
@@ -98,30 +91,31 @@ while #H > 0
     end
     h += S*x^M
 end
-
 */
 
 
-
-
 slong _fmpz_mpoly_pow_fps1(
-    fmpz ** poly1, ulong ** exp1, slong * Aalloc,
+    fmpz_mpoly_t A,
     const fmpz * fcoeffs, const ulong * fexps, slong flen,
     ulong k,
-    flint_bitcnt_t bits,
     ulong cmpmask)
 {
-    slong i, j, Alen, galloc, glen;
-    slong next_loc;
-    slong Qlen = 0, heap_len = 2; /* heap zero index unused */
+    slong N = 1;
+    flint_bitcnt_t bits = A->bits;
+    slong i, j;
+    slong next_loc, Qlen = 0, heap_len = 2; /* heap zero index unused */
     mpoly_heap1_s * heap;
     mpoly_heap_t * chain;
-    slong * Q;
-    mpoly_heap_t * x;
-    fmpz * Acoeffs = *poly1, * gc = NULL;
-    ulong * Aexps = *exp1, * ge;
     ulong exp;
     slong * hind;
+    slong * Q;
+    mpoly_heap_t * x;
+    fmpz * Acoeffs = A->coeffs;
+    ulong * Aexps = A->exps;
+    slong Alen;
+    fmpz * Gcoeffs = NULL;
+    ulong * Gexps;
+    slong galloc, glen;
     fmpz_t t1, temp1;
     fmpz * S, * C;
     slong gdemote = 0;
@@ -141,25 +135,27 @@ slong _fmpz_mpoly_pow_fps1(
     fmpz_init(t1);
     fmpz_init(temp1);
 
+    _fmpz_mpoly_fit_length(&Acoeffs, &Aexps, &A->alloc, 2, N);
+
     galloc = k*(flen - 1) + 1;
-    ge = FLINT_ARRAY_ALLOC(galloc, ulong);
+    Gexps = FLINT_ARRAY_ALLOC(galloc, ulong);
     glen = 1;
     Alen = 1;
 
-    ge[0] = fexps[0]*(k - 1);
+    Gexps[0] = fexps[0]*(k - 1);
 
     Aexps[0] = fexps[0]*k;
 
-    gc = (fmpz *) flint_calloc(galloc, sizeof(fmpz));
-    fmpz_pow_ui(gc + 0, fcoeffs + 0, k - 1);
-    fmpz_mul(Acoeffs + 0, gc + 0, fcoeffs + 0);
+    Gcoeffs = (fmpz *) flint_calloc(galloc, sizeof(fmpz));
+    fmpz_pow_ui(Gcoeffs + 0, fcoeffs + 0, k - 1);
+    fmpz_mul(Acoeffs + 0, Gcoeffs + 0, fcoeffs + 0);
 
     x = chain + 1;
     x->i = 1;
     x->j = 0;
     x->next = NULL;
 
-    HEAP_ASSIGN(heap[1], fexps[1] + ge[0], x);
+    HEAP_ASSIGN(heap[1], fexps[1] + Gexps[0], x);
 
     hind[1] = 2*1 + 0;
 
@@ -167,34 +163,28 @@ slong _fmpz_mpoly_pow_fps1(
     {
         exp = heap[1].exp;
 
-        if (Alen >= *Aalloc)
-        {
-            Aexps = (ulong *) flint_realloc(Aexps, 2*sizeof(ulong)*(*Aalloc));
-            Acoeffs = (fmpz *) flint_realloc(Acoeffs, 2*sizeof(fmpz)*(*Aalloc));
-            flint_mpn_zero(Acoeffs + *Aalloc, *Aalloc);
-            (*Aalloc) *= 2;
-        }
+        _fmpz_mpoly_fit_length(&Acoeffs, &Aexps, &A->alloc, Alen + 1, N);
 
         if (glen >= galloc)
         {
-            ge = FLINT_ARRAY_REALLOC(ge, 2*galloc, ulong);
-            gc = FLINT_ARRAY_REALLOC(gc, 2*galloc, fmpz);
-            flint_mpn_zero(gc + galloc, galloc);
+            Gexps = FLINT_ARRAY_REALLOC(Gexps, 2*galloc, ulong);
+            Gcoeffs = FLINT_ARRAY_REALLOC(Gcoeffs, 2*galloc, fmpz);
+            flint_mpn_zero(Gcoeffs + galloc, galloc);
             galloc *= 2;
         }
 
         Aexps[Alen] = exp;
         S = Acoeffs + Alen;
-        C = gc + glen;
+        C = Gcoeffs + glen;
 
         fmpz_zero(C);
         fmpz_zero(S);
 
         Qlen = 0;
 
-        ge[glen] = exp - fexps[0];
+        Gexps[glen] = exp - fexps[0];
 
-        if ((ge[glen] & ofmask) == 0)
+        if ((Gexps[glen] & ofmask) == 0)
         {
             do {
                 x = _mpoly_heap_pop1(heap, &heap_len, cmpmask);
@@ -206,16 +196,18 @@ slong _fmpz_mpoly_pow_fps1(
                     Q[Qlen++] = j = x->j;
                     fi = fcoeffs[i];
 
-                    dd = (k - 1)*fexps[i] - ge[j];
+                    FLINT_ASSERT(j >= gdemote);
+
+                    dd = (k - 1)*fexps[i] - Gexps[j];
 
                     if (!COEFF_IS_MPZ(fi) && !z_mul_checked(&ddd, dd, fi))
                     {
-                        fmpz_addmul_si(S, gc + j, fi);
-                        fmpz_addmul_si(C, gc + j, ddd);
+                        fmpz_addmul_si(S, Gcoeffs + j, fi);
+                        fmpz_addmul_si(C, Gcoeffs + j, ddd);
                     }
                     else
                     {
-                        fmpz_mul(t1, fcoeffs + i, gc + j);
+                        fmpz_mul(t1, fcoeffs + i, Gcoeffs + j);
                         fmpz_add(S, S, t1);
                         fmpz_addmul_si(C, t1, dd);
                     }
@@ -228,10 +220,10 @@ slong _fmpz_mpoly_pow_fps1(
                 x = _mpoly_heap_pop1(heap, &heap_len, cmpmask);
                 do {
                     hind[x->i] |= 1;
-                    Q[Qlen++] = x->i;
-                    Q[Qlen++] = x->j;
-                    /*FLINT_ASSERT(x->j >= gdemote);*/
-                    fmpz_addmul(S, fcoeffs + x->i, gc + x->j);
+                    Q[Qlen++] = i = x->i;
+                    Q[Qlen++] = j = x->j;
+                    FLINT_ASSERT(j >= gdemote);
+                    fmpz_addmul(S, fcoeffs + x->i, Gcoeffs + x->j);
                 } while ((x = x->next) != NULL);
             } while (heap_len > 1 && heap[1].exp == exp);
         }
@@ -253,7 +245,7 @@ slong _fmpz_mpoly_pow_fps1(
                 x->next = NULL;
 
                 hind[x->i] = 2*j + 2;
-                _mpoly_heap_insert1(heap, fexps[i + 1] + ge[j], x,
+                _mpoly_heap_insert1(heap, fexps[i + 1] + Gexps[j], x,
                                                 &next_loc, &heap_len, cmpmask);
             }
 
@@ -266,14 +258,14 @@ slong _fmpz_mpoly_pow_fps1(
                 x->next = NULL;
 
                 hind[x->i] = 2*j + 4;
-                _mpoly_heap_insert1(heap, fexps[i] + ge[j + 1], x,
+                _mpoly_heap_insert1(heap, fexps[i] + Gexps[j + 1], x,
                                                 &next_loc, &heap_len, cmpmask);
             }
         }
 
         j = hind[flen - 1]/2 - 1;
         for ( ; gdemote < j; gdemote++)
-            fmpz_clear(gc + gdemote);
+            fmpz_clear(Gcoeffs + gdemote);
 
         if (!fmpz_is_zero(C))
         {
@@ -297,7 +289,7 @@ slong _fmpz_mpoly_pow_fps1(
                 x->j = glen;
                 x->next = NULL;
                 hind[x->i] = 2*(x->j+1) + 0;
-                _mpoly_heap_insert1(heap, fexps[1] + ge[glen], x,
+                _mpoly_heap_insert1(heap, fexps[1] + Gexps[glen], x,
                                                 &next_loc, &heap_len, cmpmask);
             }
 
@@ -307,16 +299,16 @@ slong _fmpz_mpoly_pow_fps1(
         Alen += !fmpz_is_zero(S);
     }
 
-    (*poly1) = Acoeffs;
-    (*exp1) = Aexps;
+    A->coeffs = Acoeffs;
+    A->exps = Aexps;
 
     fmpz_clear(t1);
     fmpz_clear(temp1);
 
-    flint_free(ge);
     for ( ; gdemote < galloc; gdemote++)
-        fmpz_clear(gc + gdemote);
-    flint_free(gc);
+        fmpz_clear(Gcoeffs + gdemote);
+    flint_free(Gcoeffs);
+    flint_free(Gexps);
 
     TMP_END;
 
@@ -324,279 +316,232 @@ slong _fmpz_mpoly_pow_fps1(
 }
 
 
-slong _fmpz_mpoly_pow_fps(fmpz ** poly1, ulong ** exp1, slong * alloc,
-                 const fmpz * poly2, const ulong * exp2, slong len2, ulong k,
-                              flint_bitcnt_t bits, slong N, const ulong * cmpmask)
+slong _fmpz_mpoly_pow_fps(
+    fmpz_mpoly_t A,
+    const fmpz * Fcoeffs, const ulong * Fexps, slong Flen,
+    ulong k,
+    slong N,
+    const ulong * cmpmask)
 {
-   const slong topbit = (WORD(1) << (FLINT_BITS - 1));
-   const slong mask = ~topbit;
-   slong i, rnext, galloc, gnext, exp_next;
-   slong next_loc;
-   slong next_free, Q_len = 0, heap_len = 2; /* heap zero index unused */
-   mpoly_heap_s * heap;
-   mpoly_heap_t * chain;
-   mpoly_heap_t ** Q, ** reuse;
-   mpoly_heap_t * x;
-   fmpz * Acoeffs = *poly1, * gc = NULL;
-   ulong * Aexps = *exp1, * ge, * fik, * exp, * exps, * exp_copy;
-   ulong ** exp_list;
-   ulong * finalexp, * temp2;
-   slong * largest;
-   fmpz_t t1, t2, C, S, temp1;
-   int first;
-   TMP_INIT;
+    flint_bitcnt_t bits = A->bits;
+    ulong ofmask = (bits > FLINT_BITS) ? 0 : mpoly_overflow_mask_sp(bits);
+    slong i, j, exp_next;
+    slong next_loc;
+    slong heap_len; /* heap zero index unused */
+    mpoly_heap_s * heap;
+    mpoly_heap_t * chain;
+    slong * Q;
+    slong Qlen = 0;
+    slong * hind;
+    mpoly_heap_t * x;
+    fmpz * Acoeffs = A->coeffs;
+    ulong * Aexps = A->exps;
+    slong Alen;
+    fmpz * Gcoeffs;
+    slong Galloc, Glen;
+    ulong * Gexps;
+    ulong * fik, * exps;
+    ulong ** exp_list;
+    ulong * temp2;
+    fmpz_t t1, t2, C;
+    int divides;
+    TMP_INIT;
 
-   if (N == 1)
-      return _fmpz_mpoly_pow_fps1(poly1, exp1, alloc, poly2, exp2, len2, k,
-                                                             bits, cmpmask[0]);
+    if (N == 1)
+        return _fmpz_mpoly_pow_fps1(A, Fcoeffs, Fexps, Flen, k, cmpmask[0]);
 
-   TMP_START;
+    TMP_START;
 
-   next_loc = len2 + 4;   /* something bigger than heap can ever be */
-   heap = (mpoly_heap_s *) TMP_ALLOC((len2 + 1)*sizeof(mpoly_heap_s));
-   /* 2x as we pull from heap and insert more before processing pulled ones */
-   chain = (mpoly_heap_t *) TMP_ALLOC(2*len2*sizeof(mpoly_heap_t));
-   reuse = (mpoly_heap_t **) TMP_ALLOC(2*len2*sizeof(mpoly_heap_t *));
-   Q = (mpoly_heap_t **) TMP_ALLOC(len2*sizeof(mpoly_heap_t *));
-   /* we add 1 to all entries of largest to free up the value 0 */
-   largest = (slong *) TMP_ALLOC(len2*sizeof(slong));
-   exps = (ulong *) TMP_ALLOC((len2 + 1)*N*sizeof(ulong));
-   exp_list = (ulong **) TMP_ALLOC((len2 + 1)*sizeof(ulong *));
-   finalexp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-   temp2 = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-   exp_copy = (ulong *) TMP_ALLOC(N*sizeof(ulong));
+    next_loc = Flen + 4;   /* something bigger than heap can ever be */
+    heap = (mpoly_heap_s *) TMP_ALLOC((Flen + 1)*sizeof(mpoly_heap_s));
+    chain = TMP_ARRAY_ALLOC(Flen, mpoly_heap_t);
+    exps = (ulong *) TMP_ALLOC((Flen + 1)*N*sizeof(ulong));
+    exp_list = (ulong **) TMP_ALLOC((Flen + 1)*sizeof(ulong *));
+    fik = (ulong *) TMP_ALLOC(N*Flen*sizeof(ulong));
+    temp2 = (ulong *) TMP_ALLOC(N*sizeof(ulong));
+    Q = TMP_ARRAY_ALLOC(3*Flen, slong);
+    hind = Q + 2*Flen; /* space for heap indices */
 
-   fmpz_init(t1);
-   fmpz_init(t2);
-   fmpz_init(C);
-   fmpz_init(S);
-   fmpz_init(temp1);
+    for (i = 0; i < Flen; i++)
+        mpoly_monomial_mul_ui_mp(fik + i*N, Fexps + i*N, N, k - 1);
 
-   for (i = 0; i < len2 + 1; i++)
-      exp_list[i] = exps + i*N;
+    for (i = 0; i < Flen; i++)
+        hind[i] = 1;
 
-   exp_next = 0;
+    exp_next = 0;
+    for (i = 0; i < Flen + 1; i++)
+        exp_list[i] = exps + N*i;
 
-   for (i = 0; i < 2*len2; i++)
-      reuse[i] = chain + i;
+    fmpz_init(t1);
+    fmpz_init(t2);
+    fmpz_init(C);
 
-   galloc = k*(len2 - 1) + 1;
-   ge = (ulong *) flint_malloc(galloc*sizeof(ulong)*N);
-   gnext = 0;
-   rnext = 0;
+    _fmpz_mpoly_fit_length(&Acoeffs, &Aexps, &A->alloc, 2, N);
 
+    Galloc = 2*Flen + 3;
+    Gexps = (ulong *) flint_malloc(Galloc*sizeof(ulong)*N);
+    Gcoeffs = (fmpz *) flint_calloc(Galloc, sizeof(fmpz));
 
-    mpoly_monomial_mul_ui_mp(ge + 0, exp2 + 0, N, k - 1);
-    mpoly_monomial_mul_ui_mp(Aexps + 0, exp2 + 0, N, k);
+    mpoly_monomial_mul_ui_mp(Gexps + 0, Fexps + 0, N, k - 1);
+    mpoly_monomial_mul_ui_mp(Aexps + 0, Fexps + 0, N, k);
+    fmpz_pow_ui(Gcoeffs + 0, Fcoeffs + 0, k - 1);
+    fmpz_mul(Acoeffs + 0, Gcoeffs + 0, Fcoeffs + 0);
+    Glen = 1;
+    Alen = 1;
 
-   gc = (fmpz *) flint_calloc(galloc, sizeof(fmpz));
-   fmpz_pow_ui(gc + 0, poly2 + 0, k - 1);
-   fmpz_mul(Acoeffs + 0, gc + 0, poly2 + 0);
+    hind[1] = 2*1 + 0;
+    x = chain + 1;
+    x->i = 1;
+    x->j = 0;
+    x->next = NULL;
+    heap[1].next = x;
+    heap[1].exp = exp_list[exp_next++];
+    mpoly_monomial_add_mp(heap[1].exp, Fexps + N, Gexps + 0, N);
+    heap_len = 2;
 
-   next_free = 0;
+    while (heap_len > 1)
+    {
+        fmpz * const S = Acoeffs + Alen;
 
-   x = reuse[next_free++];
-   x->i = 1;
-   x->j = 0;
-   x->next = NULL;
+        mpoly_monomial_set(Aexps + N*Alen, heap[1].exp, N);
+        mpoly_monomial_sub_mp(Gexps + N*Glen, Aexps + N*Alen, Fexps + 0, N);
 
-   heap[1].next = x;
-   heap[1].exp = exp_list[exp_next++];
+        if (bits > FLINT_BITS)
+            divides = !mpoly_monomial_overflows_mp(Gexps + N*Glen, N, bits);
+        else
+            divides = !mpoly_monomial_overflows(Gexps + N*Glen, N, ofmask);
 
-    mpoly_monomial_add_mp(heap[1].exp, exp2 + N, ge + 0, N);
+        fmpz_zero(C);
+        fmpz_zero(S);
 
-    for (i = 0; i < len2; i++)
-        largest[i] = topbit;
-    largest[1] = 1;
+        while (heap_len > 1 && mpoly_monomial_equal(heap[1].exp, Aexps + N*Alen, N))
+        {
+            exp_list[--exp_next] = heap[1].exp;
+            x = _mpoly_heap_pop(heap, &heap_len, N, cmpmask);
 
-    fik = (ulong *) TMP_ALLOC(N*len2*sizeof(ulong));
+            do {
+                Q[Qlen++] = i = x->i;
+                Q[Qlen++] = j = x->j;
+                hind[i] |= 1;
 
-    for (i = 0; i < len2; i++)
-        mpoly_monomial_mul_ui_mp(fik + i*N, exp2 + i*N, N, k - 1);
-
-    mpoly_monomial_set(finalexp, exp2, N);
-
-   while (heap_len > 1)
-   {
-      exp = heap[1].exp;
-      mpoly_monomial_set(exp_copy, exp, N);
-
-      rnext++;
-      gnext++;
-
-      if (rnext >= *alloc)
-      {
-         Acoeffs = (fmpz *) flint_realloc(Acoeffs, 2*sizeof(fmpz)*(*alloc));
-         Aexps = (ulong *) flint_realloc(Aexps, 2*N*sizeof(ulong)*(*alloc));
-         flint_mpn_zero(Acoeffs + *alloc, *alloc);
-         (*alloc) *= 2;
-      }
-
-      if (gnext >= galloc)
-      {
-         ge = (ulong *) flint_realloc(ge, 2*N*sizeof(ulong)*galloc);
-         gc = (fmpz *) flint_realloc(gc, 2*sizeof(fmpz)*galloc);
-         flint_mpn_zero(gc + galloc, galloc);
-         galloc *= 2;
-      }
-
-      first = 1;
-
-      fmpz_zero(C);
-      fmpz_zero(S);
-
-      while (heap_len > 1 && mpoly_monomial_equal(heap[1].exp, exp, N))
-      {
-         exp_list[--exp_next] = heap[1].exp;
-         x = _mpoly_heap_pop(heap, &heap_len, N, cmpmask);
-
-         largest[x->i] |= topbit;
-
-         fmpz_mul(t1, poly2 + x->i, gc + x->j);
-         fmpz_add(S, S, t1);
-
-         if (!mpoly_monomial_gt(finalexp, exp, N, cmpmask))
-         {
-            mpn_sub_n(temp2, fik + x->i*N, ge + x->j*N, N);
-            fmpz_set_signed_ui_array(t2, temp2, N);
-            fmpz_addmul(C, t1, t2);
-         }
-
-         if (first)
-         {
-            mpoly_monomial_sub_mp(ge + gnext*N, exp, exp2 + 0, N);
-            first = 0; 
-         }
+                fmpz_mul(t1, Fcoeffs + x->i, Gcoeffs + x->j);
+                fmpz_add(S, S, t1);
+                if (divides)
+                {
+                    mpn_sub_n(temp2, fik + x->i*N, Gexps + x->j*N, N);
+                    fmpz_set_signed_ui_array(t2, temp2, N);
+                    fmpz_addmul(C, t1, t2);
+                }
+            } while ((x = x->next) != NULL);
+        }
       
-         Q[Q_len++] = x;
+        while (Qlen > 0)
+        {
+            /* take node from store */
+            j = Q[--Qlen];
+            i = Q[--Qlen];
 
-         while ((x = x->next) != NULL)
-         {
-            largest[x->i] |= topbit;
-
-            fmpz_mul(t1, poly2 + x->i, gc + x->j);
-            fmpz_add(S, S, t1);
-
-            if (!mpoly_monomial_gt(finalexp, exp, N, cmpmask))
+            if (i + 1 < Flen && hind[i + 1] == 2*j + 1)
             {
-               mpn_sub_n(temp2, fik + x->i*N, ge + x->j*N, N);
-               fmpz_set_signed_ui_array(t2, temp2, N);
-               fmpz_addmul(C, t1, t2);
+                x = chain + i + 1;
+                x->i = i + 1;
+                x->j = j;
+                x->next = NULL;
+
+                hind[x->i] = 2*j + 2;
+
+                mpoly_monomial_add_mp(exp_list[exp_next], Fexps + N*(i + 1),
+                                                          Gexps + N*j, N);
+
+                exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
+                                             &next_loc, &heap_len, N, cmpmask);
             }
 
-            Q[Q_len++] = x;
-         }
-      }
-      
-      while (Q_len > 0)
-      {
-         slong i, j;
+            if (j + 1 < Glen && hind[i] < 2*j + 4)
+            {
+                x = chain + i;
+                x->i = i;
+                x->j = j + 1;
+                x->next = NULL;
 
-         x = Q[--Q_len];
-         i = x->i;
-         j = x->j;
+                hind[x->i] = 2*j + 4;
 
-         if (i < len2 - 1 && largest[i + 1] == (j | topbit))
-         {
-            x->i++;
-            x->next = NULL;
+                mpoly_monomial_add_mp(exp_list[exp_next], Fexps + i*N,
+                                                          Gexps + N*(j + 1), N);
 
-            mpoly_monomial_add_mp(exp_list[exp_next], exp2 + (i + 1)*N, ge + j*N, N);
-
-            exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
+                exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
-            largest[i + 1] = j + 1;
-         }
-         else
-         {
-            reuse[--next_free] = x;
-         }
+            }
+        }
 
-         if (j < gnext - 1 && (largest[i] & mask) < j + 2)
-         {
-            x = reuse[next_free++];
+        if (!fmpz_is_zero(C))
+        {
+            mpoly_monomial_mul_ui_mp(temp2, Fexps + 0, N, k);
+            mpn_sub_n(temp2, Aexps + N*Alen, temp2, N);
+            fmpz_set_signed_ui_array(t2, temp2, N);
 
-            x->i = i;
-            x->j = j + 1;
-            x->next = NULL;
+            fmpz_divexact(t1, C, t2);
+            fmpz_add(S, S, t1);
+            fmpz_divexact(Gcoeffs + Glen, t1, Fcoeffs + 0);
 
-            mpoly_monomial_add_mp(exp_list[exp_next], exp2 + i*N, ge + (j + 1)*N, N);
+            if ((hind[1] & 1) != 0)
+            {
+                x = chain + 1;
 
-            exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
+                x->i = 1;
+                x->j = Glen;
+                x->next = NULL;
+
+                hind[x->i] = 2*(Glen + 1) + 0;
+
+                mpoly_monomial_add_mp(exp_list[exp_next], Fexps + N,
+                                                          Gexps + N*Glen, N);
+
+                exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
-            largest[i] = j + 2;
-         }
-      }
+            }
 
-      if (!fmpz_is_zero(C))
-      {
-         mpoly_monomial_mul_ui_mp(temp2, exp2 + 0, N, k);
+            Glen++;
 
-         mpn_sub_n(temp2, exp_copy, temp2, N);
-         fmpz_set_signed_ui_array(t2, temp2, N);
-         fmpz_divexact(temp1, C, t2);
-         fmpz_add(S, S, temp1);
-         fmpz_divexact(gc + gnext, temp1, poly2 + 0);
+            if (Glen >= Galloc)
+            {
+                Gexps = (ulong *) flint_realloc(Gexps, 2*N*sizeof(ulong)*Galloc);
+                Gcoeffs = (fmpz *) flint_realloc(Gcoeffs, 2*sizeof(fmpz)*Galloc);
+                flint_mpn_zero(Gcoeffs + Galloc, Galloc);
+                Galloc *= 2;
+            }
+        }
 
-         if ((largest[1] & topbit) != 0)
-         {
-            x = reuse[next_free++];
+        Alen += !fmpz_is_zero(Acoeffs + Alen);
+        _fmpz_mpoly_fit_length(&Acoeffs, &Aexps, &A->alloc, Alen+1, N);
+    }
 
-            x->i = 1;
-            x->j = gnext;
-            x->next = NULL;
-
-            mpoly_monomial_add_mp(exp_list[exp_next], exp2 + N, ge + gnext*N, N);
-
-            exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
-                                             &next_loc, &heap_len, N, cmpmask);
- 
-            largest[1] = gnext + 1;
-         }
-      }
-
-      if (!fmpz_is_zero(S))
-      {
-         fmpz_set(Acoeffs + rnext, S);
-         mpoly_monomial_add_mp(Aexps + rnext*N, ge + gnext*N, exp2 + 0, N);
-
-      } else
-         rnext--;
-
-      if (fmpz_is_zero(C))
-         gnext--;
-   }
-
-   rnext++;
-
-   (*poly1) = Acoeffs;
-   (*exp1) = Aexps;
+    A->coeffs = Acoeffs;
+    A->exps = Aexps;
    
-   fmpz_clear(t1);
-   fmpz_clear(t2);
-   fmpz_clear(C);
-   fmpz_clear(S);
-   fmpz_clear(temp1);
+    fmpz_clear(t1);
+    fmpz_clear(t2);
+    fmpz_clear(C);
 
-   flint_free(ge);
-   for (i = 0; i < galloc; i++)
-      fmpz_clear(gc + i);
-   flint_free(gc);
+    for (i = 0; i < Galloc; i++)
+        fmpz_clear(Gcoeffs + i);
+    flint_free(Gcoeffs);
+    flint_free(Gexps);
 
-   TMP_END;
+    TMP_END;
 
-   return rnext;
+    return Alen;
 }
 
 void fmpz_mpoly_pow_fps(fmpz_mpoly_t A, const fmpz_mpoly_t B,
                                            ulong k, const fmpz_mpoly_ctx_t ctx)
 {
-    slong i, N, len = 0;
+    slong i, N, len;
     fmpz * maxBfields;
-    flint_bitcnt_t exp_bits;
+    flint_bitcnt_t Abits;
     ulong * cmpmask;
-    ulong * Bexp = B->exps;
-    int freeBexp = 0;
+    ulong * Bexps;
+    int freeBexps;
     TMP_INIT;
 
     FLINT_ASSERT(k >= 2);
@@ -611,64 +556,61 @@ void fmpz_mpoly_pow_fps(fmpz_mpoly_t A, const fmpz_mpoly_t B,
     mpoly_max_fields_fmpz(maxBfields, B->exps, B->length, B->bits, ctx->minfo);
     _fmpz_vec_scalar_mul_ui(maxBfields, maxBfields, ctx->minfo->nfields, k);
 
-    exp_bits = _fmpz_vec_max_bits(maxBfields, ctx->minfo->nfields);
-    exp_bits = FLINT_MAX(MPOLY_MIN_BITS, exp_bits + 1);
-    exp_bits = FLINT_MAX(exp_bits, B->bits);
-    exp_bits = mpoly_fix_bits(exp_bits, ctx->minfo);
-
-    for (i = 0; i < ctx->minfo->nfields; i++)
-        fmpz_clear(maxBfields + i);
-
-    N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
-
-    if (exp_bits > B->bits)
-    {
-       freeBexp = 1;
-       Bexp = (ulong *) flint_malloc(N*B->length*sizeof(ulong));
-       mpoly_repack_monomials(Bexp, exp_bits, B->exps, B->bits,
-                                                        B->length, ctx->minfo);
-    }
+    Abits = _fmpz_vec_max_bits(maxBfields, ctx->minfo->nfields);
+    Abits = FLINT_MAX(MPOLY_MIN_BITS, Abits + 1);
+    Abits = FLINT_MAX(Abits, B->bits);
+    Abits = mpoly_fix_bits(Abits, ctx->minfo);
+    N = mpoly_words_per_exp(Abits, ctx->minfo);
 
     if (B->length == 1)
     {
-        fmpz_mpoly_fit_length(A, 1, ctx);
-        fmpz_mpoly_fit_bits(A, exp_bits, ctx);
-        A->bits = exp_bits;
+        /* powering a monomial */
+        fmpz_mpoly_fit_length_reset_bits(A, 1, Abits, ctx);
 
-        fmpz_pow_ui(A->coeffs + 0, B->coeffs + 0, k);
-
-        if (exp_bits <= FLINT_BITS)
-            mpoly_monomial_mul_ui(A->exps, Bexp, N, k);
+        if (B->bits == Abits && B != A)
+            mpoly_monomial_mul_ui_mp(A->exps, B->exps, N, k);
         else
-            mpoly_monomial_mul_ui_mp(A->exps, Bexp, N, k);
-
+            mpoly_pack_vec_fmpz(A->exps, maxBfields, Abits,
+                                                       ctx->minfo->nfields, 1);
+        fmpz_pow_ui(A->coeffs + 0, B->coeffs + 0, k);
         len = 1;
         goto cleanup;
     }
 
+    freeBexps = 0;
+    Bexps = B->exps;
+    if (Abits > B->bits)
+    {
+       freeBexps = 1;
+       Bexps = (ulong *) flint_malloc(N*B->length*sizeof(ulong));
+       mpoly_repack_monomials(Bexps, Abits, B->exps, B->bits,
+                                                        B->length, ctx->minfo);
+    }
+
+    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
+    mpoly_get_cmpmask(cmpmask, N, Abits, ctx->minfo);
+
     if (A == B)
     {
         fmpz_mpoly_t T;
-        fmpz_mpoly_init3(T, k*(B->length - 1) + 1, exp_bits, ctx);
-        len = _fmpz_mpoly_pow_fps(&T->coeffs, &T->exps, &T->alloc,
-                          B->coeffs, Bexp, B->length, k, exp_bits, N, cmpmask);
-
+        fmpz_mpoly_init3(T, k*(B->length - 1) + 1, Abits, ctx);
+        len = _fmpz_mpoly_pow_fps(T, B->coeffs, Bexps, B->length, k, N, cmpmask);
         fmpz_mpoly_swap(T, A, ctx);
         fmpz_mpoly_clear(T, ctx);
     }
     else
     {
-        fmpz_mpoly_fit_length_reset_bits(A, k*(B->length - 1) + 1, exp_bits, ctx);
-        len = _fmpz_mpoly_pow_fps(&A->coeffs, &A->exps, &A->alloc,
-                          B->coeffs, Bexp, B->length, k, exp_bits, N, cmpmask);
+        fmpz_mpoly_fit_length_reset_bits(A, k*(B->length - 1) + 1, Abits, ctx);
+        len = _fmpz_mpoly_pow_fps(A, B->coeffs, Bexps, B->length, k, N, cmpmask);
     }
+
+    if (freeBexps)
+        flint_free(Bexps);
 
 cleanup:
 
-    if (freeBexp)
-        flint_free(Bexp);
+    for (i = 0; i < ctx->minfo->nfields; i++)
+        fmpz_clear(maxBfields + i);
 
     _fmpz_mpoly_set_length(A, len, ctx);
 

--- a/fmpz_mpoly/pow_fps.c
+++ b/fmpz_mpoly/pow_fps.c
@@ -383,7 +383,7 @@ static slong _fmpz_mpoly_pow_fps(
                 Q[Qlen++] = j = x->j;
                 hind[i] |= 1;
 
-                FLINT_ASSERT(j + 1 >= Gdemote);
+                FLINT_ASSERT(j >= Gdemote);
 
                 fmpz_mul(t1, Fcoeffs + i, Gcoeffs + j);
                 fmpz_add(S, S, t1);

--- a/fmpz_mpoly/test/t-pow_fps.c
+++ b/fmpz_mpoly/test/t-pow_fps.c
@@ -44,14 +44,14 @@ void fmpz_mpoly_pow_naive(fmpz_mpoly_t res, fmpz_mpoly_t f,
 int
 main(void)
 {
-    slong i, j;
+    slong i, j, tmul = 10;
     FLINT_TEST_INIT(state);
 
     flint_printf("pow_fps....");
     fflush(stdout);
 
     /* Check pow_fps against pow_naive */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 10*tmul*flint_test_multiplier(); i++)
     {
         fmpz_mpoly_ctx_t ctx;
         fmpz_mpoly_t f, g, h;
@@ -78,6 +78,9 @@ main(void)
 
         for (j = 0; j < 4; j++)
         {
+
+flint_printf("i = %wd, j = %wd\n", i, j);
+
             fmpz_mpoly_randtest_bits(f, state, len1, coeff_bits, exp_bits1, ctx);
             fmpz_mpoly_randtest_bits(g, state, len, coeff_bits, exp_bits, ctx);
             fmpz_mpoly_randtest_bits(h, state, len, coeff_bits, exp_bits, ctx);
@@ -105,7 +108,7 @@ main(void)
     }
 
     /* Check aliasing */
-    for (i = 0; i < 10 * flint_test_multiplier(); i++)
+    for (i = 0; i < tmul * flint_test_multiplier(); i++)
     {
         fmpz_mpoly_ctx_t ctx;
         fmpz_mpoly_t f, g;
@@ -123,13 +126,15 @@ main(void)
         len = n_randint(state, 10);
         len1 = n_randint(state, 10);
 
-        exp_bits = n_randint(state, 600) + 2;
-        exp_bits1 = n_randint(state, 600) + 10;
+        exp_bits = n_randint(state, 400) + 2;
+        exp_bits1 = n_randint(state, 400) + 10;
 
         coeff_bits = n_randint(state, 200);
 
         for (j = 0; j < 4; j++)
         {
+flint_printf("i = %wd, j = %wd\n", i, j);
+
             fmpz_mpoly_randtest_bits(f, state, len1, coeff_bits, exp_bits1, ctx);
             fmpz_mpoly_randtest_bits(g, state, len, coeff_bits, exp_bits, ctx);
 

--- a/fmpz_mpoly/test/t-pow_fps.c
+++ b/fmpz_mpoly/test/t-pow_fps.c
@@ -15,6 +15,7 @@
 #include "fmpz_mpoly.h"
 #include "fmpz_mpoly_factor.h"
 
+
 void fmpz_mpoly_pow_naive(fmpz_mpoly_t res, fmpz_mpoly_t f,
                                                  slong n, fmpz_mpoly_ctx_t ctx)
 {
@@ -44,7 +45,7 @@ void fmpz_mpoly_pow_naive(fmpz_mpoly_t res, fmpz_mpoly_t f,
 int
 main(void)
 {
-    slong i, j, tmul = 10;
+    slong i, j, tmul = 5;
     FLINT_TEST_INIT(state);
 
     flint_printf("pow_fps....");
@@ -78,9 +79,6 @@ main(void)
 
         for (j = 0; j < 4; j++)
         {
-
-flint_printf("i = %wd, j = %wd\n", i, j);
-
             fmpz_mpoly_randtest_bits(f, state, len1, coeff_bits, exp_bits1, ctx);
             fmpz_mpoly_randtest_bits(g, state, len, coeff_bits, exp_bits, ctx);
             fmpz_mpoly_randtest_bits(h, state, len, coeff_bits, exp_bits, ctx);
@@ -133,8 +131,6 @@ flint_printf("i = %wd, j = %wd\n", i, j);
 
         for (j = 0; j < 4; j++)
         {
-flint_printf("i = %wd, j = %wd\n", i, j);
-
             fmpz_mpoly_randtest_bits(f, state, len1, coeff_bits, exp_bits1, ctx);
             fmpz_mpoly_randtest_bits(g, state, len, coeff_bits, exp_bits, ctx);
 

--- a/nmod_mpoly.h
+++ b/nmod_mpoly.h
@@ -895,6 +895,13 @@ FLINT_DLL int _nmod_mpoly_mul_dense(nmod_mpoly_t P,
 
 /* Powering ******************************************************************/
 
+FLINT_DLL void _nmod_mpoly_pow_rmul(nmod_mpoly_t A, const mp_limb_t * Bcoeffs,
+                            const ulong * Bexps, slong Blen, ulong k, slong N,
+                            const ulong * cmpmask, nmod_t mod, nmod_mpoly_t T);
+
+FLINT_DLL void nmod_mpoly_pow_rmul(nmod_mpoly_t A, const nmod_mpoly_t B,
+                                          ulong k, const nmod_mpoly_ctx_t ctx);
+
 FLINT_DLL int nmod_mpoly_pow_fmpz(nmod_mpoly_t A, const nmod_mpoly_t B,
                                    const fmpz_t k, const nmod_mpoly_ctx_t ctx);
 
@@ -1040,9 +1047,6 @@ FLINT_DLL void nmod_mpolyl_lead_coeff(nmod_mpoly_t c, const nmod_mpoly_t A,
 
 FLINT_DLL int nmod_mpolyl_content(nmod_mpoly_t g, const nmod_mpoly_t A,
                                    slong num_vars, const nmod_mpoly_ctx_t ctx);
-
-FLINT_DLL void nmod_mpoly_pow_rmul(nmod_mpoly_t A, const nmod_mpoly_t B,
-                                          ulong k, const nmod_mpoly_ctx_t ctx);
 
 FLINT_DLL void _nmod_mpoly_to_nmod_poly_deflate(nmod_poly_t A, const nmod_mpoly_t B,
                         slong var, const ulong * Bshift, const ulong * Bstride,

--- a/nmod_mpoly/pow_rmul.c
+++ b/nmod_mpoly/pow_rmul.c
@@ -11,6 +11,52 @@
 
 #include "nmod_mpoly.h"
 
+void _nmod_mpoly_pow_rmul(
+    nmod_mpoly_t A,
+    const mp_limb_t * Bcoeffs, const ulong * Bexps, slong Blen,
+    ulong k,
+    slong N,
+    const ulong * cmpmask,
+    nmod_t mod,
+    nmod_mpoly_t T)
+{
+    flint_bitcnt_t bits = A->bits;
+
+    FLINT_ASSERT(bits == T->bits);
+
+    _nmod_mpoly_fit_length(&A->coeffs, &A->coeffs_alloc,
+                           &A->exps, &A->exps_alloc, N, Blen + 2);
+
+    if (k >= 2)
+    {
+        _nmod_mpoly_mul_johnson(A, Bcoeffs, Bexps, Blen,
+                                   Bcoeffs, Bexps, Blen,
+                                   bits, N, cmpmask, mod);
+        k -= 2;
+        while (k >= 1)
+        {
+            _nmod_mpoly_mul_johnson(T, A->coeffs, A->exps, A->length,
+                                       Bcoeffs, Bexps, Blen,
+                                       bits, N, cmpmask, mod);
+            nmod_mpoly_swap(A, T, NULL);
+            k -= 1;
+        }
+    }
+    else if (k == 1)
+    {
+        FLINT_ASSERT(A->coeffs_alloc >= Blen);
+        _nmod_vec_set(A->coeffs, Bcoeffs, Blen);
+        mpoly_copy_monomials(A->exps, Bexps, Blen, N);
+        A->length = Blen;
+    }
+    else
+    {
+        mpoly_monomial_zero(A->exps, N);
+        A->coeffs[0] = 1;
+        A->length = 1;
+    }
+}
+
 void nmod_mpoly_pow_rmul(nmod_mpoly_t A, const nmod_mpoly_t B,
                                          ulong k, const nmod_mpoly_ctx_t ctx)
 {
@@ -21,17 +67,17 @@ void nmod_mpoly_pow_rmul(nmod_mpoly_t A, const nmod_mpoly_t B,
     {
         nmod_mpoly_pow_rmul(T, A, k, ctx);
         nmod_mpoly_swap(T, A, ctx);
-        goto cleanup;
+    }
+    else
+    {
+        nmod_mpoly_one(A, ctx);
+        while (k > 0)
+        { 
+            nmod_mpoly_mul_johnson(T, A, B, ctx);
+            nmod_mpoly_swap(A, T, ctx);
+            k -= 1;
+        }
     }
 
-    nmod_mpoly_set_ui(A, 1, ctx);
-    while (k >= 1)
-    { 
-        nmod_mpoly_mul_johnson(T, A, B, ctx);
-        nmod_mpoly_swap(A, T, ctx);
-        k -= 1;
-    }
-
-cleanup:
     nmod_mpoly_clear(T, ctx);
 }

--- a/nmod_mpoly/pow_ui.c
+++ b/nmod_mpoly/pow_ui.c
@@ -77,18 +77,11 @@ int nmod_mpoly_pow_ui(nmod_mpoly_t A, const nmod_mpoly_t B,
                                                        ctx->minfo->nfields, 1);
 
         A->coeffs[0] = nmod_pow_ui(B->coeffs[0], k, ctx->mod);
+
         _nmod_mpoly_set_length(A, A->coeffs[0] != 0, ctx);
 
-        for (i = 0; i < ctx->minfo->nfields; i++)
-            fmpz_clear(maxBfields + i);
-
-        TMP_END;
-
-        return 1;
+        goto cleanup;
     }
-
-    for (i = 0; i < ctx->minfo->nfields; i++)
-        fmpz_clear(maxBfields + i);
 
     freeBexps = 0;
     Bexps = B->exps;
@@ -172,6 +165,11 @@ int nmod_mpoly_pow_ui(nmod_mpoly_t A, const nmod_mpoly_t B,
 
     if (freeBexps)
         flint_free(Bexps);
+
+cleanup:
+
+    for (i = 0; i < ctx->minfo->nfields; i++)
+        fmpz_clear(maxBfields + i);
 
     TMP_END;
 

--- a/nmod_mpoly/pow_ui.c
+++ b/nmod_mpoly/pow_ui.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2018 Daniel Schultz
+    Copyright (C) 2018,2021 Daniel Schultz
 
     This file is part of FLINT.
 
@@ -10,20 +10,18 @@
 */
 
 #include "nmod_mpoly.h"
-#include "fmpz_mpoly.h"
 
 int nmod_mpoly_pow_ui(nmod_mpoly_t A, const nmod_mpoly_t B,
                                            ulong k, const nmod_mpoly_ctx_t ctx)
 {
-    int success = 1;
     slong i, exp_bits, N;
     fmpz * maxBfields;
     ulong * cmpmask;
-    ulong * Bexp;
-    int freeBexp;
-    fmpz_mpoly_t T;
-    slong Tlen;
-    fmpz * Bcoeffs_fmpz;
+    ulong * Bexps;
+    int freeBexps;
+    nmod_mpoly_t T, Atemp;
+    nmod_mpoly_struct * R;
+
     TMP_INIT;
 
     if (k == 0)
@@ -46,18 +44,8 @@ int nmod_mpoly_pow_ui(nmod_mpoly_t A, const nmod_mpoly_t B,
 
     if (k == 2)
     {
-        nmod_mpoly_mul_johnson(A, B, B, ctx);
+        nmod_mpoly_mul(A, B, B, ctx);
         return 1;
-    }
-
-    if (A == B)
-    {
-        nmod_mpoly_t T;
-        nmod_mpoly_init(T, ctx);
-        success = nmod_mpoly_pow_ui(T, B, k, ctx);
-        nmod_mpoly_swap(A, T, ctx);
-        nmod_mpoly_clear(T, ctx);
-        return success;
     }
 
     TMP_START;
@@ -71,184 +59,122 @@ int nmod_mpoly_pow_ui(nmod_mpoly_t A, const nmod_mpoly_t B,
     _fmpz_vec_scalar_mul_ui(maxBfields, maxBfields, ctx->minfo->nfields, k);
 
     exp_bits = _fmpz_vec_max_bits(maxBfields, ctx->minfo->nfields);
+
     exp_bits = FLINT_MAX(MPOLY_MIN_BITS, exp_bits + 1);
     exp_bits = FLINT_MAX(exp_bits, B->bits);
     exp_bits = mpoly_fix_bits(exp_bits, ctx->minfo);
-
-    for (i = 0; i < ctx->minfo->nfields; i++)
-        fmpz_clear(maxBfields + i);
-
     N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-
-    freeBexp = 0;
-    Bexp = B->exps;
-    if (exp_bits > B->bits)
-    {
-        freeBexp = 1;
-        Bexp = (ulong *) flint_malloc(N*B->length*sizeof(ulong));
-        mpoly_repack_monomials(Bexp, exp_bits, B->exps, B->bits,
-                                                        B->length, ctx->minfo);
-    }
 
     if (B->length == 1)
     {
         /* powering a monomial */
         nmod_mpoly_fit_length_reset_bits(A, 1, exp_bits, ctx);
 
-        if (exp_bits <= FLINT_BITS)
-            mpoly_monomial_mul_ui(A->exps, Bexp, N, k);
+        if (B->bits == exp_bits && B != A)
+            mpoly_monomial_mul_ui_mp(A->exps, B->exps, N, k);
         else
-            mpoly_monomial_mul_ui_mp(A->exps, Bexp, N, k);
+            mpoly_pack_vec_fmpz(A->exps, maxBfields, exp_bits,
+                                                       ctx->minfo->nfields, 1);
 
         A->coeffs[0] = nmod_pow_ui(B->coeffs[0], k, ctx->mod);
         _nmod_mpoly_set_length(A, A->coeffs[0] != 0, ctx);
+
+        for (i = 0; i < ctx->minfo->nfields; i++)
+            fmpz_clear(maxBfields + i);
+
+        TMP_END;
+
+        return 1;
+    }
+
+    for (i = 0; i < ctx->minfo->nfields; i++)
+        fmpz_clear(maxBfields + i);
+
+    freeBexps = 0;
+    Bexps = B->exps;
+    if (exp_bits > B->bits)
+    {
+        freeBexps = 1;
+        Bexps = (ulong *) flint_malloc(N*B->length*sizeof(ulong));
+        mpoly_repack_monomials(Bexps, exp_bits, B->exps, B->bits,
+                                                        B->length, ctx->minfo);
+    }
+
+    if (A == B)
+    {
+        nmod_mpoly_init3(Atemp, B->length, exp_bits, ctx);
+        R = Atemp;
     }
     else
     {
-        cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-        mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
+        nmod_mpoly_fit_length_reset_bits(A, B->length, exp_bits, ctx);
+        R = A;
+    }
 
-        T->alloc = k*(B->length - 1) + 1;
-        T->coeffs = (fmpz *) flint_calloc(T->alloc, sizeof(fmpz));
-        T->exps   = (ulong *) flint_malloc(T->alloc*N*sizeof(ulong));
-        T->length = 0;
-        T->bits = exp_bits;
+    nmod_mpoly_init3(T, B->length, exp_bits, ctx);
 
-        Bcoeffs_fmpz = _fmpz_vec_init(B->length);
-        _fmpz_vec_set_nmod_vec(Bcoeffs_fmpz, B->coeffs, B->length, ctx->mod);
+    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
+    mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
 
-        if (ctx->mod.n > 99999 || !n_is_prime(ctx->mod.n))
+    if (ctx->mod.n > 99999 || !n_is_prime(ctx->mod.n))
+    {
+        _nmod_mpoly_pow_rmul(R, B->coeffs, Bexps, B->length, k,
+                                                      N, cmpmask, ctx->mod, T);
+    }
+    else
+    {
+        ulong ne, kmodn;
+        nmod_mpoly_t S;
+
+        nmod_mpoly_init3(S, B->length, exp_bits, ctx);
+
+        mpoly_monomial_zero(R->exps, N);
+        R->coeffs[0] = 1;
+        R->length = 1;
+
+        for (ne = 1; k > 0; k = k/ctx->mod.n, ne = ne * ctx->mod.n)
         {
-            slong Alen, Tlen;
-            ulong limit = (ulong)(WORD_MAX)/(ulong)(2*sizeof(fmpz));
+            NMOD_RED(kmodn, k, ctx->mod);
 
-            if (B->length > 1 && k > limit/(ulong)(B->length - 1))
+            /* R *= B^(n^e*(k%n)) */
+
+            if (kmodn == 0)
+                continue;
+
+            _nmod_mpoly_pow_rmul(S, B->coeffs, Bexps, B->length, kmodn,
+                                                      N, cmpmask, ctx->mod, T);
+
+            mpoly_monomial_mul_ui_mp(S->exps, S->exps, N*S->length, ne);
+
+            if (nmod_mpoly_is_one(R, ctx))
             {
-                success = 0;
+                nmod_mpoly_swap(R, S, ctx);
             }
             else
             {
-                Tlen = _fmpz_mpoly_pow_fps(&T->coeffs, &T->exps, &T->alloc,
-                           Bcoeffs_fmpz, Bexp, B->length, k, exp_bits, N, cmpmask);
-
-                nmod_mpoly_fit_length_reset_bits(A, Tlen, exp_bits, ctx);
-
-                Alen = 0;
-                for (i = 0; i < Tlen; i++)
-                {
-                    A->coeffs[Alen] = fmpz_fdiv_ui(T->coeffs + i, ctx->mod.n);
-                    mpoly_monomial_set(A->exps + N*Alen, T->exps + N*i, N);
-                    Alen += (A->coeffs[Alen] != UWORD(0));
-                }
-
-                _nmod_mpoly_set_length(A, Alen, ctx);
+                _nmod_mpoly_mul_johnson(T, R->coeffs, R->exps, R->length,
+                                           S->coeffs, S->exps, S->length,
+                                           exp_bits, N, cmpmask, ctx->mod);
+                nmod_mpoly_swap(R, T, ctx);
             }
         }
-        else
-        {
-            ulong ne;
-            slong Slen;
-            nmod_mpoly_t S, R, U;
 
-            nmod_mpoly_init3(S, B->length, exp_bits, ctx);
-            nmod_mpoly_init3(U, B->length, exp_bits, ctx);
-            nmod_mpoly_init3(R, B->length, exp_bits, ctx);
-            nmod_mpoly_one(R, ctx);
-
-            ne = UWORD(1);
-
-            while (k > 0)
-            {
-                ulong kmodn;
-                NMOD_RED(kmodn, k, ctx->mod);
-
-                if (kmodn > 0)
-                {
-                    /* will accomplish R *= B^(n^e*(k%n)) */
-
-                    if (kmodn <= 2)
-                    {
-                        nmod_mpoly_fit_length(S, B->length, ctx);
-
-                        /* S = B^(n^e) */
-                        for (i = 0; i < B->length; i++)
-                        {
-                            S->coeffs[i] = B->coeffs[i];
-                            mpoly_monomial_mul_ui_mp(S->exps + N*i,
-                                                        Bexp + N*i, N, ne);
-                        }
-                        _nmod_mpoly_set_length(S, B->length, ctx);                        
-
-                        if (kmodn == 2)
-                        {
-                            /* R *= S */
-                            _nmod_mpoly_mul_johnson(U,
-                                             R->coeffs, R->exps, R->length,
-                                             S->coeffs, S->exps, S->length,
-                                              exp_bits,  N, cmpmask, ctx->mod);
-                            nmod_mpoly_swap(R, U, ctx);
-                        }
-                    }
-                    else
-                    {
-                        /* S = B^(n^e*(k%n)) */
-                        Tlen = _fmpz_mpoly_pow_fps(
-                                              &T->coeffs, &T->exps, &T->alloc,
-                                                Bcoeffs_fmpz, Bexp, B->length,
-                                                  kmodn, exp_bits, N, cmpmask);
-                        nmod_mpoly_fit_length(S, Tlen, ctx);
-                        Slen = 0;
-                        for (i = 0; i < Tlen; i++)
-                        {
-                            S->coeffs[Slen] = fmpz_fdiv_ui(T->coeffs + i, ctx->mod.n);
-                            mpoly_monomial_mul_ui_mp(S->exps + N*Slen,
-                                                     T->exps + N*i, N, ne);
-                            Slen += (S->coeffs[Slen] != UWORD(0));
-                        }
-                        _nmod_mpoly_set_length(S, Slen, ctx);
-                    }
-
-                    /* R = R * S */
-                    if (nmod_mpoly_is_one(R, ctx))
-                    {
-                        nmod_mpoly_swap(R, S, ctx);
-                    }
-                    else
-                    {
-                        _nmod_mpoly_mul_johnson(U,
-                                             R->coeffs, R->exps, R->length,
-                                             S->coeffs, S->exps, S->length,
-                                              exp_bits,  N, cmpmask, ctx->mod);
-                        nmod_mpoly_swap(R, U, ctx);
-                    }
-                }
-
-                k = k/ctx->mod.n;
-                ne = ne * ctx->mod.n;
-            }
-
-            nmod_mpoly_swap(A, R, ctx);
-
-            nmod_mpoly_clear(S, ctx);
-            nmod_mpoly_clear(U, ctx);
-            nmod_mpoly_clear(R, ctx);
-        }
-
-        _fmpz_vec_clear(Bcoeffs_fmpz, B->length);
-
-        for (i = 0; i < T->alloc; i++)
-            fmpz_clear(T->coeffs + i);
-
-        flint_free(T->coeffs);
-        flint_free(T->exps);
+        nmod_mpoly_clear(S, ctx);
     }
 
-    if (freeBexp)
+    nmod_mpoly_clear(T, ctx);
+
+    if (A == B)
     {
-        flint_free(Bexp);
+        nmod_mpoly_swap(A, Atemp, ctx);
+        nmod_mpoly_clear(Atemp, ctx);
     }
+
+    if (freeBexps)
+        flint_free(Bexps);
 
     TMP_END;
 
-    return success;
+    return 1;
 }
+

--- a/nmod_mpoly/test/t-pow_rmul.c
+++ b/nmod_mpoly/test/t-pow_rmul.c
@@ -13,7 +13,6 @@
 #include <stdlib.h>
 #include "nmod_mpoly.h"
 
-
 void nmod_mpoly_pow_naive(nmod_mpoly_t res, nmod_mpoly_t f,
                                                  slong n, nmod_mpoly_ctx_t ctx)
 {
@@ -46,7 +45,7 @@ main(void)
     slong i, j;
     FLINT_TEST_INIT(state);
 
-    flint_printf("pow_ui....");
+    flint_printf("pow_rmul....");
     fflush(stdout);
 
     for (i = 0; i < 10 * flint_test_multiplier(); i++)
@@ -75,12 +74,7 @@ main(void)
         exp_bits1 = n_randint(state, 20) + 2;
         exp_bits2 = n_randint(state, 20) + 2;
 
-        if (n_is_prime(nmod_mpoly_ctx_modulus(ctx)))
-            pow_bound = 5000/(FLINT_BIT_COUNT(modulus)+1);
-        else
-            pow_bound = 200;
-
-        pow_bound = pow_bound/(len1+1);
+        pow_bound = 250/(len1+1);
         pow_bound = pow_bound/ctx->minfo->nvars;
         pow_bound = FLINT_MAX(pow_bound, UWORD(5));
 
@@ -94,12 +88,7 @@ main(void)
             nmod_mpoly_randtest_bits(g, state, len2, exp_bits2, ctx);
             nmod_mpoly_randtest_bits(h, state, len, exp_bits, ctx);
 
-            if (!nmod_mpoly_pow_ui(g, f, pow, ctx))
-            {
-                flint_printf("FAIL\n");
-                flint_printf("Check pow_ui success\ni = %wd, j = %wd\n", i, j);
-                flint_abort();
-            }
+            nmod_mpoly_pow_rmul(g, f, pow, ctx);
             nmod_mpoly_assert_canonical(g, ctx);
 
             nmod_mpoly_pow_naive(h, f, pow, ctx);
@@ -112,12 +101,7 @@ main(void)
                 flint_abort();
             }
 
-            if (!nmod_mpoly_pow_ui(f, f, pow, ctx))
-            {
-                flint_printf("FAIL: Check pow_ui success\n");
-                flint_printf("i = %wd, j = %wd\n", i, j);
-                flint_abort();
-            }
+            nmod_mpoly_pow_rmul(f, f, pow, ctx);
             nmod_mpoly_assert_canonical(f, ctx);
 
             if (!nmod_mpoly_equal(g, f, ctx))


### PR DESCRIPTION
1. pow_fps is no longer used in nmod_mpoly_pow_ui
2. fmpz_mpoly/pow_fps.c has the algo outlined in a comment section
3. tabs are 4 spaces now in fmpz_mpoly/pow_fps.c and the two code sections are analogous to each other.
4. powering monomials might be slightly more efficient now.
5. The amount of code has gone down, and the amount of test code has gone up.