### PR TITLE
fix fmpq_randtest with bits == 1

### DIFF
--- a/fmpq/randtest.c
+++ b/fmpq/randtest.c
@@ -17,6 +17,13 @@ _fmpq_randtest(fmpz_t num, fmpz_t den, flint_rand_t state, flint_bitcnt_t bits)
     mp_limb_t x = n_randlimb(state);
 
     fmpz_randtest(num, state, bits);
+
+    if (bits == 1)
+    {
+        fmpz_one(den);
+        return;
+    }
+
     fmpz_randtest_not_zero(den, state, bits);
 
     switch (x % 16)

--- a/fmpq/test/t-randtest.c
+++ b/fmpq/test/t-randtest.c
@@ -1,0 +1,54 @@
+/*
+    Copyright (C) 2021 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <gmp.h>
+#include "flint.h"
+#include "fmpz.h"
+#include "fmpq.h"
+#include "fmpz_vec.h"
+#include "ulong_extras.h"
+#include "long_extras.h"
+
+int
+main(void)
+{
+    int i;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("randtest....");
+    fflush(stdout);
+
+    for (i = 0; i < 10000; i++)
+    {
+        fmpq_t x;
+        slong bits;
+
+        fmpq_init(x);
+        bits = 1 + n_randint(state, 100);
+
+        fmpq_randtest(x, state, bits);
+
+        if (!fmpq_is_canonical(x) || fmpz_bits(fmpq_numref(x)) > bits || fmpz_bits(fmpq_denref(x)) > bits)
+        {
+            flint_printf("FAIL\n");
+            flint_printf("x: "); fmpq_print(x); flint_printf("\n");
+            abort();
+        }
+
+        fmpq_clear(x);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+    flint_printf("PASS\n");
+    return 0;
+}


### PR DESCRIPTION
From the bugs-that-never-should-have-existed-department: fmpq_randtest with bits == 1 producing 2-bit numbers.