### PR TITLE
fix compilation with musl libc

### DIFF
--- a/thread_pool.h
+++ b/thread_pool.h
@@ -12,14 +12,6 @@
 #ifndef THREAD_POOL_H
 #define THREAD_POOL_H
 
-/* for some reason this define needs to be outside of the next if */
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
-#if FLINT_USES_CPUSET
-#include <sched.h>
-#endif
-
 #include "flint.h"
 
 #if FLINT_USES_PTHREAD
@@ -52,7 +44,7 @@ typedef thread_pool_entry_struct thread_pool_entry_t[1];
 typedef struct
 {
 #if FLINT_USES_CPUSET && FLINT_USES_PTHREAD
-    cpu_set_t original_affinity;
+    void * original_affinity;
 #endif
 #if FLINT_USES_PTHREAD
     pthread_mutex_t mutex;

--- a/thread_pool/clear.c
+++ b/thread_pool/clear.c
@@ -44,6 +44,12 @@ void thread_pool_clear(thread_pool_t T)
     {
         flint_free(D);
     }
+#if FLINT_USES_CPUSET && FLINT_USES_PTHREAD
+    if (T->original_affinity != NULL) {
+        flint_free(T->original_affinity);
+        T->original_affinity = NULL;
+    }
+#endif
 #if FLINT_USES_PTHREAD
     pthread_mutex_unlock(&T->mutex);
     pthread_mutex_destroy(&T->mutex);

--- a/thread_pool/init.c
+++ b/thread_pool/init.c
@@ -9,6 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#define _GNU_SOURCE
+#include <sched.h>
+
 #include "thread_pool.h"
 
 thread_pool_t global_thread_pool;
@@ -73,10 +76,11 @@ void thread_pool_init(thread_pool_t T, slong size)
     T->length = size;
 
 #if FLINT_USES_CPUSET && FLINT_USES_PTHREAD
+    T->original_affinity = flint_malloc(sizeof(cpu_set_t));
     if (0 != pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t),
-                                                        &T->original_affinity))
+                                        (cpu_set_t *)T->original_affinity))
     {
-        CPU_ZERO(&T->original_affinity);
+        CPU_ZERO((cpu_set_t *)T->original_affinity);
     }
 #endif
 

--- a/thread_pool/restore_affinity.c
+++ b/thread_pool/restore_affinity.c
@@ -9,6 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#define _GNU_SOURCE
+#include <sched.h>
+
 #include "thread_pool.h"
 
 int thread_pool_restore_affinity(thread_pool_t T)
@@ -23,14 +26,14 @@ int thread_pool_restore_affinity(thread_pool_t T)
     for (i = 0; i < T->length; i++)
     {
         errorno = pthread_setaffinity_np(D[i].pth, sizeof(cpu_set_t),
-                                                        &T->original_affinity);
+                                            (cpu_set_t *)T->original_affinity);
         if (errorno != 0)
             return errorno;
     }
 
     /* restore affinity for main thread */
     errorno = pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t),
-                                                        &T->original_affinity);
+                                        (cpu_set_t *)T->original_affinity);
     if (errorno != 0)
         return errorno;
 #endif

--- a/thread_pool/set_affinity.c
+++ b/thread_pool/set_affinity.c
@@ -9,6 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#define _GNU_SOURCE
+#include <sched.h>
+
 #include "thread_pool.h"
 
 /*


### PR DESCRIPTION
In order to use `cpu_set_t` it is necessary to `#define _GNU_SOURCE` before including `sched.h`. This is currently done in `thread_pool.h`.

However, in musl libc `sched.h` will be included from `pthread.h`. This means by the time `thread_pool.h` gets to include `sched.h`, it has already been included so it won't work.

The fix is easy: `#define _GNU_SOURCE` before each `#include <pthread.h>`. This is what this PR does.

In `fmpz.h` we check it hasn't been defined before to avoid a warning. The other cases are all in `.c` files which are ok as is.