### PR TITLE
Speed up `fmpz_gcd`

### DIFF
--- a/doc/source/fmpz.rst
+++ b/doc/source/fmpz.rst
@@ -1032,6 +1032,7 @@ Basic arithmetic
 Greatest common divisor
 --------------------------------------------------------------------------------
 
+.. function:: void fmpz_gcd_ui(fmpz_t f, const fmpz_t g, ulong h)
 
 .. function:: void fmpz_gcd(fmpz_t f, const fmpz_t g, const fmpz_t h)
 

--- a/doc/source/ulong_extras.rst
+++ b/doc/source/ulong_extras.rst
@@ -321,18 +321,7 @@ Greatest common divisor
     Returns the greatest common divisor `g` of `x` and `y`. No assumptions
     are made about the values `x` and `y`.
 
-    The algorithm is a slight embellishment of the Euclidean algorithm
-    which uses some branches to avoid most divisions.
-
-    One wishes to compute the quotient and remainder of `u_3 / v_3` without 
-    division where possible. This is accomplished when `u_3 < 4 v_3`, i.e. 
-    the quotient is either `1`, `2` or `3`.
-
-    We first compute `s = u_3 - v_3`. If `s < v_3`, i.e.\ `u_3 < 2 v_3`, we 
-    know the quotient is `1`, else if `s < 2 v_3`, i.e.\ `u_3 < 3 v_3` we 
-    know the quotient is `2`. In the remaining cases, the quotient must 
-    be `3`. When the quotient is `4` or above, we use division. However this 
-    happens rarely for generic inputs.
+    This function wraps GMP's ``mpn_gcd_1``.
 
 .. function:: ulong n_gcd_full(ulong x, ulong y)
 

--- a/fmpz.h
+++ b/fmpz.h
@@ -627,6 +627,7 @@ fmpz_negmod(fmpz_t r, const fmpz_t a, const fmpz_t mod)
 }
 
 FLINT_DLL void fmpz_gcd(fmpz_t f, const fmpz_t g, const fmpz_t h);
+FLINT_DLL void fmpz_gcd_ui(fmpz_t res, const fmpz_t a, ulong b);
 FLINT_DLL void fmpz_gcd3(fmpz_t f, const fmpz_t a, const fmpz_t b, const fmpz_t c);
 
 FLINT_DLL void fmpz_lcm(fmpz_t f, const fmpz_t g, const fmpz_t h);

--- a/fmpz/gcd.c
+++ b/fmpz/gcd.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2009 William Hart
+    Copyright (C) 2021 Albin Ahlbäck
 
     This file is part of FLINT.
 
@@ -11,17 +12,7 @@
 
 #include <gmp.h>
 #include "flint.h"
-#include "ulong_extras.h"
 #include "fmpz.h"
-
-ulong
-z_gcd(slong a, slong b)
-{
-    ulong ua = FLINT_ABS(a);
-    ulong ub = FLINT_ABS(b);
-
-    return n_gcd(ua, ub);
-}
 
 void
 fmpz_gcd(fmpz_t f, const fmpz_t g, const fmpz_t h)
@@ -29,43 +20,65 @@ fmpz_gcd(fmpz_t f, const fmpz_t g, const fmpz_t h)
     fmpz c1 = *g;
     fmpz c2 = *h;
 
-    if (fmpz_is_zero(g))
-    {
-        fmpz_abs(f, h);
-        return;
-    }
-
-    if (fmpz_is_zero(h))
-    {
-        fmpz_abs(f, g);
-        return;
-    }
-
     if (!COEFF_IS_MPZ(c1))      /* g is small */
     {
-        if (!COEFF_IS_MPZ(c2))  /* h is also small */
+        ulong u1;
+
+        if (c1 == 0)
         {
-            fmpz_set_si(f, z_gcd(c1, c2));
+            fmpz_abs(f, h);
+            return;
         }
-        else                    /* h is large, but g is small */
+
+        u1 = FLINT_ABS(c1);
+        if (!COEFF_IS_MPZ(c2))  /* and h is also small */
         {
-            fmpz c2d = fmpz_fdiv_ui(h, FLINT_ABS(c1));
-            fmpz_set_si(f, z_gcd(c1, c2d));
+            ulong u2;
+
+            if (c2 == 0)
+            {
+                fmpz_abs(f, g);
+                return;
+            }
+
+            u2 = FLINT_ABS(c2);
+            fmpz_set_ui(f, mpn_gcd_1((mp_srcptr) &u2, (mp_size_t) 1, u1));
+        }
+        else                    /* but h is large */
+        {
+            __mpz_struct * mpzc2 = COEFF_TO_PTR(c2);
+            mp_size_t size = mpzc2->_mp_size;
+            /* The sign is stored in the size of an mpz, and gcd_1 only takes
+             * positive integers. */
+            fmpz_set_ui(f, mpn_gcd_1(mpzc2->_mp_d, FLINT_ABS(size), u1));
         }
     }
-    else
+    else                        /* g is large */
     {
-        if (!COEFF_IS_MPZ(c2))  /* h is small, but g is large */
+        if (!COEFF_IS_MPZ(c2))  /* but h is small */
         {
-            fmpz c1d = fmpz_fdiv_ui(g, FLINT_ABS(c2));
-            fmpz_set_si(f, z_gcd(c2, c1d));
-        }
-        else                    /* g and h are both large */
-        {
-            __mpz_struct *mpz_ptr = _fmpz_promote(f);   /* aliasing fine as g, h already large */
+            ulong u2;
+            __mpz_struct * mpzc1;
+            mp_size_t size;
 
+            if (c2 == 0)
+            {
+                fmpz_abs(f, g);
+                return;
+            }
+
+            u2 = FLINT_ABS(c2);
+            mpzc1 = COEFF_TO_PTR(c1);
+            size = mpzc1->_mp_size;
+            fmpz_set_ui(f, mpn_gcd_1(mpzc1->_mp_d, FLINT_ABS(size), u2));
+        }
+        else
+        {
+            /* TODO: Change to mpn_gcd in order to save some calculations that
+             * has already been already made. */
+            __mpz_struct * mpz_ptr = _fmpz_promote(f);
             mpz_gcd(mpz_ptr, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
-            _fmpz_demote_val(f);    /* gcd may be small */
+            _fmpz_demote_val(f);
         }
     }
 }

--- a/fmpz/gcd.c
+++ b/fmpz/gcd.c
@@ -75,7 +75,7 @@ fmpz_gcd(fmpz_t f, const fmpz_t g, const fmpz_t h)
         else
         {
             /* TODO: Change to mpn_gcd in order to save some calculations that
-             * has already been already made. */
+             * have already been already made. */
             __mpz_struct * mpz_ptr = _fmpz_promote(f);
             mpz_gcd(mpz_ptr, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
             _fmpz_demote_val(f);

--- a/fmpz/gcd3.c
+++ b/fmpz/gcd3.c
@@ -50,15 +50,20 @@ _fmpz_gcd3_small(fmpz_t res, const fmpz_t a, const fmpz_t b, ulong c)
         else
         {
             __mpz_struct * ma = COEFF_TO_PTR(*a);
-            c = mpn_gcd_1(ma->_mp_d, FLINT_ABS(ma->_mp_size), c);
-            if (c != 1)
+
+            if (!COEFF_IS_MPZ(*b))
             {
-                if (!COEFF_IS_MPZ(*b))
-                {
-                    if (*b != 0)
-                        c = mpn_gcd_1(&c, 1, FLINT_ABS(*b));
-                }
-                else
+                if (*b != 0)
+                    c = mpn_gcd_1(&c, 1, FLINT_ABS(*b));
+
+                if (c != 1)
+                    c = mpn_gcd_1(ma->_mp_d, FLINT_ABS(ma->_mp_size), c);
+            }
+            else
+            {
+                c = mpn_gcd_1(ma->_mp_d, FLINT_ABS(ma->_mp_size), c);
+
+                if (c != 1)
                 {
                     ma = COEFF_TO_PTR(*b);
                     c = mpn_gcd_1(ma->_mp_d, FLINT_ABS(ma->_mp_size), c);

--- a/fmpz/gcd3.c
+++ b/fmpz/gcd3.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2021 Fredrik Johansson
+    Copyright (C) 2021 Albin Ahlbäck
 
     This file is part of FLINT.
 
@@ -14,23 +15,9 @@
 #include "ulong_extras.h"
 #include "fmpz.h"
 
-static ulong _fmpz_gcd_big_small(const fmpz_t g, ulong h)
-{
-    __mpz_struct * z = COEFF_TO_PTR(*g);
-
-    return n_gcd(mpn_mod_1(z->_mp_d, FLINT_ABS(z->_mp_size), h), h);
-}
-
-static ulong _fmpz_gcd_small(const fmpz_t g, ulong h)
-{
-    if (!COEFF_IS_MPZ(*g))
-        return n_gcd(FLINT_ABS(*g), h);
-    else
-        return _fmpz_gcd_big_small(g, h);
-}
-
+/* Assumes that c fits in fmpz */
 static void
-fmpz_gcd3_small(fmpz_t res, const fmpz_t a, const fmpz_t b, ulong c)
+_fmpz_gcd3_small(fmpz_t res, const fmpz_t a, const fmpz_t b, ulong c)
 {
     if (c <= 1)
     {
@@ -43,18 +30,45 @@ fmpz_gcd3_small(fmpz_t res, const fmpz_t a, const fmpz_t b, ulong c)
     {
         if (!COEFF_IS_MPZ(*a))
         {
-            c = n_gcd(FLINT_ABS(*a), c);
+            if (*a != 0)
+                c = mpn_gcd_1(&c, 1, FLINT_ABS(*a));
+
             if (c != 1)
-                c = _fmpz_gcd_small(b, c);
+            {
+                if (!COEFF_IS_MPZ(*b))
+                {
+                    if (*b != 0)
+                        c = mpn_gcd_1(&c, 1, FLINT_ABS(*b));
+                }
+                else
+                {
+                    __mpz_struct * mb = COEFF_TO_PTR(*b);
+                    c = mpn_gcd_1(mb->_mp_d, FLINT_ABS(mb->_mp_size), c);
+                }
+            }
         }
         else
         {
-            c = _fmpz_gcd_small(b, c);
+            __mpz_struct * ma = COEFF_TO_PTR(*a);
+            c = mpn_gcd_1(ma->_mp_d, FLINT_ABS(ma->_mp_size), c);
             if (c != 1)
-                c = _fmpz_gcd_big_small(a, c);
+            {
+                if (!COEFF_IS_MPZ(*b))
+                {
+                    if (*b != 0)
+                        c = mpn_gcd_1(&c, 1, FLINT_ABS(*b));
+                }
+                else
+                {
+                    ma = COEFF_TO_PTR(*b);
+                    c = mpn_gcd_1(ma->_mp_d, FLINT_ABS(ma->_mp_size), c);
+                }
+            }
         }
 
-        fmpz_set_ui(res, c);
+        if (COEFF_IS_MPZ(*res) && res != a && res != b)
+            _fmpz_demote(res);
+        *res = c;
     }
 }
 
@@ -63,15 +77,15 @@ fmpz_gcd3(fmpz_t res, const fmpz_t a, const fmpz_t b, const fmpz_t c)
 {
     if (!COEFF_IS_MPZ(*a))
     {
-        fmpz_gcd3_small(res, b, c, FLINT_ABS(*a));
+        _fmpz_gcd3_small(res, b, c, FLINT_ABS(*a));
     }
     else if (!COEFF_IS_MPZ(*b))
     {
-        fmpz_gcd3_small(res, a, c, FLINT_ABS(*b));
+        _fmpz_gcd3_small(res, a, c, FLINT_ABS(*b));
     }
     else if (!COEFF_IS_MPZ(*c))
     {
-        fmpz_gcd3_small(res, a, b, FLINT_ABS(*c));
+        _fmpz_gcd3_small(res, a, b, FLINT_ABS(*c));
     }
     else
     {

--- a/fmpz/gcd_ui.c
+++ b/fmpz/gcd_ui.c
@@ -1,0 +1,35 @@
+/*
+    Copyright (C) 2021 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <gmp.h>
+#include "fmpz.h"
+
+void
+fmpz_gcd_ui(fmpz_t res, const fmpz_t a, ulong b)
+{
+    if (b == 0)
+        fmpz_abs(res, a);
+    else if (!COEFF_IS_MPZ(*a))
+    {
+        if (*a != 0)
+        {
+            _fmpz_demote(res);
+            *res = mpn_gcd_1(&b, 1, FLINT_ABS(*a));
+        }
+        else
+            fmpz_set_ui(res, b);
+    }
+    else
+    {
+        __mpz_struct * ma = COEFF_TO_PTR(*a);
+        fmpz_set_ui(res, mpn_gcd_1(ma->_mp_d, FLINT_ABS(ma->_mp_size), b));
+    }
+}

--- a/fmpz/profile/p-gcd.c
+++ b/fmpz/profile/p-gcd.c
@@ -1,0 +1,158 @@
+/*
+    Copyright (C) 2009 William Hart
+    Copyright (C) 2021 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <gmp.h>
+#include "flint/flint.h"
+#include "flint/ulong_extras.h"
+#include "flint/fmpz.h"
+#include "flint/profiler.h"
+
+typedef struct
+{
+   slong bits;
+}
+info_t;
+
+ulong
+z_gcd_old(slong a, slong b)
+{
+    ulong ua = FLINT_ABS(a);
+    ulong ub = FLINT_ABS(b);
+
+    return n_gcd(ua, ub);
+}
+
+void
+fmpz_gcd_old(fmpz_t f, const fmpz_t g, const fmpz_t h)
+{
+    fmpz c1 = *g;
+    fmpz c2 = *h;
+
+    if (fmpz_is_zero(g))
+    {
+        fmpz_abs(f, h);
+        return;
+    }
+
+    if (fmpz_is_zero(h))
+    {
+        fmpz_abs(f, g);
+        return;
+    }
+
+    if (!COEFF_IS_MPZ(c1))      /* g is small */
+    {
+        if (!COEFF_IS_MPZ(c2))  /* h is also small */
+        {
+            fmpz_set_si(f, z_gcd_old(c1, c2));
+        }
+        else                    /* h is large, but g is small */
+        {
+            fmpz c2d = fmpz_fdiv_ui(h, FLINT_ABS(c1));
+            fmpz_set_si(f, z_gcd_old(c1, c2d));
+        }
+    }
+    else
+    {
+        if (!COEFF_IS_MPZ(c2))  /* h is small, but g is large */
+        {
+            fmpz c1d = fmpz_fdiv_ui(g, FLINT_ABS(c2));
+            fmpz_set_si(f, z_gcd_old(c2, c1d));
+        }
+        else                    /* g and h are both large */
+        {
+            __mpz_struct *mpz_ptr = _fmpz_promote(f);   /* aliasing fine as g, h already large */
+
+            mpz_gcd(mpz_ptr, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
+            _fmpz_demote_val(f);    /* gcd may be small */
+        }
+    }
+}
+
+
+void
+sample_new(void * arg, ulong count)
+{
+    fmpz_t r, a, b;
+    int ix;
+    info_t * info = (info_t *) arg;
+    slong bits = info->bits;
+
+    fmpz_init(r);
+    fmpz_init(a);
+    fmpz_init(b);
+
+    FLINT_TEST_INIT(state);
+
+    prof_start();
+    for (ix = 0; ix < 1000 * count; ix++)
+    {
+        fmpz_randtest(a, state, bits);
+        fmpz_randtest(b, state, bits);
+        fmpz_gcd(r, a, b);
+    }
+    prof_stop();
+
+    fmpz_clear(r);
+    fmpz_clear(a);
+    fmpz_clear(b);
+
+    flint_randclear(state);
+}
+
+void
+sample_old(void * arg, ulong count)
+{
+    fmpz_t r, a, b;
+    int ix;
+    info_t * info = (info_t *) arg;
+    slong bits = info->bits;
+
+    fmpz_init(r);
+    fmpz_init(a);
+    fmpz_init(b);
+
+    FLINT_TEST_INIT(state);
+
+    prof_start();
+    for (ix = 0; ix < 1000 * count; ix++)
+    {
+        fmpz_randtest(a, state, bits);
+        fmpz_randtest(b, state, bits);
+        fmpz_gcd_old(r, a, b);
+    }
+    prof_stop();
+
+    fmpz_clear(r);
+    fmpz_clear(a);
+    fmpz_clear(b);
+
+    flint_randclear(state);
+}
+
+int
+main()
+{
+    double minnew, maxnew, minold, maxold;
+    int bits;
+    info_t as;
+
+    for (bits = 5; bits <= 150; bits += 5)
+    {
+        as.bits = bits;
+
+        prof_repeat(&minnew, &maxnew, sample_new, &as);
+        prof_repeat(&minold, &maxold, sample_old, &as);
+        flint_printf("%3d bits:   (min) %.2fx speedup   (max) %.2fx speedup\n",
+                bits, minold / minnew, maxold / maxnew);
+    }
+}

--- a/fmpz/profile/p-gcd3.c
+++ b/fmpz/profile/p-gcd3.c
@@ -1,0 +1,231 @@
+/*
+    Copyright (C) 2021 Fredrik Johansson
+    Copyright (C) 2021 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <gmp.h>
+#include "flint/fmpz.h"
+#include "flint/profiler.h"
+
+typedef struct
+{
+   slong bits;
+}
+info_t;
+
+static ulong _fmpz_gcd_big_small_old(const fmpz_t g, ulong h)
+{
+    __mpz_struct * z = COEFF_TO_PTR(*g);
+
+    return n_gcd(mpn_mod_1(z->_mp_d, FLINT_ABS(z->_mp_size), h), h);
+}
+
+static ulong _fmpz_gcd_small_old(const fmpz_t g, ulong h)
+{
+    if (!COEFF_IS_MPZ(*g))
+        return n_gcd(FLINT_ABS(*g), h);
+    else
+        return _fmpz_gcd_big_small_old(g, h);
+}
+
+static void
+fmpz_gcd3_small_old(fmpz_t res, const fmpz_t a, const fmpz_t b, ulong c)
+{
+    if (c <= 1)
+    {
+        if (c == 1)
+            fmpz_one(res);
+        else
+            fmpz_gcd(res, a, b);
+    }
+    else
+    {
+        if (!COEFF_IS_MPZ(*a))
+        {
+            c = n_gcd(FLINT_ABS(*a), c);
+            if (c != 1)
+                c = _fmpz_gcd_small_old(b, c);
+        }
+        else
+        {
+            c = _fmpz_gcd_small_old(b, c);
+            if (c != 1)
+                c = _fmpz_gcd_big_small_old(a, c);
+        }
+
+        fmpz_set_ui(res, c);
+    }
+}
+
+void
+fmpz_gcd3_old(fmpz_t res, const fmpz_t a, const fmpz_t b, const fmpz_t c)
+{
+    if (!COEFF_IS_MPZ(*a))
+    {
+        fmpz_gcd3_small_old(res, b, c, FLINT_ABS(*a));
+    }
+    else if (!COEFF_IS_MPZ(*b))
+    {
+        fmpz_gcd3_small_old(res, a, c, FLINT_ABS(*b));
+    }
+    else if (!COEFF_IS_MPZ(*c))
+    {
+        fmpz_gcd3_small_old(res, a, b, FLINT_ABS(*c));
+    }
+    else
+    {
+        /* Three-way mpz_gcd. */
+        __mpz_struct *rp, *ap, *bp, *cp, *tp;
+        mp_size_t an, bn, cn, mn;
+
+        /* If res is small, it cannot be aliased with a, b, c, so promoting is fine. */
+        rp = _fmpz_promote(res);
+
+        ap = COEFF_TO_PTR(*a);
+        bp = COEFF_TO_PTR(*b);
+        cp = COEFF_TO_PTR(*c);
+
+        an = FLINT_ABS(ap->_mp_size);
+        bn = FLINT_ABS(bp->_mp_size);
+        cn = FLINT_ABS(cp->_mp_size);
+
+        /* Select c to be the largest operand; we do the smaller gcd first. */
+        mn = FLINT_MAX(FLINT_MAX(an, bn), cn);
+        tp = cp;
+        if (mn != cn)
+        {
+            if (mn == an)
+            {
+                cp = ap;
+                ap = tp;
+            }
+            else
+            {
+                cp = bp;
+                bp = tp;
+            }
+
+            cn = mn;
+        }
+
+        /* Handle aliasing */
+        if (rp == cp)
+        {
+            mpz_t t;
+            TMP_INIT;
+            TMP_START;
+
+            /* It would be more efficient to allocate temporary space for
+               gcd(a, b), but we can't be sure that mpz_gcd never attempts
+               to reallocate the output. */
+            t->_mp_d = TMP_ALLOC(sizeof(mp_limb_t) * cn);
+            t->_mp_size = t->_mp_alloc = cn;
+            flint_mpn_copyi(t->_mp_d, cp->_mp_d, cn);
+
+            mpz_gcd(rp, ap, bp);
+            if (mpz_cmpabs_ui(rp, 1) != 0)
+                mpz_gcd(rp, rp, t);
+
+            TMP_END;
+        }
+        else
+        {
+            mpz_gcd(rp, ap, bp);
+            if (mpz_cmpabs_ui(rp, 1) != 0)
+                mpz_gcd(rp, rp, cp);
+        }
+
+        /* The result may be small */
+        _fmpz_demote_val(res);
+    }
+}
+
+
+void
+sample_new(void * arg, ulong count)
+{
+    fmpz_t r, a, b, c;
+    int ix;
+    info_t * info = (info_t *) arg;
+    slong bits = info->bits;
+
+    fmpz_init(r);
+    fmpz_init(a);
+    fmpz_init(b);
+    fmpz_init(c);
+
+    FLINT_TEST_INIT(state);
+
+    prof_start();
+    for (ix = 0; ix < 1000 * count; ix++)
+    {
+        fmpz_randtest(a, state, bits);
+        fmpz_randtest(b, state, bits);
+        fmpz_randtest(c, state, bits);
+        fmpz_gcd3(r, a, b, c);
+    }
+    prof_stop();
+
+    fmpz_clear(r);
+    fmpz_clear(a);
+    fmpz_clear(b);
+
+    flint_randclear(state);
+}
+
+void
+sample_old(void * arg, ulong count)
+{
+    fmpz_t r, a, b, c;
+    int ix;
+    info_t * info = (info_t *) arg;
+    slong bits = info->bits;
+
+    fmpz_init(r);
+    fmpz_init(a);
+    fmpz_init(b);
+    fmpz_init(c);
+
+    FLINT_TEST_INIT(state);
+
+    prof_start();
+    for (ix = 0; ix < 1000 * count; ix++)
+    {
+        fmpz_randtest(a, state, bits);
+        fmpz_randtest(b, state, bits);
+        fmpz_randtest(c, state, bits);
+        fmpz_gcd3_old(r, a, b, c);
+    }
+    prof_stop();
+
+    fmpz_clear(r);
+    fmpz_clear(a);
+    fmpz_clear(b);
+
+    flint_randclear(state);
+}
+
+int
+main()
+{
+    double minnew, maxnew, minold, maxold;
+    int bits;
+    info_t as;
+
+    for (bits = 1; bits <= 200; bits += 3)
+    {
+        as.bits = bits;
+
+        prof_repeat(&minnew, &maxnew, sample_new, &as);
+        prof_repeat(&minold, &maxold, sample_old, &as);
+        flint_printf("%3d bits:   (min) %.2fx speedup   (max) %.2fx speedup\n",
+                bits, minold / minnew, maxold / maxnew);
+    }
+}

--- a/fmpz/test/t-gcd_ui.c
+++ b/fmpz/test/t-gcd_ui.c
@@ -1,0 +1,107 @@
+/*
+    Copyright (C) 2021 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <gmp.h>
+#include "flint.h"
+#include "fmpz.h"
+
+int
+main(void)
+{
+    int i, result;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("gcd_ui....");
+    fflush(stdout);
+    
+
+    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
+    {
+        fmpz_t r1, r2, a, fb;
+        ulong b;
+
+        fmpz_init(r1);
+        fmpz_init(r2);
+        fmpz_init(a);
+        fmpz_init(fb);
+
+        fmpz_randtest(a, state, 200);
+        b = n_randtest(state);
+        fmpz_set_ui(fb, b);
+
+        fmpz_gcd(r1, a, fb);
+        fmpz_gcd_ui(r2, a, b);
+
+        result = (fmpz_cmp(r1, r2) == 0);
+
+        if (!result)
+        {
+            flint_printf("FAIL:\n");
+            flint_printf("a = ");
+            fmpz_print(a);
+            flint_printf("\nb = %wu", b);
+            flint_printf("\nr1 = ");
+            fmpz_print(r1);
+            flint_printf("\nr2 = ");
+            fmpz_print(r2);
+            flint_printf("\n");
+            fflush(stdout);
+            abort();
+        }
+
+        fmpz_clear(r1);
+        fmpz_clear(r2);
+        fmpz_clear(a);
+        fmpz_clear(fb);
+    }
+
+    /* Check aliasing of res and a */
+    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
+    {
+        fmpz_t r, a, fb;
+        ulong b;
+
+        fmpz_init(r);
+        fmpz_init(a);
+        fmpz_init(fb);
+
+        fmpz_randtest(a, state, 200);
+        b = n_randtest(state);
+        fmpz_set_ui(fb, b);
+
+        fmpz_gcd(r, a, fb);
+        fmpz_gcd_ui(a, a, b);
+
+        result = (fmpz_cmp(r, a) == 0);
+        if (!result)
+        {
+            flint_printf("FAIL:\n");
+            flint_printf("Aliasing with res and a.\n");
+            flint_printf("a = ");
+            fmpz_print(a);
+            flint_printf("\nb = %wu", b);
+            flint_printf("\nr = ");
+            fmpz_print(r);
+            flint_printf("\n");
+            fflush(stdout);
+            abort();
+        }
+
+        fmpz_clear(r);
+        fmpz_clear(a);
+        fmpz_clear(fb);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+    
+    flint_printf("PASS\n");
+    return 0;
+}

--- a/ulong_extras/gcd.c
+++ b/ulong_extras/gcd.c
@@ -1,6 +1,5 @@
 /*
-    Copyright (C) 2009, 2015 William Hart
-    Copyright (C) 2014 Abhinav Baid
+    Copyright (C) 2021 Albin Ahlbäck
 
     This file is part of FLINT.
 
@@ -11,108 +10,13 @@
 */
 
 #include <gmp.h>
-#include "flint.h"
 #include "ulong_extras.h"
 
-#if (defined (__amd64__) || defined (__i386__) || defined (__i486__))
-
 ulong
 n_gcd(ulong x, ulong y)
 {
-    register ulong s0, s1, f;
-
-    if (x == 0)
-        return y;
-    if (y == 0)
-        return x;
-
-    count_trailing_zeros(s0, x);
-    count_trailing_zeros(s1, y);
-
-    f = FLINT_MIN(s0, s1);
-
-    x >>= s0;
-    y >>= s1;
-
-    while (x != y)
-    {
-        if (x < y)
-        {
-            y -= x;
-            count_trailing_zeros(s1, y);
-            y >>= s1;
-        }
-        else
-        {
-            x -= y;
-            count_trailing_zeros(s0, x);
-            x >>= s0;
-        }
-    }
-
-    return x << f;
-}
-
-#else
-
-ulong
-n_gcd(ulong x, ulong y)
-{
-    ulong d, v, quot, rem;
-
-    if (x >= y)
-        v = y;
+    if (x != 0 && y != 0)
+        return mpn_gcd_1(&x, 1, y);
     else
-    {
-        v = x;
-        x = y;
-    }
-
-    /* x and y both have top bit set */
-    if ((slong) (x & v) < WORD(0))
-    {
-        d = x - v;
-        x = v;
-        v = d;
-    }
-
-    /* second value has second msb set */
-    while ((slong) (v << 1) < WORD(0))
-    {
-        d = x - v;
-        x = v;
-        if (d < v)
-            v = d;              /* quot = 1 */
-        else if (d < (v << 1))
-            v = d - x;          /* quot = 2 */
-        else
-            v = d - (x << 1);   /* quot = 3 */
-    }
-
-    while (v)
-    {
-        /* overflow not possible due to top 2 bits of v not being set */
-        if (x < (v << 2))       /* avoid divisions when quotient < 4 */
-        {
-            d = x - v;
-            x = v;
-            if (d < v)
-                v = d;          /* quot = 1 */
-            else if (d < (v << 1))
-                v = d - x;      /* quot = 2 */
-            else
-                v = d - (x << 1);   /* quot = 3 */
-        }
-        else
-        {
-            quot = x / v;
-            rem = x - v * quot;
-            x = v;
-            v = rem;
-        }
-    }
-
-    return x;
+        return x + y;
 }
-
-#endif


### PR DESCRIPTION
With the profiler code, I get
```
  5 bits:   (min) 0.97x speedup   (max) 0.93x speedup
 10 bits:   (min) 1.05x speedup   (max) 1.05x speedup
 15 bits:   (min) 1.07x speedup   (max) 1.06x speedup
 20 bits:   (min) 1.09x speedup   (max) 1.08x speedup
 25 bits:   (min) 1.11x speedup   (max) 1.11x speedup
 30 bits:   (min) 1.12x speedup   (max) 1.12x speedup
 35 bits:   (min) 1.14x speedup   (max) 1.14x speedup
 40 bits:   (min) 1.15x speedup   (max) 1.15x speedup
 45 bits:   (min) 1.16x speedup   (max) 1.16x speedup
 50 bits:   (min) 1.18x speedup   (max) 1.18x speedup
 55 bits:   (min) 1.19x speedup   (max) 1.19x speedup
 60 bits:   (min) 1.20x speedup   (max) 1.19x speedup
 65 bits:   (min) 1.20x speedup   (max) 1.20x speedup
 70 bits:   (min) 1.19x speedup   (max) 1.19x speedup
 75 bits:   (min) 1.18x speedup   (max) 1.19x speedup
 80 bits:   (min) 1.17x speedup   (max) 1.16x speedup
 85 bits:   (min) 1.16x speedup   (max) 1.16x speedup
 90 bits:   (min) 1.15x speedup   (max) 1.13x speedup
 95 bits:   (min) 1.14x speedup   (max) 1.12x speedup
100 bits:   (min) 1.14x speedup   (max) 1.14x speedup
105 bits:   (min) 1.12x speedup   (max) 1.12x speedup
110 bits:   (min) 1.12x speedup   (max) 1.04x speedup
115 bits:   (min) 1.11x speedup   (max) 1.09x speedup
120 bits:   (min) 1.11x speedup   (max) 1.10x speedup
125 bits:   (min) 1.10x speedup   (max) 1.08x speedup
130 bits:   (min) 1.10x speedup   (max) 1.09x speedup
135 bits:   (min) 1.09x speedup   (max) 1.09x speedup
140 bits:   (min) 1.09x speedup   (max) 1.09x speedup
145 bits:   (min) 1.09x speedup   (max) 1.10x speedup
150 bits:   (min) 1.08x speedup   (max) 1.07x speedup
```

Edit: This was made on an i5 6300U.