### PR TITLE
When nvars is one

### DIFF
--- a/fmpz_mpoly.h
+++ b/fmpz_mpoly.h
@@ -481,6 +481,10 @@ FLINT_DLL void _fmpz_mpoly_set_fmpz_poly(fmpz_mpoly_t A, flint_bitcnt_t Abits,
 FLINT_DLL void fmpz_mpoly_set_fmpz_poly(fmpz_mpoly_t A, const fmpz_poly_t B,
                                           slong v, const fmpz_mpoly_ctx_t ctx);
 
+FLINT_DLL void _fmpz_mpoly_set_fmpz_poly_one_var(fmpz_mpoly_t A,
+                        flint_bitcnt_t Aminbits, fmpz * Acoeffs, slong Adeg,
+                                                   const fmpz_mpoly_ctx_t ctx);
+
 /* comparison ****************************************************************/
 
 FLINT_DLL int fmpz_mpoly_cmp(const fmpz_mpoly_t A, const fmpz_mpoly_t B,

--- a/fmpz_mpoly.h
+++ b/fmpz_mpoly.h
@@ -754,6 +754,9 @@ FLINT_DLL void fmpz_mpoly_compose_fmpz_mpoly_gen(fmpz_mpoly_t A,
 FLINT_DLL void fmpz_mpoly_mul(fmpz_mpoly_t A,
        const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
 
+FLINT_DLL void fmpz_mpoly_mul_monomial(fmpz_mpoly_t A, const fmpz_mpoly_t B,
+                             const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
+
 FLINT_DLL void fmpz_mpoly_mul_johnson(fmpz_mpoly_t A,
        const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
 

--- a/fmpz_mpoly/clear.c
+++ b/fmpz_mpoly/clear.c
@@ -17,14 +17,11 @@
 
 void fmpz_mpoly_clear(fmpz_mpoly_t poly, const fmpz_mpoly_ctx_t ctx)
 {
-   if (poly->coeffs != NULL)
-   {
-      slong i;
+    slong i;
 
-      for (i = 0; i < poly->alloc; i++)
-         _fmpz_demote(poly->coeffs + i);
+    for (i = 0; i < poly->alloc; i++)
+        _fmpz_demote(poly->coeffs + i);
 
-      flint_free(poly->coeffs);
-      flint_free(poly->exps);
-   }
+    flint_free(poly->coeffs);
+    flint_free(poly->exps);
 }

--- a/fmpz_mpoly/fit_length_reset_bits.c
+++ b/fmpz_mpoly/fit_length_reset_bits.c
@@ -18,7 +18,7 @@
     Since the coefficient alloc and the exponent alloc are coupled, we must
     have the assumption that A is allocated wrt ctx upon entry.
 
-    TODO: possibly decouple the two allocations as in nmod_mpoly/fq_nmod_mpoly
+    TODO: decouple the two allocations as in nmod_mpoly/fq_nmod_mpoly
 */
 void fmpz_mpoly_fit_length_reset_bits(
     fmpz_mpoly_t A,
@@ -42,7 +42,7 @@ void fmpz_mpoly_fit_length_reset_bits(
 
         A->alloc = len;
     }
-    else if (newN > oldN)
+    else if (newN > oldN && A->alloc > 0)
     {
         A->exps = (ulong *) flint_realloc(A->exps, newN*A->alloc*sizeof(ulong));
     }

--- a/fmpz_mpoly/get_set_is_fmpz_poly.c
+++ b/fmpz_mpoly/get_set_is_fmpz_poly.c
@@ -191,7 +191,7 @@ void _fmpz_mpoly_set_fmpz_poly_one_var(
     }
     else
     {
-        FLINT_ASSERT(2 == mpoly_words_per_exp(Abits, ctx->minfo))
+        FLINT_ASSERT(2 == mpoly_words_per_exp(Abits, ctx->minfo));
 
         for (i = Adeg; i >= 0; i--)
         {

--- a/fmpz_mpoly/get_set_is_fmpz_poly.c
+++ b/fmpz_mpoly/get_set_is_fmpz_poly.c
@@ -138,3 +138,72 @@ void fmpz_mpoly_set_fmpz_poly(
     bits = mpoly_fix_bits(bits, ctx->minfo);
     _fmpz_mpoly_set_fmpz_poly(A, bits, B->coeffs, B->length, v, ctx);
 }
+
+/*
+    construct a polynomial with at least Aminbits bits from the coefficients
+    Acoeffs[0], ..., Acoeffs[deg]. *** These fmpz's are cleared *** .
+*/
+void _fmpz_mpoly_set_fmpz_poly_one_var(
+    fmpz_mpoly_t A,
+    flint_bitcnt_t Aminbits,
+    fmpz * Acoeffs,     /* cleared upon return */
+    slong Adeg,
+    const fmpz_mpoly_ctx_t ctx)
+{
+    slong i, Alen;
+    flint_bitcnt_t Abits;
+
+    Abits = mpoly_gen_pow_exp_bits_required(0, Adeg, ctx->minfo);
+    Abits = FLINT_MAX(Abits, Aminbits);
+    Abits = mpoly_fix_bits(Abits, ctx->minfo);
+    fmpz_mpoly_fit_length_reset_bits(A, Adeg + 1, Abits, ctx);
+
+    FLINT_ASSERT(Abits <= FLINT_BITS);
+
+    Alen = 0;
+    if (ctx->minfo->ord == ORD_LEX)
+    {
+        FLINT_ASSERT(1 == mpoly_words_per_exp(Abits, ctx->minfo));
+
+        for (i = Adeg; i >= 0; i--)
+        {
+            if (fmpz_is_zero(Acoeffs + i))
+                continue;
+
+            fmpz_swap(A->coeffs + Alen, Acoeffs + i);
+            A->exps[Alen] = i;
+            Alen++;
+            fmpz_clear(Acoeffs + i);
+        }
+    }
+    else if (1 == mpoly_words_per_exp(Abits, ctx->minfo))
+    {
+        for (i = Adeg; i >= 0; i--)
+        {
+            if (fmpz_is_zero(Acoeffs + i))
+                continue;
+
+            fmpz_swap(A->coeffs + Alen, Acoeffs + i);
+            A->exps[Alen] = i + (i << Abits);
+            Alen++;
+            fmpz_clear(Acoeffs + i);
+        }
+    }
+    else
+    {
+        FLINT_ASSERT(2 == mpoly_words_per_exp(Abits, ctx->minfo))
+
+        for (i = Adeg; i >= 0; i--)
+        {
+            if (fmpz_is_zero(Acoeffs + i))
+                continue;
+
+            fmpz_swap(A->coeffs + Alen, Acoeffs + i);
+            A->exps[2*Alen + 1] = A->exps[2*Alen + 0] = i;
+            Alen++;
+            fmpz_clear(Acoeffs + i);
+        }
+    }
+
+    _fmpz_mpoly_set_length(A, Alen, ctx);
+}

--- a/fmpz_mpoly/is_canonical.c
+++ b/fmpz_mpoly/is_canonical.c
@@ -37,11 +37,11 @@ void fmpz_mpoly_assert_canonical(const fmpz_mpoly_t A, const fmpz_mpoly_ctx_t ct
 {
     slong i;
 
-    if (!mpoly_monomials_valid_test(A->exps, A->length, A->bits, ctx->minfo))
-        flint_throw(FLINT_ERROR, "Polynomial exponents invalid");
-
     if (mpoly_monomials_overflow_test(A->exps, A->length, A->bits, ctx->minfo))
         flint_throw(FLINT_ERROR, "Polynomial exponents overflow");
+
+    if (!mpoly_monomials_valid_test(A->exps, A->length, A->bits, ctx->minfo))
+        flint_throw(FLINT_ERROR, "Polynomial exponents invalid");
 
     if (!mpoly_monomials_inorder_test(A->exps, A->length, A->bits, ctx->minfo))
         flint_throw(FLINT_ERROR, "Polynomial exponents out of order");

--- a/fmpz_mpoly/mul.c
+++ b/fmpz_mpoly/mul.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz_mpoly.h"
+#include "long_extras.h"
 
 
 static int _try_dense(int try_array, slong * Bdegs, slong * Cdegs,
@@ -107,6 +108,94 @@ static int _try_array_DEG(slong Btotaldeg, slong Ctotaldeg,
            dense_size/Blen/Clen < WORD(10);
 }
 
+/* !!! this function DOES need to change with new orderings */
+static int _try_dense_univar(
+    fmpz_mpoly_t A,
+    const fmpz_mpoly_t B,
+    const fmpz_mpoly_t C,
+    const fmpz_mpoly_ctx_t ctx)
+{
+    slong i;
+    ulong maskB = (-UWORD(1)) >> (FLINT_BITS - B->bits);
+    ulong maskC = (-UWORD(1)) >> (FLINT_BITS - C->bits);
+    slong NB = mpoly_words_per_exp_sp(B->bits, ctx->minfo);
+    slong NC = mpoly_words_per_exp_sp(C->bits, ctx->minfo);
+    slong Blen = B->length;
+    slong Clen = C->length;
+    slong BClen;
+    const ulong * Bexps = B->exps;
+    const ulong * Cexps = C->exps;
+    fmpz * Acoeffs, * Bcoeffs, * Ccoeffs;
+    slong Adeg, Bdeg, Cdeg;
+    TMP_INIT;
+
+    /* the variable power is stored at offset 0 */
+    Bdeg = Bexps[NB*0 + 0] & maskB;
+    Cdeg = Cexps[NC*0 + 0] & maskC;
+
+    if (z_mul_checked(&BClen, Blen, Clen))
+    {
+        if (z_add_checked(&Adeg, Bdeg, Cdeg))
+            return 0;
+    }
+    else
+    {
+        Adeg = Bdeg + Cdeg;
+    }
+
+    if (Adeg > WORD_MAX/FLINT_BITS)
+        return 0;
+
+    if (Adeg > BClen)
+        return 0;
+
+    {
+        slong Bcoeffbits = _fmpz_vec_max_bits(B->coeffs, Blen);
+        slong Ccoeffbits = _fmpz_vec_max_bits(C->coeffs, Clen);
+        slong t = FLINT_ABS(Bcoeffbits) + FLINT_ABS(Ccoeffbits);
+
+        if (t > FLINT_BITS && Adeg > BClen/4)
+            return 0;
+    }
+
+    TMP_START;
+
+    Acoeffs = TMP_ARRAY_ALLOC(Adeg + 1 + Bdeg + 1 + Cdeg + 1, fmpz);
+    Bcoeffs = Acoeffs + Adeg + 1;
+    Ccoeffs = Bcoeffs + Bdeg + 1;
+
+    /* we own the fmpz's in Acoeffs */
+    for (i = 0; i < Adeg + 1; i++)
+        fmpz_init(Acoeffs + i);
+
+    if (A != B && A != C)
+    {
+        for (i = FLINT_MIN(A->length - 1, Adeg); i >= 0; i--)
+            fmpz_swap(Acoeffs + i, A->coeffs + i);
+    }
+
+    /* Bcoeffs and Ccoeffs are shallow copies */
+    for (i = 0; i < Bdeg + 1 + Cdeg + 1; i++)
+        Bcoeffs[i] = 0;
+
+    for (i = 0; i < Blen; i++)
+        Bcoeffs[Bexps[NB*i + 0] & maskB] = B->coeffs[i];
+
+    for (i = 0; i < Clen; i++)
+        Ccoeffs[Cexps[NC*i + 0] & maskC] = C->coeffs[i];
+
+    if (Bdeg >= Cdeg)
+        _fmpz_poly_mul(Acoeffs, Bcoeffs, Bdeg + 1, Ccoeffs, Cdeg + 1);
+    else
+        _fmpz_poly_mul(Acoeffs, Ccoeffs, Cdeg + 1, Bcoeffs, Bdeg + 1);
+
+    /* Acoeffs cleared */
+    _fmpz_mpoly_set_fmpz_poly_one_var(A, FLINT_MAX(B->bits, C->bits),
+                                                           Acoeffs, Adeg, ctx);
+    TMP_END;
+    return 1;
+}
+
 
 void fmpz_mpoly_mul(
     fmpz_mpoly_t A,
@@ -139,6 +228,12 @@ void fmpz_mpoly_mul(
     {
         fmpz_mpoly_mul_monomial(A, B, C, ctx);
         return;
+    }
+
+    if (nvars == 1 && B->bits <= FLINT_BITS && C->bits <= FLINT_BITS)
+    {
+        if (_try_dense_univar(A, B, C, ctx))
+            return;
     }
 
     TMP_START;

--- a/fmpz_mpoly/mul.c
+++ b/fmpz_mpoly/mul.c
@@ -125,41 +125,19 @@ void fmpz_mpoly_mul(
     slong thread_limit;
     TMP_INIT;
 
-    if (B->length == 0 || C->length == 0)
+    if (B->length < 1 || C->length < 1)
     {
         fmpz_mpoly_zero(A, ctx);
         return;
     }
-
-    if (fmpz_mpoly_is_fmpz(B, ctx))
+    else if (B->length == 1)
     {
-        if (A == B || C == B)
-        {
-            fmpz_t t;
-            fmpz_init_set(t, B->coeffs);
-            fmpz_mpoly_scalar_mul_fmpz(A, C, t, ctx);
-            fmpz_clear(t);
-        }
-        else
-        {
-            fmpz_mpoly_scalar_mul_fmpz(A, C, B->coeffs, ctx);
-        }
+        fmpz_mpoly_mul_monomial(A, C, B, ctx);
         return;
     }
-
-    if (fmpz_mpoly_is_fmpz(C, ctx))
+    else if (C->length == 1)
     {
-        if (A == C || B == C)
-        {
-            fmpz_t t;
-            fmpz_init_set(t, C->coeffs);
-            fmpz_mpoly_scalar_mul_fmpz(A, B, t, ctx);
-            fmpz_clear(t);
-        }
-        else
-        {
-            fmpz_mpoly_scalar_mul_fmpz(A, B, C->coeffs, ctx);
-        }
+        fmpz_mpoly_mul_monomial(A, B, C, ctx);
         return;
     }
 

--- a/fmpz_mpoly/mul_monomial.c
+++ b/fmpz_mpoly/mul_monomial.c
@@ -1,0 +1,114 @@
+/*
+    Copyright (C) 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz_mpoly.h"
+
+/* TODO: decouple the exp/coeff alloc in fmpz_mpoly and move this to mpoly */
+void fmpz_mpoly_mul_monomial(
+    fmpz_mpoly_t A,
+    const fmpz_mpoly_t B,
+    const fmpz_mpoly_t C,
+    const fmpz_mpoly_ctx_t ctx)
+{
+    slong i, N, Blen = B->length;
+    ulong ofmask;
+    flint_bitcnt_t Abits;
+    ulong * Aexps, * Bexps = B->exps, * Cexps = C->exps;
+    fmpz Ccoeff0 = C->coeffs[0];
+    int freeCcoeff0 = 0, overflowed = 0;
+    TMP_INIT;
+
+    FLINT_ASSERT(C->length == 1);
+
+    if (A == C)
+    {
+        freeCcoeff0 = 1;
+        fmpz_init_set(&Ccoeff0, C->coeffs + 0);
+    }
+
+    if (C->exps[0] == 0 && mpoly_monomial_is_zero(C->exps,
+                                     mpoly_words_per_exp(C->bits, ctx->minfo)))
+    {
+        fmpz_mpoly_scalar_mul_fmpz(A, B, &Ccoeff0, ctx);
+        goto cleanup_C;
+    }
+
+    TMP_START;
+
+    Abits = FLINT_MAX(B->bits, C->bits);
+    N = mpoly_words_per_exp(Abits, ctx->minfo);
+
+    if (A == C || Abits != C->bits)
+    {
+        Cexps = TMP_ARRAY_ALLOC(N, ulong);
+        mpoly_repack_monomials(Cexps, Abits, C->exps, C->bits, 1, ctx->minfo);
+    }
+
+    if (A == B)
+    {
+        /* inplace operation on A */
+        fmpz_mpoly_fit_bits(A, Abits, ctx);
+        Bexps = Aexps = A->exps;
+    }
+    else
+    {
+        if (Abits != B->bits)
+        {
+            Bexps = TMP_ARRAY_ALLOC(N*Blen, ulong);
+            mpoly_repack_monomials(Bexps, Abits, B->exps, B->bits, Blen, ctx->minfo);
+        }
+
+        fmpz_mpoly_fit_length_reset_bits(A, Blen, Abits, ctx);
+        Aexps = A->exps;
+    }
+
+    if (Abits > FLINT_BITS)
+    {
+        for (i = 0; i < Blen; i++)
+            mpoly_monomial_add_mp(Aexps + N*i, Bexps + N*i, Cexps + N*0, N);
+
+        for (i = 0; !overflowed && i < Blen; i++)
+            overflowed = mpoly_monomial_overflows_mp(Aexps + N*i, N, Abits);
+    }
+    else
+    {
+        for (i = 0; i < Blen; i++)
+            mpoly_monomial_add(Aexps + N*i, Bexps + N*i, Cexps + N*0, N);
+
+        ofmask = mpoly_overflow_mask_sp(Abits);
+        for (i = 0; !overflowed && i < Blen; i++)
+            overflowed = mpoly_monomial_overflows(Aexps + N*i, N, ofmask);
+    }
+
+    TMP_END;
+
+    /* slightly dirty: repack monomials can handle 1-bit overfown fields */
+    if (overflowed)
+    {
+        ulong * newAexps;
+        flint_bitcnt_t newAbits = mpoly_fix_bits(Abits + 1, ctx->minfo);
+        N = mpoly_words_per_exp(newAbits, ctx->minfo);
+        newAexps = FLINT_ARRAY_ALLOC(N*A->alloc, ulong);
+        mpoly_repack_monomials(newAexps, newAbits, A->exps, Abits, Blen, ctx->minfo);
+        flint_free(A->exps);
+        A->exps = newAexps;
+        A->bits = newAbits;
+    }
+
+    _fmpz_vec_scalar_mul_fmpz(A->coeffs, B->coeffs, Blen, &Ccoeff0);
+    _fmpz_mpoly_set_length(A, Blen, ctx);
+
+cleanup_C:
+
+    if (freeCcoeff0)
+        fmpz_clear(&Ccoeff0);
+}
+

--- a/fmpz_mpoly/profile/p-univar.c
+++ b/fmpz_mpoly/profile/p-univar.c
@@ -1,0 +1,106 @@
+/*
+    Copyright 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "profiler.h"
+#include "fmpz_mpoly.h"
+
+int main(int argc, char *argv[])
+{
+    slong i, j, k;
+    timeit_t timer;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("\n");
+
+    {
+        slong nreps = 100;
+        slong npolys = 10000;
+        fmpz_mpoly_ctx_t ctx;
+        fmpz_mpoly_struct * mpolys, * mres;
+        fmpz_poly_struct * polys, * res;
+        slong len;
+        ulong exp_bound;
+        flint_bitcnt_t coeff_bits;
+
+        fmpz_mpoly_ctx_init(ctx, 1, ORD_LEX);
+        mpolys = FLINT_ARRAY_ALLOC(npolys, fmpz_mpoly_struct);
+        polys = FLINT_ARRAY_ALLOC(npolys, fmpz_poly_struct);
+        mres = FLINT_ARRAY_ALLOC(npolys, fmpz_mpoly_struct);
+        res = FLINT_ARRAY_ALLOC(npolys, fmpz_poly_struct);
+
+        flint_printf("****** dense mul ********\n");
+
+        for (i = 0; i < npolys; i++)
+        {
+            fmpz_mpoly_init(mpolys + i, ctx);
+            fmpz_poly_init(polys + i);
+            fmpz_mpoly_init(mres + i, ctx);
+            fmpz_poly_init(res + i);
+
+            len = 1 + n_randint(state, 5);
+            exp_bound = len + 1;
+            coeff_bits = 10 + n_randint(state, 10);
+            fmpz_mpoly_randtest_bound(mpolys + i, state, len, coeff_bits, exp_bound, ctx);
+            if (!fmpz_mpoly_get_fmpz_poly(polys + i, mpolys + i, 0, ctx))
+            {
+                flint_printf("oops");
+                flint_abort();
+            }
+        }
+
+        for (j = 0; j < 4; j++)
+        {
+            timeit_start(timer);
+            for (k = 0; k < nreps; k++)
+            for (i = 1; i < npolys; i++)
+                fmpz_mpoly_mul(mres + i, mpolys + i, mpolys + i - 1, ctx);
+            timeit_stop(timer);
+            flint_printf("mpoly: %wd  ", timer->wall);
+            fflush(stdout);
+
+            timeit_start(timer);
+            for (k = 0; k < nreps; k++)
+            for (i = 1; i < npolys; i++)
+                fmpz_poly_mul(res + i, polys + i, polys + i - 1);
+            timeit_stop(timer);
+            flint_printf("poly: %wd\n", timer->wall);
+            fflush(stdout);
+
+            for (i = 1; i < npolys; i++)
+            {
+                if (!fmpz_mpoly_get_fmpz_poly(res + 0, mres + i, 0, ctx) ||
+                    !fmpz_poly_equal(res + 0, res + i))
+                {
+                    flint_printf("oops");
+                    flint_abort();
+                }
+            }
+        }
+
+        for (i = 0; i < npolys; i++)
+        {
+            fmpz_mpoly_clear(mpolys + i, ctx);
+            fmpz_poly_clear(polys + i);
+            fmpz_mpoly_clear(mres + i, ctx);
+            fmpz_poly_clear(res + i);
+        }
+        flint_free(mpolys);
+        flint_free(polys);
+        flint_free(mres);
+        flint_free(res);
+        fmpz_mpoly_ctx_clear(ctx);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+    return 0;
+}

--- a/fmpz_mpoly/profile/p-univar.c
+++ b/fmpz_mpoly/profile/p-univar.c
@@ -184,6 +184,18 @@ int main(int argc, char *argv[])
             exp_bound = len + 1;
             coeff_bits = 10 + n_randint(state, 10);
             fmpz_mpoly_randtest_bound(mpolys + i, state, len, coeff_bits, exp_bound, ctx);
+        }
+        for (i = 0; i + 2 <= npolys; i += 2)
+        {
+            len = 1 + n_randint(state, 5);
+            exp_bound = len + 1;
+            coeff_bits = 10 + n_randint(state, 10);
+            fmpz_mpoly_randtest_bound(mres + 0, state, len, coeff_bits, exp_bound, ctx);
+            fmpz_mpoly_mul(mpolys + i, mpolys + i, mres + 0, ctx);
+            fmpz_mpoly_mul(mpolys + i + 1, mpolys + i + 1, mres + 0, ctx);
+        }
+        for (i = 0; i < npolys; i++)
+        {
             fmpz_mpoly_get_fmpz_poly(polys + i, mpolys + i, 0, ctx);
         }
         run_cmp(mpolys, polys, mres, res, npolys, ctx, (void (*)(fmpz_mpoly_t, const fmpz_mpoly_t, const fmpz_mpoly_t, const fmpz_mpoly_ctx_t)) fmpz_mpoly_gcd, fmpz_poly_gcd);
@@ -195,6 +207,18 @@ int main(int argc, char *argv[])
             exp_bound = len + 1;
             coeff_bits = 10 + n_randint(state, 200);
             fmpz_mpoly_randtest_bound(mpolys + i, state, len, coeff_bits, exp_bound, ctx);
+        }
+        for (i = 0; i + 2 <= npolys; i += 2)
+        {
+            len = 1 + n_randint(state, 5);
+            exp_bound = len + 1;
+            coeff_bits = 10 + n_randint(state, 200);
+            fmpz_mpoly_randtest_bound(mres + 0, state, len, coeff_bits, exp_bound, ctx);
+            fmpz_mpoly_mul(mpolys + i, mpolys + i, mres + 0, ctx);
+            fmpz_mpoly_mul(mpolys + i + 1, mpolys + i + 1, mres + 0, ctx);
+        }
+        for (i = 0; i < npolys; i++)
+        {
             fmpz_mpoly_get_fmpz_poly(polys + i, mpolys + i, 0, ctx);
         }
         run_cmp(mpolys, polys, mres, res, npolys, ctx, (void (*)(fmpz_mpoly_t, const fmpz_mpoly_t, const fmpz_mpoly_t, const fmpz_mpoly_ctx_t)) fmpz_mpoly_gcd, fmpz_poly_gcd);

--- a/fmpz_mpoly/test/t-mul_monomial.c
+++ b/fmpz_mpoly/test/t-mul_monomial.c
@@ -1,0 +1,111 @@
+/*
+    Copyright (C) 2021 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz_mpoly.h"
+
+int
+main(void)
+{
+    slong i, j;
+    slong tmul = 200;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("mul_monomial....");
+    fflush(stdout);
+
+    for (i = 0; i < tmul * flint_test_multiplier(); i++)
+    {
+        fmpz_mpoly_ctx_t ctx;
+        fmpz_mpoly_t a, b, c, d, bb, cc;
+
+        fmpz_mpoly_ctx_init_rand(ctx, state, 20);
+
+        fmpz_mpoly_init(a, ctx);
+        fmpz_mpoly_init(b, ctx);
+        fmpz_mpoly_init(c, ctx);
+        fmpz_mpoly_init(d, ctx);
+        fmpz_mpoly_init(bb, ctx);
+        fmpz_mpoly_init(cc, ctx);
+
+        for (j = 0; j < 10; j++)
+        {
+            fmpz_mpoly_randtest_bits(a, state, 1 + n_randint(state, 50),
+                                               1 + n_randint(state, 200),
+                                               1 + n_randint(state, 192), ctx);
+
+            fmpz_mpoly_randtest_bits(b, state, 1 + n_randint(state, 30),
+                                               1 + n_randint(state, 200),
+                                               1 + n_randint(state, 192), ctx);
+
+            fmpz_mpoly_randtest_bits(c, state, 1,
+                                               1 + n_randint(state, 200),
+                                               1 + n_randint(state, 192), ctx);
+
+            if (fmpz_mpoly_length(c, ctx) != 1 || n_randint(state, 50) == 0)
+                fmpz_mpoly_set_ui(c, n_randtest_not_zero(state), ctx);
+
+            fmpz_mpoly_mul_monomial(a, b, c, ctx);
+            fmpz_mpoly_assert_canonical(a, ctx);
+            fmpz_mpoly_mul_johnson(d, b, c, ctx);
+            if (!fmpz_mpoly_equal(a, d, ctx))
+            {
+                flint_printf("FAIL: check mul_monomial against mul_johnson\n");
+                flint_abort();
+            }
+
+            fmpz_mpoly_set(bb, b, ctx);
+            fmpz_mpoly_set(cc, c, ctx);
+            fmpz_mpoly_mul_monomial(bb, bb, cc, ctx);
+            fmpz_mpoly_assert_canonical(bb, ctx);
+            if (!fmpz_mpoly_equal(bb, d, ctx) ||
+                 !fmpz_mpoly_equal(cc, c, ctx))
+            {
+                flint_printf("FAIL: check aliasing first input\n");
+                flint_abort();
+            }
+
+            fmpz_mpoly_set(bb, b, ctx);
+            fmpz_mpoly_set(cc, c, ctx);
+            fmpz_mpoly_mul_monomial(cc, bb, cc, ctx);
+            fmpz_mpoly_assert_canonical(cc, ctx);
+            if (!fmpz_mpoly_equal(cc, d, ctx) ||
+                 !fmpz_mpoly_equal(bb, b, ctx))
+            {
+                flint_printf("FAIL: check aliasing second input\n");
+                flint_abort();
+            }
+
+            fmpz_mpoly_set(cc, c, ctx);
+            fmpz_mpoly_mul_monomial(cc, cc, cc, ctx);
+            fmpz_mpoly_assert_canonical(cc, ctx);
+            fmpz_mpoly_mul_johnson(d, c, c, ctx);
+            if (!fmpz_mpoly_equal(cc, d, ctx))
+            {
+                flint_printf("FAIL: check aliasing both inputs\n");
+                flint_abort();
+            }
+        }
+
+        fmpz_mpoly_clear(a, ctx);
+        fmpz_mpoly_clear(b, ctx);
+        fmpz_mpoly_clear(c, ctx);
+        fmpz_mpoly_clear(d, ctx);
+        fmpz_mpoly_clear(bb, ctx);
+        fmpz_mpoly_clear(cc, ctx);
+        fmpz_mpoly_ctx_clear(ctx);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+
+    flint_printf("PASS\n");
+    return 0;
+}
+


### PR DESCRIPTION
closes #744 as best as I am willing to try. @fredrik-johansson seems to think addition can be optimized for nvars=1. I am very pessimistic about addition, so I will let him do/try that.

here is my p-univar, which times twice a bunch of operations in a loop.
Edit: the old version is shown on the right, so you can see the regressions.
```
new                                            | old
****** dense mul, small coeffs ********        | ****** dense mul, small coeffs ********
mpoly: 220  poly: 111                          | mpoly: 341  poly: 111
mpoly: 218  poly: 110                          | mpoly: 338  poly: 110
****** dense mul, large coeffs ********        | ****** dense mul, large coeffs ********
mpoly: 742  poly: 742                          | mpoly: 718  poly: 737
mpoly: 738  poly: 737                          | mpoly: 711  poly: 731
****** large dense mul, small coeffs ********  | ****** large dense mul, small coeffs ********
mpoly: 509  poly: 279                          | mpoly: 1802  poly: 277
mpoly: 507  poly: 276                          | mpoly: 1799  poly: 275
****** large dense mul, large coeffs ********  | ****** large dense mul, large coeffs ********
mpoly: 4000  poly: 3321                        | mpoly: 4601  poly: 3305
mpoly: 3981  poly: 3310                        | mpoly: 4586  poly: 3294
****** sparse mul, small coeffs ********       | ****** sparse mul, small coeffs ********
mpoly: 574  poly: 309                          | mpoly: 606  poly: 307
mpoly: 572  poly: 307                          | mpoly: 605  poly: 304
****** sparse mul, large coeffs ********       | ****** sparse mul, large coeffs ********
mpoly: 914  poly: 3144                         | mpoly: 944  poly: 3141
mpoly: 912  poly: 3150                         | mpoly: 948  poly: 3134
****** very sparse mul, small coeffs ********  | ****** very sparse mul, small coeffs ********
mpoly: 616  poly: 953                          | mpoly: 639  poly: 945
mpoly: 615  poly: 948                          | mpoly: 641  poly: 942
****** very sparse mul, large coeffs ********  | ****** very sparse mul, large coeffs ********
mpoly: 936  poly: 6266                         | mpoly: 968  poly: 6263
mpoly: 937  poly: 6264                         | mpoly: 967  poly: 6241
****** gcd, small coeffs ********              | ****** gcd, small coeffs ********
mpoly: 1327  poly: 1427                        | mpoly: 1316  poly: 1422
mpoly: 1325  poly: 1423                        | mpoly: 1313  poly: 1421
****** gcd, large coeffs ********              | ****** gcd, large coeffs ********
mpoly: 4224  poly: 4818                        | mpoly: 4176  poly: 4767
mpoly: 4216  poly: 4814                        | mpoly: 4176  poly: 4789
```
