### PR TITLE
Use the same ulong workaround as in nmod_vec.h

### DIFF
--- a/qsieve/factor.c
+++ b/qsieve/factor.c
@@ -21,6 +21,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#undef ulong
+#define ulong ulongxx /* interferes with system includes */
 #include <sys/types.h>
 #if (!defined (__WIN32) || defined(__CYGWIN__)) && !defined(_MSC_VER)
 #include <unistd.h>
@@ -46,7 +48,7 @@ void qsieve_factor(fmpz_factor_t factors, const fmpz_t n)
 {
     qs_t qs_inf;
     mp_limb_t small_factor, delta;
-    ulong expt = 0;
+    ulongxx expt = 0;
     unsigned char * sieve;
     slong ncols, nrows, i, j = 0, count, relation = 0, num_primes;
     uint64_t * nullrows = NULL;
@@ -195,7 +197,7 @@ void qsieve_factor(fmpz_factor_t factors, const fmpz_t n)
     qs_inf->num_handles = flint_request_threads(&qs_inf->handles, flint_get_num_threads());
 
     /* ensure cache lines don't overlap if num_handles > 0 */
-    sieve = flint_malloc((qs_inf->sieve_size + sizeof(ulong)
+    sieve = flint_malloc((qs_inf->sieve_size + sizeof(ulongxx)
                + (qs_inf->num_handles > 0 ? 64 : 0))*(qs_inf->num_handles + 1));
 
 #if FLINT_USES_PTHREAD


### PR DESCRIPTION
For https://github.com/sagemathinc/JSage, I'm building FLINT for WebAssembly against GMP with long long limbs (WASM has 32-bit pointers but 64-bit arithmetic, so it WASM GMP is much faster when built with long long limbs).  This ends up conflicting with how "ulong" is defined internally in FLINT.   FLINT already has a workaround for this sort of problem in the file nmod_vec.h, but not in qsieve/factor.c.  I'm proposing using the same workaround there.