### PR TITLE
nmod_mat_charpoly_berkowitz && small determinant speedup

### DIFF
--- a/doc/source/nmod_mat.rst
+++ b/doc/source/nmod_mat.rst
@@ -641,15 +641,13 @@ Transforms
 Characteristic polynomial
 --------------------------------------------------------------------------------
 
-.. function:: void nmod_mat_charpoly_danilevsky(nmod_poly_t p, const nmod_mat_t M)
-
-    Compute the characteristic polynomial `p` of the matrix `M`. The matrix
-    is assumed to be square.
-
-.. function:: void nmod_mat_charpoly(nmod_poly_t p, const nmod_mat_t M)
+.. function:: void nmod_mat_charpoly_berkowitz(nmod_poly_t p, const nmod_mat_t M)
+              void nmod_mat_charpoly_danilevsky(nmod_poly_t p, const nmod_mat_t M)
+              void nmod_mat_charpoly(nmod_poly_t p, const nmod_mat_t M)
 
     Compute the characteristic polynomial `p` of the matrix `M`. The matrix
     is required to be square, otherwise an exception is raised.
+    The *danilevsky* algorithm assumes that the modulus is prime.
 
 
 Minimal polynomial

--- a/nmod_mat/charpoly.c
+++ b/nmod_mat/charpoly.c
@@ -1,0 +1,26 @@
+/*
+    Copyright (C) 2021 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdlib.h>
+#include <gmp.h>
+#include "flint.h"
+#include "nmod_vec.h"
+#include "nmod_mat.h"
+#include "nmod_poly.h"
+
+void nmod_mat_charpoly(nmod_poly_t cp, const nmod_mat_t mat)
+{
+    if (mat->r <= 8 || !n_is_prime(mat->mod.n))
+        nmod_mat_charpoly_berkowitz(cp, mat);
+    else
+        nmod_mat_charpoly_danilevsky(cp, mat);
+}
+

--- a/nmod_mat/charpoly_berkowitz.c
+++ b/nmod_mat/charpoly_berkowitz.c
@@ -1,0 +1,113 @@
+/*
+    Copyright (C) 2021 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdlib.h>
+#include <gmp.h>
+#include "flint.h"
+#include "nmod_vec.h"
+#include "nmod_mat.h"
+#include "nmod_poly.h"
+
+void
+_nmod_mat_charpoly_berkowitz(mp_ptr cp, const nmod_mat_t mat, nmod_t mod)
+{
+    const slong n = mat->r;
+
+    if (mod.n == 1)
+    {
+        _nmod_vec_zero(cp, n + 1);
+    }
+    else if (n == 0)
+    {
+        cp[0] = 1;
+    }
+    else if (n == 1)
+    {
+        cp[0] = nmod_neg(nmod_mat_entry(mat, 0, 0), mod);
+        cp[1] = 1;
+    }
+    else if (n == 2)
+    {
+        cp[0] = nmod_sub(nmod_mul(nmod_mat_entry(mat, 0, 0), nmod_mat_entry(mat, 1, 1), mod),
+                         nmod_mul(nmod_mat_entry(mat, 0, 1), nmod_mat_entry(mat, 1, 0), mod), mod);
+        cp[1] = nmod_add(nmod_mat_entry(mat, 0, 0), nmod_mat_entry(mat, 1, 1), mod);
+        cp[1] = nmod_neg(cp[1], mod);
+        cp[2] = 1;
+    }
+    else
+    {
+        slong i, k, t;
+        mp_ptr a, A, s;
+        int nlimbs;
+        TMP_INIT;
+
+        TMP_START;
+        a = TMP_ALLOC(sizeof(mp_limb_t) * (n * n));
+        A = a + (n - 1) * n;
+
+        nlimbs = _nmod_vec_dot_bound_limbs(n, mod);
+
+        _nmod_vec_zero(cp, n + 1);
+        cp[0] = nmod_neg(nmod_mat_entry(mat, 0, 0), mod);
+
+        for (t = 1; t < n; t++)
+        {
+            for (i = 0; i <= t; i++)
+            {
+                a[0 * n + i] = nmod_mat_entry(mat, i, t);
+            }
+
+            A[0] = nmod_mat_entry(mat, t, t);
+
+            for (k = 1; k < t; k++)
+            {
+                for (i = 0; i <= t; i++)
+                {
+                    s = a + k * n + i;
+                    s[0] = _nmod_vec_dot(mat->rows[i], a + (k - 1) * n, t + 1, mod, nlimbs);
+                }
+
+                A[k] = a[k * n + t];
+            }
+
+            A[t] = _nmod_vec_dot(mat->rows[t], a + (t - 1) * n, t + 1, mod, nlimbs);
+
+            for (k = 0; k <= t; k++)
+            {
+                cp[k] = nmod_sub(cp[k], _nmod_vec_dot_rev(A, cp, k, mod, nlimbs), mod);
+                cp[k] = nmod_sub(cp[k], A[k], mod);
+            }
+        }
+
+        /* Shift all coefficients up by one */
+        for (i = n; i > 0; i--)
+            cp[i] = cp[i - 1];
+
+        cp[0] = 1;
+        _nmod_poly_reverse(cp, cp, n + 1, n + 1);
+
+        TMP_END;
+    }
+}
+
+void nmod_mat_charpoly_berkowitz(nmod_poly_t cp, const nmod_mat_t mat)
+{
+    if (mat->r != mat->c)
+    {
+        flint_printf("Exception (nmod_mat_charpoly_berkowitz).  Non-square matrix.\n");
+        flint_abort();
+    }
+
+    nmod_poly_fit_length(cp, mat->r + 1);
+    _nmod_poly_set_length(cp, mat->r + 1);
+    _nmod_mat_charpoly_berkowitz(cp->coeffs, mat, mat->mod);
+}
+

--- a/nmod_mat/det.c
+++ b/nmod_mat/det.c
@@ -15,8 +15,65 @@
 #include "ulong_extras.h"
 #include "nmod_vec.h"
 #include "nmod_mat.h"
+#include "nmod_poly.h"
 #include "perm.h"
 
+static mp_limb_t
+_nmod_mat_det_2x2(mp_limb_t a, mp_limb_t b, mp_limb_t c, mp_limb_t d, nmod_t mod)
+{
+    b = nmod_neg(b, mod);
+    return nmod_addmul(nmod_mul(a, d, mod), b, c, mod);
+}
+
+static mp_limb_t
+_nmod_mat_det_3x3(mp_limb_t a, mp_limb_t b, mp_limb_t c,
+                  mp_limb_t d, mp_limb_t e, mp_limb_t f,
+                  mp_limb_t g, mp_limb_t h, mp_limb_t i, nmod_t mod)
+{
+    mp_limb_t s, t, u;
+
+    s = _nmod_mat_det_2x2(e, f, h, i, mod);
+    t = _nmod_mat_det_2x2(g, i, d, f, mod);
+    u = _nmod_mat_det_2x2(d, e, g, h, mod);
+
+    s = nmod_mul(a, s, mod);
+    s = nmod_addmul(s, b, t, mod);
+    s = nmod_addmul(s, c, u, mod);
+
+    return s;
+}
+
+static mp_limb_t
+_nmod_mat_det_4x4(mp_limb_t ** const mat, nmod_t mod)
+{
+    mp_limb_t s, t, u, v;
+
+    s = _nmod_mat_det_3x3(mat[1][1], mat[1][2], mat[1][3],
+                          mat[2][1], mat[2][2], mat[2][3],
+                          mat[3][1], mat[3][2], mat[3][3], mod);
+
+    t = _nmod_mat_det_3x3(mat[1][0], mat[1][2], mat[1][3],
+                          mat[2][0], mat[2][2], mat[2][3],
+                          mat[3][0], mat[3][2], mat[3][3], mod);
+
+    u = _nmod_mat_det_3x3(mat[1][0], mat[1][1], mat[1][3],
+                          mat[2][0], mat[2][1], mat[2][3],
+                          mat[3][0], mat[3][1], mat[3][3], mod);
+
+    v = _nmod_mat_det_3x3(mat[1][0], mat[1][1], mat[1][2],
+                          mat[2][0], mat[2][1], mat[2][2],
+                          mat[3][0], mat[3][1], mat[3][2], mod);
+
+    t = nmod_neg(t, mod);
+    v = nmod_neg(v, mod);
+
+    s = nmod_mul(mat[0][0], s, mod);
+    s = nmod_addmul(s, mat[0][1], t, mod);
+    s = nmod_addmul(s, mat[0][2], u, mod);
+    s = nmod_addmul(s, mat[0][3], v, mod);
+
+    return s;
+}
 
 mp_limb_t
 _nmod_mat_det(nmod_mat_t A)
@@ -62,7 +119,29 @@ nmod_mat_det(const nmod_mat_t A)
     }
 
     if (dim == 0) return A->mod.n != 1;
+
     if (dim == 1) return nmod_mat_entry(A, 0, 0);
+
+    if (dim == 2) return _nmod_mat_det_2x2(
+        nmod_mat_entry(A, 0, 0), nmod_mat_entry(A, 0, 1),
+        nmod_mat_entry(A, 1, 0), nmod_mat_entry(A, 1, 1), A->mod);
+
+    if (dim == 3) return _nmod_mat_det_3x3(
+        nmod_mat_entry(A, 0, 0), nmod_mat_entry(A, 0, 1), nmod_mat_entry(A, 0, 2),
+        nmod_mat_entry(A, 1, 0), nmod_mat_entry(A, 1, 1), nmod_mat_entry(A, 1, 2),
+        nmod_mat_entry(A, 2, 0), nmod_mat_entry(A, 2, 1), nmod_mat_entry(A, 2, 2), A->mod);
+
+    if (dim == 4) return _nmod_mat_det_4x4(A->rows, A->mod);
+
+    if (dim <= 8)
+    {
+        mp_limb_t cp[9];
+        _nmod_mat_charpoly_berkowitz(cp, A, A->mod);
+        if (dim % 2)
+            return nmod_neg(cp[0], A->mod);
+        else
+            return cp[0];
+    }
 
     nmod_mat_init_set(tmp, A);
     if (n_is_prime(A->mod.n))
@@ -73,3 +152,4 @@ nmod_mat_det(const nmod_mat_t A)
 
     return det;
 }
+

--- a/nmod_mat/test/t-charpoly_berkowitz.c
+++ b/nmod_mat/test/t-charpoly_berkowitz.c
@@ -51,8 +51,8 @@ main(void)
         nmod_mat_mul(C, A, B);
         nmod_mat_mul(D, B, A);
 
-        nmod_mat_charpoly(f, C);
-        nmod_mat_charpoly(g, D);
+        nmod_mat_charpoly_berkowitz(f, C);
+        nmod_mat_charpoly_berkowitz(g, D);
 
         if (!nmod_poly_equal(f, g))
         {
@@ -88,7 +88,7 @@ main(void)
 
         nmod_mat_randtest(A, state);
 
-        nmod_mat_charpoly(f, A);
+        nmod_mat_charpoly_berkowitz(f, A);
 
         for (i = 0; i < 10; i++)
            nmod_mat_similarity(A, n_randint(state, m), n_randint(state, mod));

--- a/nmod_mat/test/t-charpoly_danilevsky.c
+++ b/nmod_mat/test/t-charpoly_danilevsky.c
@@ -25,7 +25,7 @@ main(void)
     ulong mod;
     FLINT_TEST_INIT(state);
 
-    flint_printf("charpoly....");
+    flint_printf("charpoly_danilevsky....");
     fflush(stdout);
 
     for (rep = 0; rep < 1000 * flint_test_multiplier(); rep++)
@@ -36,7 +36,7 @@ main(void)
         m = n_randint(state, 10);
         n = m;
 
-        mod = n_randtest_not_zero(state);
+        mod = n_randprime(state, 6, 0);
 
         nmod_mat_init(A, m, n, mod);
         nmod_mat_init(B, m, n, mod);
@@ -51,8 +51,8 @@ main(void)
         nmod_mat_mul(C, A, B);
         nmod_mat_mul(D, B, A);
 
-        nmod_mat_charpoly(f, C);
-        nmod_mat_charpoly(g, D);
+        nmod_mat_charpoly_danilevsky(f, C);
+        nmod_mat_charpoly_danilevsky(g, D);
 
         if (!nmod_poly_equal(f, g))
         {
@@ -80,7 +80,7 @@ main(void)
         m = n_randint(state, 10);
         n = m;
 
-        mod = n_randtest_not_zero(state);
+        mod = n_randprime(state, 6, 0);
 
         nmod_mat_init(A, m, n, mod);
         nmod_poly_init(f, mod);
@@ -93,7 +93,7 @@ main(void)
         for (i = 0; i < 10; i++)
            nmod_mat_similarity(A, n_randint(state, m), n_randint(state, mod));
 
-        nmod_mat_charpoly(g, A);
+        nmod_mat_charpoly_danilevsky(g, A);
 
         if (!nmod_poly_equal(f, g))
         {

--- a/nmod_mat/test/t-det.c
+++ b/nmod_mat/test/t-det.c
@@ -24,7 +24,7 @@ main(void)
 {
     slong m, mod, rep;
     FLINT_TEST_INIT(state);
-    
+
 
     flint_printf("det....");
     fflush(stdout);
@@ -39,12 +39,12 @@ main(void)
 
         m = n_randint(state, 30);
         mod = n_randtest(state);
-	mod += mod == 0;
+        mod += mod == 0;
 
         nmod_mat_init(A, m, m, mod);
         fmpz_mat_init(B, m, m);
 
-	switch (rep % 3)
+        switch (rep % 3)
         {
             case 0:
                 nmod_mat_randrank(A, state, m);
@@ -52,7 +52,7 @@ main(void)
                 break;
             case 1:
                 t = n_randint(state, m);
-		t = FLINT_MIN(t, m);
+                t = FLINT_MIN(t, m);
                 nmod_mat_randrank(A, state, t);
                 nmod_mat_randops(A, n_randint(state, 2*m + 1), state);
                 break;
@@ -60,7 +60,7 @@ main(void)
                 nmod_mat_randtest(A, state);
         }
 
-	fmpz_mat_set_nmod_mat_unsigned(B, A);
+    	fmpz_mat_set_nmod_mat_unsigned(B, A);
 
         Adet = nmod_mat_det(A);
 
@@ -71,7 +71,7 @@ main(void)
         if (Adet != fmpz_get_ui(Bdet))
         {
             flint_printf("FAIL\n");
-	    flint_printf("Adet = %wu, Bdet = %wu\n", Adet, fmpz_get_ui(Bdet));
+            flint_printf("Adet = %wu, Bdet = %wu\n", Adet, fmpz_get_ui(Bdet));
             abort();
         }
 
@@ -79,8 +79,6 @@ main(void)
         fmpz_mat_clear(B);
         fmpz_clear(Bdet);
     }
-
-    
 
     FLINT_TEST_CLEANUP(state);
     flint_printf("PASS\n");

--- a/nmod_poly.h
+++ b/nmod_poly.h
@@ -1414,13 +1414,10 @@ FLINT_DLL void nmod_poly_inflate(nmod_poly_t result, const nmod_poly_t input,
 
 /* Characteristic polynomial and minimal polynomial */
 
+FLINT_DLL void _nmod_mat_charpoly_berkowitz(mp_ptr p, const nmod_mat_t M, nmod_t mod);
+FLINT_DLL void nmod_mat_charpoly_berkowitz(nmod_poly_t p, const nmod_mat_t M);
 FLINT_DLL void nmod_mat_charpoly_danilevsky(nmod_poly_t p, const nmod_mat_t M);
-
-NMOD_POLY_INLINE
-void nmod_mat_charpoly(nmod_poly_t p, const nmod_mat_t M)
-{
-   nmod_mat_charpoly_danilevsky(p, M);
-}
+FLINT_DLL void nmod_mat_charpoly(nmod_poly_t p, const nmod_mat_t M);
 
 FLINT_DLL void nmod_mat_minpoly_with_gens(nmod_poly_t p, 
                                                 const nmod_mat_t X, ulong * P);


### PR DESCRIPTION
* Add nmod_mat_charpoly_berkowitz
* Use Berkowitz in nmod_mat_charpoly for small matrices and when the modulus is not prime, so that nmod_mat_charpoly now works with any modulus (it would previously abort if it hit an impossible inverse)
* Use cofactor expansion or Berkowitz in nmod_mat_det for matrices up to n = 8.

Timings for nmod_mat_det:

              mod = 16                          mod = 17                      mod = 2^63                   mod = nextprime(2^63)

    n      Old       New   (Speedup)       Old    New                        Old     New                   Old       New
    -------------------------------------------------------------------------------------------------------------------------------
    2     2.6e-07  2e-08    (12.79x) |   2e-07    2e-08    (10.41x) |   3.1e-07  1.9e-08  (16.76x) |   2.4e-06  1.8e-08  (135.36x)
    3     3.4e-07  8.9e-08  (3.85x)  |   3.5e-07  8.1e-08  (4.31x)  |   1.3e-06  7.3e-08  (17.10x) |   2.7e-06  7.4e-08  (36.86x)
    4     6.1e-07  3.4e-07  (1.79x)  |   9.3e-07  3.4e-07  (2.73x)  |   1.5e-06  3.2e-07  (4.69x)  |   3.5e-06  3.1e-07  (11.21x)
    5     1.3e-06  6.6e-07  (1.94x)  |   1.2e-06  6.4e-07  (1.89x)  |   3e-06  1.1e-06  (2.71x)    |   4.1e-06  1.1e-06  (3.61x)
    6     1.3e-06  1.1e-06  (1.17x)  |   1.5e-06  1.1e-06  (1.32x)  |   5.3e-06  2e-06  (2.64x)    |   4.7e-06  2.1e-06  (2.24x)
    7     2.3e-06  2.1e-06  (1.12x)  |   2.5e-06  1.9e-06  (1.30x)  |   6.6e-06  3.4e-06  (1.95x)  |   5.5e-06  3.3e-06  (1.68x)
    8     2.3e-06  2.5e-06  (0.90x)  |   3.1e-06  2.6e-06  (1.22x)  |   8e-06  5e-06  (1.59x)      |   7e-06  5e-06  (1.40x)
    9     3.4e-06  3.3e-06  (1.02x)  |   3.9e-06  3.7e-06  (1.04x)  |   8.8e-06  8.8e-06  (1.00x)  |   7.9e-06  8e-06  (0.98x)

Not done:
* I did not bother optimizing the n <= 4 case with delayed reduction.
* O(n^3) characteristic polynomial with non-prime modulus
