### PR TITLE
[WIP] start new exception system

### DIFF
--- a/exception.c
+++ b/exception.c
@@ -82,3 +82,52 @@ void flint_throw(flint_err_t exc, const char * msg, ...)
 
      flint_abort();
 }
+
+/**** overridable exception function *****************************************/
+
+FLINT_NORETURN static void
+def_exception_func(int exc, const char * msg, char * extra)
+{
+    flint_printf("flint exception (");
+
+    if (exc == FLINT_ERROR)
+        flint_printf("General error");
+    else if (exc == FLINT_IMPINV)
+        flint_printf("Impossible inverse");
+    else if (exc == FLINT_DOMERR)
+        flint_printf("Domain error");
+    else if (exc == FLINT_DIVZERO)
+        flint_printf("Divide by zero");
+    else if (exc == FLINT_INEXACT)
+        flint_printf("Inexact");
+    else
+        flint_printf("Unknown");
+
+    flint_printf("): ");
+    flint_printf(msg);
+
+    if (extra != NULL)
+    {
+        flint_printf(extra);
+        flint_free(extra);
+    }
+
+    flint_printf("\n");
+    fflush(stdout);
+
+    flint_abort();
+}
+
+FLINT_NORETURN void (*exception_func)(int, const char *, char *) = def_exception_func;
+
+FLINT_NORETURN void
+flint_exception(flint_err_t exc, const char * msg, char * extra)
+{
+    (*exception_func)((int)(exc), msg, extra);
+}
+
+void flint_set_exception(FLINT_NORETURN void (*func)(int, const char *, char *))
+{
+    exception_func = func;
+}
+

--- a/exception.h
+++ b/exception.h
@@ -22,9 +22,20 @@ typedef enum
    FLINT_INEXACT /* inexact error */
 } flint_err_t;
 
+/* for all except NONE the "extra" is flint-mallocated object */
+typedef enum
+{
+    FLINT_EXC_EXTRA_NONE,
+    FLINT_EXC_EXTRA_STR,
+    FLINT_EXC_EXTRA_SI,
+    FLINT_EXC_EXTRA_UI,
+    FLINT_EXC_EXTRA_FMPZ,
+    FLINT_EXC_EXTRA_FMPQ
+} flint_exc_extra_t;
+
 FLINT_DLL void flint_throw(flint_err_t exc, const char * msg, ...);
 
-FLINT_DLL FLINT_NORETURN void flint_exception(flint_err_t exc,
-                                               const char * msg, char * extra);
+FLINT_DLL FLINT_NORETURN void flint_exception(flint_err_t exc, const char * msg,
+                                   flint_exc_extra_t extra_type, void * extra);
 
 #endif

--- a/exception.h
+++ b/exception.h
@@ -24,4 +24,7 @@ typedef enum
 
 FLINT_DLL void flint_throw(flint_err_t exc, const char * msg, ...);
 
+FLINT_DLL FLINT_NORETURN void flint_exception(flint_err_t exc,
+                                               const char * msg, char * extra);
+
 #endif

--- a/fmpz_mod/inv.c
+++ b/fmpz_mod/inv.c
@@ -19,9 +19,19 @@ void fmpz_mod_inv(fmpz_t a, const fmpz_t b, const fmpz_mod_ctx_t ctx)
     fmpz_gcdinv(d, a, b, ctx->n);
     if (!fmpz_is_one(d))
     {
-        fmpz_clear(d);
-        /* printing b and n would entail leaking the string so no b nor n */
-        flint_throw(FLINT_IMPINV, "Exception in fmpz_mod_inv: Cannot invert.\n");
+        if (fmpz_is_zero(b))
+        {
+            fmpz_clear(d);
+            flint_exception(FLINT_DIVZERO, "fmpz_mod_inv: Division by zero.",
+                            FLINT_EXC_EXTRA_NONE, NULL);
+        }
+        else
+        {
+            fmpz * ex = FLINT_ARRAY_ALLOC(1, fmpz);
+            *ex = *d;
+            flint_exception(FLINT_IMPINV, "fmpz_mod_inv: Modulus has divisor ",
+                            FLINT_EXC_EXTRA_FMPZ, ex);
+        }
     }
     fmpz_clear(d);
     FLINT_ASSERT(fmpz_mod_is_canonical(a, ctx));

--- a/ulong_extras/nextprime.c
+++ b/ulong_extras/nextprime.c
@@ -82,8 +82,9 @@ mp_limb_t n_nextprime(mp_limb_t n, int proved)
 
     if (n >= UWORD_MAX_PRIME)
     {
-        flint_printf("Exception (n_nextprime). No larger single-limb prime exists.\n");
-        flint_abort();
+        flint_exception(FLINT_DOMERR,
+                        "n_nextprime: No larger single-limb prime exists.",
+                        NULL);
     }
 
     index = n % 30;

--- a/ulong_extras/nextprime.c
+++ b/ulong_extras/nextprime.c
@@ -84,7 +84,7 @@ mp_limb_t n_nextprime(mp_limb_t n, int proved)
     {
         flint_exception(FLINT_DOMERR,
                         "n_nextprime: No larger single-limb prime exists.",
-                        NULL);
+                        FLINT_EXC_EXTRA_NONE, NULL);
     }
 
     index = n % 30;


### PR DESCRIPTION
The current exception function is not useful because:
- it cannot be overriden
- we always get an annoying message printed to stdout
- there is no way to (or, at least I couldn't figure out a way to) pass the printed string of, say, an fmpz, and have this string cleaned up properly.

I'm sure @thofma will have something to add here.

EDIT:
so I decided to try throwing strings +  objects. This is what it looks like.

First of all, the julia code for these is very clean:
```julia
function inv(a::fmpz_mod)
   R = parent(a)
   z = R()
   ccall((:fmpz_mod_inv, libflint), Nothing,
         (Ref{fmpz}, Ref{fmpz}, Ref{fmpz_mod_ctx_struct}),
	     z.data, a.data, R.ninv)
   return z
end

function next_prime(x::UInt, proved::Bool = true)
   return ccall((:n_nextprime, libflint), UInt,
                (UInt, Cint),
                x, proved)
end
```

Then, you can get in julia some of the flint objects back.

```julia
julia> R = ResidueRing(ZZ, fmpz(100))
Integers modulo 100

julia> inv(R(10))
ERROR: FLINT IMPINV: fmpz_mod_inv: Modulus has divisor 10
Stacktrace:
 [1] flint_exception(exctype::Int32, msg::Ptr{UInt8}, extratype::Int32, extra::Ptr{Nothing})
   @ Nemo ~/.julia/dev/Nemo/src/Nemo.jl:458
 [2] inv(a::fmpz_mod)
   @ Nemo ~/.julia/dev/Nemo/src/flint/fmpz_mod.jl:244
 [3] top-level scope
   @ REPL[5]:1

julia> x = try; inv(R(10)); catch e; e; end;

julia> typeof(x), x.data
(Nemo.FlintException{:impinv, fmpz}, 10)
```