### PR TITLE
[bug fix] aliasing in ndiv_qr

### DIFF
--- a/fmpz/test/t-ndiv_qr.c
+++ b/fmpz/test/t-ndiv_qr.c
@@ -18,27 +18,28 @@
 int
 main(void)
 {
-    int i, result;
+    slong i;
+    int result;
     FLINT_TEST_INIT(state);
 
     flint_printf("ndiv_qr....");
     fflush(stdout);
 
-    
-    /* Check that a = b * nquo + nrem, and tha nrem is smallest */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
+    /* Check that a = b * nquo + nrem, and that nrem is smallest */
+    for (i = 0; i < 30000 * flint_test_multiplier(); i++)
     {
-        fmpz_t max;
         fmpz_t tmp;
         fmpz_t a, b;
+        fmpz_t A, B;
         fmpz_t nquo, nrem;
         fmpz_t fquo, frem;
         fmpz_t cquo, crem;
 
-        fmpz_init(max);
         fmpz_init(tmp);
         fmpz_init(a);
         fmpz_init(b);
+        fmpz_init(A);
+        fmpz_init(B);
         fmpz_init(nquo);
         fmpz_init(nrem);
         fmpz_init(fquo);
@@ -46,17 +47,30 @@ main(void)
         fmpz_init(cquo);
         fmpz_init(crem);
 
-        fmpz_set_d_2exp(max, 1.0, FLINT_BITS);
-        fmpz_randm(a, state, max);
-        fmpz_randm(b, state, max);
-        if (n_randint(state, 2))
-            fmpz_neg(a, a);
-        if (n_randint(state, 2))
-            fmpz_neg(b, b);
-        if (fmpz_is_zero(b))
-            fmpz_one(b);
+        fmpz_randbits(a, state, n_randint(state, 200));
+        fmpz_randbits(b, state, 1 + n_randint(state, 200));
 
         fmpz_ndiv_qr(nquo, nrem, a, b);
+        {
+            fmpz_set(A, a);
+            fmpz_set(B, b);
+            fmpz_ndiv_qr(A, B, A, B);
+            if (!fmpz_equal(A, nquo) || !fmpz_equal(B, nrem))
+            {
+                flint_printf("FAIL: check (A, B, A, B) aliasing\n");
+                flint_abort();
+            }
+
+            fmpz_set(A, a);
+            fmpz_set(B, b);
+            fmpz_ndiv_qr(B, A, A, B);
+            if (!fmpz_equal(B, nquo) || !fmpz_equal(A, nrem))
+            {
+                flint_printf("FAIL: check (B, A, A, B) aliasing\n");
+                flint_abort();
+            }
+        }
+
         fmpz_fdiv_qr(fquo, frem, a, b);
         fmpz_cdiv_qr(cquo, crem, a, b);
 
@@ -72,13 +86,14 @@ main(void)
             flint_printf("b = "); fmpz_print(b); flint_printf("\n");
             flint_printf("q = "); fmpz_print(nquo); flint_printf("\n");
             flint_printf("r = "); fmpz_print(nrem); flint_printf("\n");
-            abort();
+            flint_abort();
         }
 
-        fmpz_clear(max);
         fmpz_clear(tmp);
         fmpz_clear(a);
         fmpz_clear(b);
+        fmpz_clear(A);
+        fmpz_clear(B);
         fmpz_clear(nquo);
         fmpz_clear(nrem);
         fmpz_clear(fquo);
@@ -106,7 +121,7 @@ main(void)
         fmpz_init(tquo);
         fmpz_init(trem);
 
-        fmpz_set_d_2exp(max, 1.0, FLINT_BITS);
+        fmpz_set_d_2exp(max, 1.0, 2*FLINT_BITS);
         fmpz_randm(a, state, max);
         fmpz_set(b, a);
 
@@ -139,7 +154,7 @@ main(void)
             flint_printf("b = "); fmpz_print(b); flint_printf("\n");
             flint_printf("q = "); fmpz_print(nquo); flint_printf("\n");
             flint_printf("r = "); fmpz_print(nrem); flint_printf("\n");
-            abort();
+            flint_abort();
         }
 
         fmpz_clear(max);


### PR DESCRIPTION
Should be back ported to 2.8. But, first let's make sure @albinahlback doesn't want to optimize the non-small cases further. This code already removes extra the fmpz_submul, and my initial impression is that it is not worth optimizing the case of one small input and one large input.