### PR TITLE
Better code for Stirling numbers of both kinds

### DIFF
--- a/arith.h
+++ b/arith.h
@@ -54,12 +54,12 @@ FLINT_DLL void arith_divisors(fmpz_poly_t res, const fmpz_t n);
 
 /* Stirling numbers **********************************************************/
 
-FLINT_DLL void arith_stirling_number_1u(fmpz_t s, slong n, slong k);
-FLINT_DLL void arith_stirling_number_1(fmpz_t s, slong n, slong k);
+FLINT_DLL void arith_stirling_number_1u(fmpz_t s, ulong n, ulong k);
+FLINT_DLL void arith_stirling_number_1(fmpz_t s, ulong n, ulong k);
 FLINT_DLL void arith_stirling_number_2(fmpz_t s, slong n, slong k);
 
-FLINT_DLL void arith_stirling_number_1u_vec(fmpz * row, slong n, slong klen);
-FLINT_DLL void arith_stirling_number_1_vec(fmpz * row, slong n, slong klen);
+FLINT_DLL void arith_stirling_number_1u_vec(fmpz * row, ulong n, slong klen);
+FLINT_DLL void arith_stirling_number_1_vec(fmpz * row, ulong n, slong klen);
 FLINT_DLL void arith_stirling_number_2_vec(fmpz * row, slong n, slong klen);
 
 FLINT_DLL void arith_stirling_number_1u_vec_next(fmpz * row,

--- a/arith.h
+++ b/arith.h
@@ -56,11 +56,11 @@ FLINT_DLL void arith_divisors(fmpz_poly_t res, const fmpz_t n);
 
 FLINT_DLL void arith_stirling_number_1u(fmpz_t s, ulong n, ulong k);
 FLINT_DLL void arith_stirling_number_1(fmpz_t s, ulong n, ulong k);
-FLINT_DLL void arith_stirling_number_2(fmpz_t s, slong n, slong k);
+FLINT_DLL void arith_stirling_number_2(fmpz_t s, ulong n, ulong k);
 
 FLINT_DLL void arith_stirling_number_1u_vec(fmpz * row, ulong n, slong klen);
 FLINT_DLL void arith_stirling_number_1_vec(fmpz * row, ulong n, slong klen);
-FLINT_DLL void arith_stirling_number_2_vec(fmpz * row, slong n, slong klen);
+FLINT_DLL void arith_stirling_number_2_vec(fmpz * row, ulong n, slong klen);
 
 FLINT_DLL void arith_stirling_number_1u_vec_next(fmpz * row,
         const fmpz * prev, slong n, slong klen);

--- a/arith/stirling2.c
+++ b/arith/stirling2.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2010 Fredrik Johansson
+    Copyright (C) 2010, 2021 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -9,50 +9,513 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include <string.h>
 #include "arith.h"
+#include "nmod_poly.h"
+#include "fmpq_poly.h"
 
-static __inline__ void
-_fmpz_addmul_alt(fmpz_t s, fmpz_t t, fmpz_t u, int parity)
+/* S(n,k) <= (1/2) binomial(n,k) * k^(n-k) */
+static slong
+stirling_2_bound_2exp(ulong n, ulong k)
 {
-    if (parity % 2)
-        fmpz_submul(s, t, u);
-    else
-        fmpz_addmul(s, t, u);
+    double bnk;
+    int exp;
+    slong bnk_exp, j;
+
+    /* binomial coefficients */
+    bnk = 1.0;
+    bnk_exp = 0;
+
+    for (j = 1; j <= k; j++)
+    {
+        bnk = (bnk * (n + 1 - j)) / j;
+        bnk = frexp(bnk, &exp);
+        bnk_exp += exp;
+    }
+
+    /* (1/2) * binomial(n,k) * k^(n-k) */
+    /* add instead of subtract 1 to ensure upper bound in fp */
+    return bnk_exp + (n - k) * log(k) * 1.44269504088896 + 1;
+}
+
+static slong
+stirling_2_bound_2exp_vec(slong * bound, ulong n, slong len)
+{
+    double bnk;
+    int exp;
+    slong bnk_exp, k, max, kmax;
+
+    kmax = len - 1;
+    bound[0] = 0;
+
+    max = 0;
+
+    /* binomial coefficients */
+    bnk = 1.0;
+    bnk_exp = 0;
+
+    for (k = 1; k <= kmax; k++)
+    {
+        /* binomial recurrence */
+        bnk = (bnk * (n + 1 - k)) / k;
+        bnk = frexp(bnk, &exp);
+        bnk_exp += exp;
+
+        /* (1/2) * binomial(n,k) * k^(n-k) */
+        bound[k] = bnk_exp + (n-k) * log(k) * 1.44269504088896 + 1;
+        max = FLINT_MAX(max, bound[k]);
+    }
+
+    return max;
+}
+
+#if FLINT_BITS == 32
+#define MAX_N_1LIMB 16
+#define MAX_N_2LIMB 26
+#else
+#define MAX_N_1LIMB 26
+#define MAX_N_2LIMB 43
+#endif
+
+static void
+triangular_1(mp_ptr c, slong n, slong klen)
+{
+    slong m, k;
+
+    c[0] = 0; c[1] = 1; c[2] = 3; c[3] = 1;
+
+    for (m = 4; m <= n; m++)
+    {
+        if (m < klen)
+            c[m] = 1;
+
+        for (k = FLINT_MIN(m, klen) - 1; k >= 2; k--)
+            c[k] = c[k] * k + c[k - 1];
+    }
 }
 
 static void
-_fmpz_stirling2_powsum(fmpz_t s, slong n, slong k)
+triangular_2(mp_ptr c, slong n, slong klen)
+{
+    mp_limb_t hi, lo;
+    slong m, k;
+
+    triangular_1(c, MAX_N_1LIMB, klen);
+
+    for (k = FLINT_MIN(MAX_N_1LIMB, klen - 1); k >= 0; k--)
+    {
+        c[2 * k] = c[k];
+        c[2 * k + 1] = 0;
+    }
+
+    for (m = MAX_N_1LIMB + 1; m <= n; m++)
+    {
+        if (m < klen)
+        {
+            c[2 * m] = 1;
+            c[2 * m + 1] = 0;
+        }
+
+        for (k = FLINT_MIN(m, klen) - 1; k >= 2; k--)
+        {
+            umul_ppmm(hi, lo, c[2 * k], k);
+            hi += c[2 * k + 1] * k;
+            add_ssaaaa(c[2 * k + 1], c[2 * k],
+                hi, lo, c[2 * (k - 1) + 1], c[2 * (k - 1)]);
+        }
+    }
+}
+
+void
+arith_stirling_number_2_vec_triangular(fmpz * row, slong n, slong klen)
+{
+    mp_limb_t c[2 * MAX_N_2LIMB + 2];
+    slong m, k;
+
+    if (klen <= 0)
+        return;
+
+    if (n >= 1)
+    {
+        if (n <= MAX_N_1LIMB)
+        {
+            triangular_1(c, n, klen);
+            for (k = 0; k <= FLINT_MIN(klen - 1, n); k++)
+                fmpz_set_ui(row + k, c[k]);
+        }
+        else
+        {
+            m = FLINT_MIN(n, MAX_N_2LIMB);
+
+            triangular_2(c, m, klen);
+            for (k = 0; k <= FLINT_MIN(klen - 1, m); k++)
+                fmpz_set_uiui(row + k, c[2 * k + 1], c[2 * k]);
+
+            for (m = MAX_N_2LIMB + 1 ; m <= n; m++)
+            {
+                if (m < klen)
+                    fmpz_one(row + m);
+
+                for (k = FLINT_MIN(m, klen) - 1; k >= 2; k--)
+                {
+                    fmpz_mul_ui(row + k, row + k, k);
+                    fmpz_add(row + k, row + k - 1, row + k);
+                }
+            }
+        }
+    }
+
+    for (k = n; k < klen; k++)
+        fmpz_set_ui(row + k, k == n);
+}
+
+void
+arith_stirling_number_2_vec_convolution(fmpz * res, ulong n, slong klen)
+{
+    slong k, kodd, len;
+    ulong e;
+    fmpz *t, *u, *v;
+
+    if (klen <= 0)
+        return;
+
+    len = FLINT_MIN(klen - 1, n - 1);
+
+    t = _fmpz_vec_init(len + 1);
+    u = _fmpz_vec_init(len);
+    v = _fmpz_vec_init(len);
+
+    if (n >= 1 && len >= 1)
+    {
+        fmpz_one(t + len);
+        for (k = len - 1; k >= 0; k--)
+            fmpz_mul_ui(t + k, t + k + 1, k + 1);
+
+        for (kodd = 1; kodd <= len; kodd += 2)
+        {
+            fmpz_set_ui(v, kodd);
+            fmpz_pow_ui(v, v, n);
+
+            for (k = kodd, e = 0; k <= len; k *= 2, e++)
+            {
+                /* k^n / k! */
+                fmpz_mul(u + k - 1, v, t + k);
+                fmpz_mul_2exp(u + k - 1, u + k - 1, e * n);
+            }
+        }
+
+        for (k = 1; k < len; k += 2)
+            fmpz_neg(t + k, t + k);
+
+        _fmpz_poly_mullow(v, t, len, u, len, len);
+
+        fmpz_mul(t, t, t);
+        for (k = 0; k < len; k++)
+            fmpz_divexact(res + k + 1, v + k, t);
+    }
+
+    fmpz_set_ui(res + 0, n == 0);
+    for (k = n; k < klen; k++)
+        fmpz_set_ui(res + k, n == k);
+
+    _fmpz_vec_clear(t, len + 1);
+    _fmpz_vec_clear(u, len);
+    _fmpz_vec_clear(v, len);
+}
+
+static void
+arith_stirling_number_2_nmod_vec(mp_ptr res, ulong n, slong len, nmod_t mod)
+{
+    mp_ptr t, u;
+    slong i, j;
+    mp_limb_t c;
+    TMP_INIT;
+    TMP_START;
+
+    t = TMP_ALLOC(len * sizeof(mp_limb_t));
+    u = TMP_ALLOC(len * sizeof(mp_limb_t));
+    memset(u, 0, len * sizeof(mp_limb_t));
+
+    /* compute inverse factorials */
+    t[len - 1] = 1;
+    for (i = len - 2; i >= 0; i--)
+        t[i] = nmod_mul(t[i + 1], i + 1, mod);
+
+    c = nmod_inv(t[0], mod);
+    t[0] = 1;
+    for (i = 1; i < len; i++)
+        t[i] = nmod_mul(t[i], c, mod);
+
+    /* compute powers */
+    u[0] = nmod_pow_ui(0, n, mod);
+    u[1] = nmod_pow_ui(1, n, mod);
+
+    for (i = 2; i < len; i++)
+    {
+        if (u[i] == 0)
+            u[i] = nmod_pow_ui(i, n, mod);
+
+        for (j = 2; j <= i && i * j < len; j++)
+            if (u[i * j] == 0)
+                u[i * j] = nmod_mul(u[i], u[j], mod);
+    }
+
+    for (i = 1; i < len; i++)
+        u[i] = nmod_mul(u[i], t[i], mod);
+
+    for (i = 1; i < len; i += 2)
+        t[i] = nmod_neg(t[i], mod);
+
+    _nmod_poly_mullow(res, t, len, u, len, len, mod);
+
+    TMP_END;
+}
+
+#define CRT_MAX_RESOLUTION 16
+
+void
+arith_stirling_number_2_vec_multi_mod(fmpz * res, ulong n, slong klen)
+{
+    fmpz_comb_t comb[CRT_MAX_RESOLUTION];
+    fmpz_comb_temp_t temp[CRT_MAX_RESOLUTION];
+    mp_ptr primes, residues;
+    mp_ptr * polys;
+    nmod_t mod;
+    slong i, j, k, len, num_primes, num_primes_k, resolution;
+    slong need_bits, size, prime_bits;
+    slong *bounds;
+    /* per comb */
+    slong * local_len;
+    slong * local_num_primes;
+
+    if (klen <= 0)
+        return;
+
+    if (n <= 2)
+    {
+        arith_stirling_number_2_vec_triangular(res, n, klen);
+        return;
+    }
+
+    if (klen > n + 1)
+    {
+        _fmpz_vec_zero(res + n + 1, klen - n - 1);
+        klen = n + 1;
+    }
+
+    len = klen;
+
+    bounds = flint_malloc(sizeof(slong) * len);
+
+    need_bits = stirling_2_bound_2exp_vec(bounds, n, len);
+    need_bits = FLINT_MAX(need_bits, 1);
+
+    /* make bounds nonincreasing */
+    for (k = len - 2; k >= 0; k--)
+        bounds[k] = FLINT_MAX(bounds[k], bounds[k + 1]);
+
+    resolution = FLINT_MAX(1, FLINT_MIN(CRT_MAX_RESOLUTION, n / 16));
+
+    size = need_bits;
+    prime_bits = FLINT_BITS - 1;
+    num_primes = (size + prime_bits - 1) / prime_bits;
+
+    primes = flint_malloc(num_primes * sizeof(mp_limb_t));
+    residues = flint_malloc(num_primes * sizeof(mp_limb_t));
+    polys = flint_malloc(num_primes * sizeof(mp_ptr));
+
+    local_len = flint_malloc(resolution * sizeof(slong));
+    local_num_primes = flint_malloc(resolution * sizeof(slong));
+
+    primes[0] = n_nextprime(UWORD(1) << prime_bits, 0);
+    for (k = 1; k < num_primes; k++)
+        primes[k] = n_nextprime(primes[k-1], 0);
+
+    for (i = 0; i < resolution; i++)
+    {
+        local_num_primes[i] = FLINT_MAX(1, num_primes * (i + 1) / resolution);
+
+        fmpz_comb_init(comb[i], primes, local_num_primes[i]);
+        fmpz_comb_temp_init(temp[i], comb[i]);
+        local_len[i] = len;
+
+        if (i > 0)
+        {
+            while (local_len[i] > 0 && bounds[local_len[i] - 1] < prime_bits * local_num_primes[i - 1])
+                local_len[i]--;
+        }
+    }
+
+    for (j = 0; j < num_primes; j++)
+    {
+        i = resolution - 1;
+        while (i > 0 && j < local_num_primes[i - 1])
+            i--;
+
+        polys[j] = _nmod_vec_init(local_len[i]);
+        nmod_init(&mod, primes[j]);
+        arith_stirling_number_2_nmod_vec(polys[j], n, local_len[i], mod);
+    }
+
+    for (k = 0; k < len; k++)
+    {
+        i = 0;
+        while (i + 1 < resolution && bounds[k] >= comb[i]->num_primes * prime_bits)
+            i++;
+
+        /* Use only as large a comb as needed */
+        num_primes_k = comb[i]->num_primes;
+
+        for (j = 0; j < num_primes_k; j++)
+            residues[j] = polys[j][k];
+
+        fmpz_multi_CRT_ui(res + k, residues, comb[i], temp[i], 0);
+    }
+
+    /* Cleanup */
+    for (k = 0; k < num_primes; k++)
+        _nmod_vec_clear(polys[k]);
+
+    for (i = 0; i < resolution; i++)
+    {
+        fmpz_comb_temp_clear(temp[i]);
+        fmpz_comb_clear(comb[i]);
+    }
+
+    flint_free(primes);
+    flint_free(residues);
+    flint_free(polys);
+
+    flint_free(bounds);
+
+    flint_free(local_len);
+    flint_free(local_num_primes);
+}
+
+void
+arith_stirling_number_2_vec(fmpz * row, ulong n, slong klen)
+{
+    if (n <= 80)
+        arith_stirling_number_2_vec_triangular(row, n, klen);
+    else if (klen < n / 2)
+        arith_stirling_number_2_vec_convolution(row, n, klen);
+    else
+        arith_stirling_number_2_vec_multi_mod(row, n, klen);
+}
+
+static void
+stirling_2_egf(fmpz_t res, ulong n, ulong k)
+{
+    fmpz * num;
+    fmpz * rnum;
+    fmpz_t den;
+    fmpz_t rden;
+    slong i, len;
+
+    if (k >= n || k == 0)
+    {
+        fmpz_set_ui(res, n == k);
+        return;
+    }
+
+    len = n - k + 1;
+
+    num = _fmpz_vec_init(len);
+    rnum = _fmpz_vec_init(len);
+    fmpz_init(den);
+    fmpz_init(rden);
+
+    fmpz_one(num + len - 1);
+    for (i = len - 2; i >= 0; i--)
+        fmpz_mul_ui(num + i, num + i + 1, i + 2);
+
+    fmpz_set(den, num + 0);
+
+    _fmpq_poly_pow_trunc(rnum, rden, num, den, len, k, len);
+
+    fmpz_set_ui(num, k);
+    fmpz_add_ui(num, num, 1);
+    fmpz_rfac_ui(num, num, n - k);
+
+    fmpz_mul(num, num, rnum + n - k);
+    fmpz_divexact(res, num, rden);
+
+    _fmpz_vec_clear(num, len);
+    _fmpz_vec_clear(rnum, len);
+    fmpz_clear(den);
+    fmpz_clear(rden);
+}
+
+static void
+_fmpz_ui_pow_ui(fmpz_t x, ulong b, ulong e)
+{
+    if (e <= 1)
+    {
+        fmpz_set_ui(x, e == 0 ? 1 : b);
+    }
+    else if (e == 2)
+    {
+        mp_limb_t t[2];
+        umul_ppmm(t[1], t[0], b, b);
+        fmpz_set_uiui(x, t[1], t[0]);
+    }
+    else if (b <= 1)
+    {
+        fmpz_set_ui(x, b);
+    }
+    else
+    {
+        ulong bits = FLINT_BIT_COUNT(b);
+
+        if (e * bits <= FLINT_BITS)
+        {
+            fmpz_set_ui(x, n_pow(b, e));
+        }
+        else
+        {
+            __mpz_struct * z = _fmpz_promote(x);
+            flint_mpz_set_ui(z, b);
+            flint_mpz_pow_ui(z, z, e);
+            _fmpz_demote_val(x);
+        }
+    }
+}
+
+static void
+stirling_2_powsum(fmpz_t s, ulong n, ulong k)
 {
     fmpz_t t, u;
-    fmpz * bc;
-    slong j, m, max_bc;
+    fmpz *b;
+    slong i, j, m, max_b;
+
+    max_b = (k + 1) / 2;
 
     fmpz_init(t);
     fmpz_init(u);
-    max_bc = (k+1) / 2;
+    b = _fmpz_vec_init(max_b + 1);
 
-    bc = _fmpz_vec_init(max_bc + 1);
-    fmpz_one(bc);
-    for (j = 1; j <= max_bc; j++)
+    fmpz_one(b + 0);
+    for (j = 1; j <= max_b; j++)
     {
-        fmpz_set(bc+j, bc+j-1);
-        fmpz_mul_ui(bc+j, bc+j, k+1-j);
-        fmpz_divexact_ui(bc+j, bc+j, j);
+        fmpz_mul_ui(b + j, b + j - 1, k + 1 - j);
+        fmpz_divexact_ui(b  + j, b + j, j);
     }
 
     fmpz_zero(s);
     for (j = 1; j <= k; j += 2)
     {
-        fmpz_set_ui(u, j);
-        fmpz_pow_ui(u, u, n);
+        _fmpz_ui_pow_ui(u, j, n);
+
         m = j;
-        /* Process each m = 2^p * j */
-        while (1)
+        while (1)  /* Process each m = 2^p * j */
         {
-            if (m > max_bc)
-                _fmpz_addmul_alt(s, bc+k-m, u, k + m);
+            i = (m <= max_b) ? m : k - m;
+
+            if ((k + m) & 1)
+                fmpz_submul(s, b + i, u);
             else
-                _fmpz_addmul_alt(s, bc+m, u, k + m);
+                fmpz_addmul(s, b + i, u);
+
             m *= 2;
             if (m > k)
                 break;
@@ -60,61 +523,227 @@ _fmpz_stirling2_powsum(fmpz_t s, slong n, slong k)
         }
     }
 
-    _fmpz_vec_clear(bc, max_bc + 1);
+    _fmpz_vec_clear(b, max_b + 1);
     fmpz_fac_ui(t, k);
     fmpz_divexact(s, s, t);
     fmpz_clear(t);
     fmpz_clear(u);
 }
 
-void
-arith_stirling_number_2(fmpz_t s, slong n, slong k)
+/* req: k >= 2 */
+static mp_limb_t
+stirling_2_nmod(ulong n, ulong k, nmod_t mod)
 {
-    if (n < 0 || k < 0 || k > n)
+    mp_ptr t, u;
+    slong i, j, bin_len, pow_len;
+    mp_limb_t s1, s2, bden, bd;
+    int bound_limbs;
+    TMP_INIT;
+    TMP_START;
+
+    pow_len = k + 1;
+    bin_len = FLINT_MIN(pow_len, k / 2 + 1);
+
+    t = TMP_ALLOC(bin_len * sizeof(mp_limb_t));
+    u = TMP_ALLOC(pow_len * sizeof(mp_limb_t));
+    memset(u, 0, pow_len * sizeof(mp_limb_t));
+
+    /* compute binomial coefficients + denominator */
+    t[0] = 1;
+    for (i = 1; i < bin_len; i++)
+        t[i] = nmod_mul(t[i - 1], k + 1 - i, mod);
+
+    bd = t[bin_len - 1 - (k + 1) % 2];
+    bden = 1;
+    for (i = bin_len - 1; i >= 0; i--)
     {
-        fmpz_zero(s);
-        return;
+        bden = nmod_mul(bden, i + 1, mod);
+        t[i] = nmod_mul(t[i], bden, mod);
     }
 
-    /* Topmost diagonals */
-    if (k >= n - 1)
+    /* compute powers */
+    u[0] = nmod_pow_ui(0, n, mod);
+    u[1] = nmod_pow_ui(1, n, mod);
+
+    for (i = 2; i < pow_len; i++)
     {
-        if (k == n)
-            fmpz_one(s);
-        else /* k == n - 1 */
-        {
-            /* S(n,n-1) = binomial(n,2) */
-            fmpz_set_ui(s, n);
-            fmpz_mul_ui(s, s, n-1);
-            fmpz_divexact_ui(s, s, UWORD(2));
-        }
-        return;
+        if (u[i] == 0)
+            u[i] = nmod_pow_ui(i, n, mod);
+
+        for (j = 2; j <= i && i * j < pow_len; j++)
+            if (u[i * j] == 0)
+                u[i * j] = nmod_mul(u[i], u[j], mod);
     }
 
-    /* Leftmost columns */
-    if (k <= 2)
+    for (i = 1; i < bin_len; i += 2)
+        t[i] = nmod_neg(t[i], mod);
+
+    bound_limbs = _nmod_vec_dot_bound_limbs(bin_len, mod);
+    s1 = _nmod_vec_dot(t, u, bin_len, mod, bound_limbs);
+
+    if (pow_len > bin_len)
     {
-        if (k < 2)
-            fmpz_set_ui(s, k);
+        bound_limbs = _nmod_vec_dot_bound_limbs(pow_len - bin_len, mod);
+        s2 = _nmod_vec_dot_rev(u + bin_len, t + k - pow_len + 1, pow_len - bin_len, mod, bound_limbs);
+        if (k % 2)
+            s1 = nmod_sub(s1, s2, mod);
         else
-        {
-            /* S(n,2) = 2^(n-1)-1 */
-            fmpz_one(s);
-            fmpz_mul_2exp(s, s, n-1);
-            fmpz_sub_ui(s, s, UWORD(1));
-        }
-        return;
+            s1 = nmod_add(s1, s2, mod);
     }
 
-    _fmpz_stirling2_powsum(s, n, k);
+    TMP_END;
+
+    if (k % 2)
+        s1 = nmod_neg(s1, mod);
+
+    bden = nmod_mul(bden, bden, mod);
+    bden = nmod_mul(bden, bd, mod);
+    bden = nmod_inv(bden, mod);
+    return nmod_mul(s1, bden, mod);
+}
+
+static void
+_fmpz_crt_combine(fmpz_t r1r2, fmpz_t m1m2, const fmpz_t r1, const fmpz_t m1, const fmpz_t r2, const fmpz_t m2)
+{
+    fmpz_invmod(m1m2, m1, m2);
+    fmpz_mul(m1m2, m1m2, m1);
+    fmpz_sub(r1r2, r2, r1);
+    fmpz_mul(r1r2, r1r2, m1m2);
+    fmpz_add(r1r2, r1r2, r1);
+    fmpz_mul(m1m2, m1, m2);
+    fmpz_mod(r1r2, r1r2, m1m2);
+}
+
+static void
+tree_crt(fmpz_t r, fmpz_t m, mp_srcptr residues, mp_srcptr primes, slong len)
+{
+    if (len == 0)
+    {
+        fmpz_zero(r);
+        fmpz_one(m);
+    }
+    else if (len == 1)
+    {
+        fmpz_set_ui(r, residues[0]);
+        fmpz_set_ui(m, primes[0]);
+    }
+    else
+    {
+        fmpz_t r1, m1, r2, m2;
+
+        fmpz_init(r1);
+        fmpz_init(m1);
+        fmpz_init(r2);
+        fmpz_init(m2);
+
+        tree_crt(r1, m1, residues, primes, len / 2);
+        tree_crt(r2, m2, residues + len / 2, primes + len / 2, len - len / 2);
+        _fmpz_crt_combine(r, m, r1, m1, r2, m2);
+
+        fmpz_clear(r1);
+        fmpz_clear(m1);
+        fmpz_clear(r2);
+        fmpz_clear(m2);
+    }
+}
+
+static void
+stirling_2_multi_mod(fmpz_t res, ulong n, ulong k)
+{
+    fmpz_t tmp;
+    nmod_t mod;
+    mp_ptr primes, residues;
+    slong i, num_primes;
+    flint_bitcnt_t size, prime_bits;
+
+    size = stirling_2_bound_2exp(n, k);
+    prime_bits = FLINT_BITS - 1;
+    num_primes = (size + prime_bits - 1) / prime_bits;
+
+    fmpz_init(tmp);
+    primes = flint_malloc(num_primes * sizeof(mp_limb_t));
+    residues = flint_malloc(num_primes * sizeof(mp_limb_t));
+
+    primes[0] = n_nextprime(UWORD(1) << prime_bits, 0);
+    for (i = 1; i < num_primes; i++)
+        primes[i] = n_nextprime(primes[i - 1], 0);
+
+    for (i = 0; i < num_primes; i++)
+    {
+        nmod_init(&mod, primes[i]);
+        residues[i] = stirling_2_nmod(n, k, mod);
+    }
+
+    tree_crt(res, tmp, residues, primes, num_primes);
+
+    flint_free(primes);
+    flint_free(residues);
+    fmpz_clear(tmp);
 }
 
 void
-arith_stirling_number_2_vec(fmpz * row, slong n, slong klen)
+arith_stirling_number_2(fmpz_t res, ulong n, ulong k)
 {
-    slong m;
+    if (k >= n)
+    {
+        fmpz_set_ui(res, n == k);
+    }
+    else if (k <= 1)
+    {
+        fmpz_set_ui(res, k);
+    }
+    else if (k == n - 1)  /* S(n, n-1) = binomial(n, 2) */
+    {
+        fmpz_set_ui(res, n);
+        fmpz_mul_ui(res, res, n - 1);
+        fmpz_tdiv_q_2exp(res, res, 1);
+    }
+    else if (k == 2) /* S(n,2) = 2^(n-1)-1 */
+    {
+        fmpz_one(res);
+        fmpz_mul_2exp(res, res, n - 1);
+        fmpz_sub_ui(res, res, 1);
+    }
+    else if (n <= MAX_N_1LIMB)
+    {
+        mp_limb_t c[MAX_N_2LIMB + 1];
+        triangular_1(c, n, k + 1);
+        fmpz_set_ui(res, c[k]);
+    }
+    else if (n <= MAX_N_2LIMB)
+    {
+        mp_limb_t c[2 * MAX_N_2LIMB + 2];
+        triangular_2(c, n, k + 1);
+        fmpz_set_uiui(res, c[2 * k + 1], c[2 * k]);
+    }
+    else
+    {
+        double low_cutoff, high_cutoff;
 
-    for (m = 0; m <= n; m++)
-        arith_stirling_number_2_vec_next(row, row, m, klen);
+        if (n < 200)
+        {
+            low_cutoff = high_cutoff = 0.9;
+        }
+        else
+        {
+            if (n < 3000)
+                low_cutoff = 0.95 * exp(-0.00022 * n);
+            else
+                low_cutoff = 1500 / n;
+
+            low_cutoff = FLINT_MAX(low_cutoff, 0.0002);
+            low_cutoff = FLINT_MIN(low_cutoff, 0.8);
+
+            high_cutoff = 0.92 + 0.005 * log(n);
+            high_cutoff = FLINT_MIN(high_cutoff, 0.98);
+        }
+
+        if (k <= low_cutoff * n)
+            stirling_2_powsum(res, n, k);
+        else if (k >= high_cutoff * n)
+            stirling_2_egf(res, n, k);
+        else
+            stirling_2_multi_mod(res, n, k);
+    }
 }
 

--- a/arith/test/t-stirling.c
+++ b/arith/test/t-stirling.c
@@ -71,6 +71,75 @@ int main(void)
             }
         }
 
+        for (iter = 0; iter < 100 * flint_test_multiplier(); iter++)
+        {
+            n = n_randint(state, 1000);
+            k = 1 + n_randint(state, 1000);
+
+            arith_stirling_number_2(a, n + 1, k);
+            arith_stirling_number_2(b, n, k);
+            arith_stirling_number_2(c, n, k - 1);
+
+            fmpz_set(d, c);
+            fmpz_addmul_ui(d, b, k);
+
+            if (!fmpz_equal(a, d))
+            {
+                flint_printf("stirling2");
+                flint_printf("n = %wd, k = %wd\n", n, k);
+                flint_printf("a: "); fmpz_print(a); flint_printf("\n");
+                flint_printf("b: "); fmpz_print(b); flint_printf("\n");
+                flint_printf("c: "); fmpz_print(c); flint_printf("\n");
+                flint_printf("d: "); fmpz_print(d); flint_printf("\n");
+                abort();
+            }
+        }
+
+        for (iter = 0; iter < 50 * flint_test_multiplier(); iter++)
+        {
+            n = n_randint(state, 200);
+            k = 1 + n_randint(state, 200);
+
+            row = _fmpz_vec_init(k + 1);
+
+            arith_stirling_number_1u_vec(row, n, k + 1);
+            arith_stirling_number_1u(b, n, k);
+
+            if (!fmpz_equal(row + k, b))
+            {
+                flint_printf("stirling1u (2)");
+                flint_printf("n = %wd, k = %wd\n", n, k);
+                flint_printf("a: "); fmpz_print(row + k); flint_printf("\n");
+                flint_printf("b: "); fmpz_print(b); flint_printf("\n");
+                abort();
+            }
+
+            _fmpz_vec_clear(row, k + 1);
+        }
+
+
+        for (iter = 0; iter < 50 * flint_test_multiplier(); iter++)
+        {
+            n = n_randint(state, 400);
+            k = 1 + n_randint(state, 400);
+
+            row = _fmpz_vec_init(k + 1);
+
+            arith_stirling_number_2_vec(row, n, k + 1);
+            arith_stirling_number_2(b, n, k);
+
+            if (!fmpz_equal(row + k, b))
+            {
+                flint_printf("stirling2 (2)");
+                flint_printf("n = %wd, k = %wd\n", n, k);
+                flint_printf("a: "); fmpz_print(row + k); flint_printf("\n");
+                flint_printf("b: "); fmpz_print(b); flint_printf("\n");
+                abort();
+            }
+
+            _fmpz_vec_clear(row, k + 1);
+        }
+
         fmpz_clear(a);
         fmpz_clear(b);
         fmpz_clear(c);

--- a/arith/test/t-stirling.c
+++ b/arith/test/t-stirling.c
@@ -23,7 +23,6 @@
 int main(void)
 {
     fmpz_mat_t mat, mat2, mat3;
-
     fmpz * row;
     fmpz_t s;
 
@@ -37,6 +36,46 @@ int main(void)
     fflush(stdout);
 
     fmpz_init(s);
+
+    /* test a few large Stirling numbers */
+    {
+        slong iter;
+        fmpz_t a, b, c, d;
+
+        fmpz_init(a);
+        fmpz_init(b);
+        fmpz_init(c);
+        fmpz_init(d);
+
+        for (iter = 0; iter < 50 * flint_test_multiplier(); iter++)
+        {
+            n = n_randint(state, 200);
+            k = 1 + n_randint(state, 200);
+
+            arith_stirling_number_1u(a, n + 1, k);
+            arith_stirling_number_1u(b, n, k);
+            arith_stirling_number_1u(c, n, k - 1);
+
+            fmpz_set(d, c);
+            fmpz_addmul_ui(d, b, n);
+
+            if (!fmpz_equal(a, d))
+            {
+                flint_printf("stirling1u");
+                flint_printf("n = %wd, k = %wd\n", n, k);
+                flint_printf("a: "); fmpz_print(a); flint_printf("\n");
+                flint_printf("b: "); fmpz_print(b); flint_printf("\n");
+                flint_printf("c: "); fmpz_print(c); flint_printf("\n");
+                flint_printf("d: "); fmpz_print(d); flint_printf("\n");
+                abort();
+            }
+        }
+
+        fmpz_clear(a);
+        fmpz_clear(b);
+        fmpz_clear(c);
+        fmpz_clear(d);
+    }
 
     for (mm = 0; mm < maxn / 2; mm++)
     {

--- a/doc/source/arith.rst
+++ b/doc/source/arith.rst
@@ -28,9 +28,9 @@ Stirling numbers
 --------------------------------------------------------------------------------
 
 
-.. function:: void arith_stirling_number_1u(fmpz_t s, slong n, slong k)
+.. function:: void arith_stirling_number_1u(fmpz_t s, ulong n, ulong k)
 
-.. function:: void arith_stirling_number_1(fmpz_t s, slong n, slong k)
+.. function:: void arith_stirling_number_1(fmpz_t s, ulong n, ulong k)
 
 .. function:: void arith_stirling_number_2(fmpz_t s, slong n, slong k)
 
@@ -56,9 +56,9 @@ Stirling numbers
     numbers efficiently. To compute a range of numbers, the vector or 
     matrix versions should generally be used.
 
-.. function:: void arith_stirling_number_1u_vec(fmpz * row, slong n, slong klen)
+.. function:: void arith_stirling_number_1u_vec(fmpz * row, ulong n, slong klen)
 
-.. function:: void arith_stirling_number_1_vec(fmpz * row, slong n, slong klen)
+.. function:: void arith_stirling_number_1_vec(fmpz * row, ulong n, slong klen)
 
 .. function:: void arith_stirling_number_2_vec(fmpz * row, slong n, slong klen)
 

--- a/doc/source/arith.rst
+++ b/doc/source/arith.rst
@@ -32,7 +32,7 @@ Stirling numbers
 
 .. function:: void arith_stirling_number_1(fmpz_t s, ulong n, ulong k)
 
-.. function:: void arith_stirling_number_2(fmpz_t s, slong n, slong k)
+.. function:: void arith_stirling_number_2(fmpz_t s, ulong n, ulong k)
 
     Sets `s` to `S(n,k)` where `S(n,k)` denotes an unsigned Stirling
     number of the first kind `|S_1(n, k)|`, a signed Stirling number 
@@ -60,7 +60,7 @@ Stirling numbers
 
 .. function:: void arith_stirling_number_1_vec(fmpz * row, ulong n, slong klen)
 
-.. function:: void arith_stirling_number_2_vec(fmpz * row, slong n, slong klen)
+.. function:: void arith_stirling_number_2_vec(fmpz * row, ulong n, slong klen)
 
     Computes the row of Stirling numbers
     ``S(n,0), S(n,1), S(n,2), ..., S(n,klen-1)``.


### PR DESCRIPTION
Speedup computing s(n,0), ..., s(n,n) by calling arith_stirling_number_1u (n+1) times:

```
n = 2      8.2x
n = 4      17x
n = 8      21x
n = 16     21x
n = 32     5.9x
n = 64     3.1x
n = 128    3.4x
n = 256    2.7x
n = 512    2.8x
n = 1024   3.7x
n = 2048   2.9x
n = 4096   2.8x
```

Speedup computing s(n,0), ..., s(n,n) by calling arith_stirling_number_1u_vec:

```
n = 2      0.93x
n = 4      8.5x
n = 8      10x
n = 16     10x
n = 32     1.6x
n = 64     1.2x
n = 128    2.4x
n = 256    2.0x
n = 512    1.9x
n = 1024   2.x
n = 2048   1.8x
n = 4096   1.8x
n = 8192   1.7x
n = 16384  1.7x
```

Speedup computing s(n,n-4):

```
n = 8      29x
n = 16     40x
n = 32     23x
n = 64     39x
n = 128    156x
n = 256    483x
n = 512    2082x
n = 1024   13730x
n = 2048   61607x
n = 4096   258655x
n = 8192   1093382x
```

I also changed the function signatures (n, k passed as ulong instead of slong; negative values are not really interesting here).