### PR TITLE
Fixed latexpdf errors

### DIFF
--- a/doc/source/fmpq_mpoly.rst
+++ b/doc/source/fmpq_mpoly.rst
@@ -502,7 +502,7 @@ Multiplication
 
 .. function:: void fmpq_mpoly_mul(fmpq_mpoly_t A, const fmpq_mpoly_t B, const fmpq_mpoly_t C, const fmpq_mpoly_ctx_t ctx)
 
-    Set *A* to `B \time C`.
+    Set *A* to `B \times C`.
 
 
 Powering

--- a/doc/source/fmpz.rst
+++ b/doc/source/fmpz.rst
@@ -1074,29 +1074,30 @@ Greatest common divisor
 
     .. math ::
 
-        \newcommand{\xgcd}{\operatorname{xgcd}}
-        \newcommand{\sgn}{\operatorname{sgn}}
-        \begin{align*}
-            \xgcd(\pm g, g) &= \bigl(|g|, 0, \sgn(g)\bigr)\\
-            \xgcd(f, 0) &= \bigl(|f|, \sgn(f), 0\bigr)\\
-            \xgcd(0, g) &= \bigl(|g|, 0, \sgn(g)\bigr)\\
-            \xgcd(f, \mp 1) &= (1, 0, \mp 1)\\
-            \xgcd(\mp 1, g) &= (1, \mp 1, 0)\quad g \neq 0, \pm 1\\
-            \xgcd(\mp 2 d, g) &=
-                \bigl(d, {\textstyle\frac{d - |g|}{\mp 2 d}}, \sgn(g)\bigr)\\
-            \xgcd(f, \mp 2 d) &=
-                \bigl(d, \sgn(f), {\textstyle\frac{d - |g|}{\mp 2 d}}\bigr).
-        \end{align*}
+        \operatorname{xgcd}(\pm g, g) &= \bigl(|g|, 0, \operatorname{sgn}(g)\bigr)
+
+        \operatorname{xgcd}(f, 0) &= \bigl(|f|, \operatorname{sgn}(f), 0\bigr)
+
+        \operatorname{xgcd}(0, g) &= \bigl(|g|, 0, \operatorname{sgn}(g)\bigr)
+
+        \operatorname{xgcd}(f, \mp 1) &= (1, 0, \mp 1)
+
+        \operatorname{xgcd}(\mp 1, g) &= (1, \mp 1, 0)\quad g \neq 0, \pm 1
+
+        \operatorname{xgcd}(\mp 2 d, g) &=
+                \bigl(d, {\textstyle\frac{d - |g|}{\mp 2 d}}, \operatorname{sgn}(g)\bigr)
+
+         \operatorname{xgcd}(f, \mp 2 d) &=
+                \bigl(d, \operatorname{sgn}(f), {\textstyle\frac{d - |g|}{\mp 2 d}}\bigr).
+
 
     If the pair `(f, g)` does not satisfy any of these conditions, the solution
     `(d, a, b)` will satisfy the following:
 
     .. math ::
 
-        \begin{equation*}
             |a| < \Bigl| \frac{g}{2 d} \Bigr|,
             \qquad |b| < \Bigl| \frac{f}{2 d} \Bigr|.
-        \end{equation*}
 
     Assumes that there is no aliasing among the outputs.
 

--- a/doc/source/fmpz_mpoly.rst
+++ b/doc/source/fmpz_mpoly.rst
@@ -458,7 +458,7 @@ Differentiation/Integration
 
 .. function:: void fmpz_mpoly_integral(fmpz_mpoly_t A, fmpz_t scale, const fmpz_mpoly_t B, slong var, const fmpz_mpoly_ctx_t ctx)
 
-    Set *A* and *scale* so that *A* is an integral of `scale \time B` with respect to the variable of index *var*, where *scale* is positive and as small as possible.
+    Set *A* and *scale* so that *A* is an integral of `scale \times B` with respect to the variable of index *var*, where *scale* is positive and as small as possible.
 
 
 Evaluation


### PR DESCRIPTION
fixed conflicts between latex environments and sphinx environments in
fmpz.rst

replaced \time with \times in fmpz_mpoly.rst and fmpq_mpoly.rst (I'm
pretty sure that is what was intended).

This should fix #979