### PR TITLE
fix bug when hlen < n in _nmod_poly_exp_series_newton

### DIFF
--- a/nmod_poly/exp_series.c
+++ b/nmod_poly/exp_series.c
@@ -71,7 +71,7 @@ _nmod_poly_exp_series_newton(mp_ptr f, mp_ptr g,
         a[++i] = (n = (n + 1) / 2);
 
     /* f := exp(h) + O(x^n),  g := exp(-h) + O(x^n) */
-    _nmod_poly_exp_series_basecase(f, h, n, n, mod);
+    _nmod_poly_exp_series_basecase(f, h, hlen, n, mod);
     _nmod_poly_inv_series(g, f, n, n, mod);
 
     for (i--; i >= 0; i--)


### PR DESCRIPTION
Fixes a bug in _nmod_poly_exp_series_newton when the input polynomial is shorter than the basecase length.

I think the algorithm thresholds prevent this from actually being triggered if you only call nmod_poly_exp_series, but it could be a problem if you call the Newton function directly.