### PR TITLE
Speed up nmod multiplications

### DIFF
--- a/doc/source/nmod_mat.rst
+++ b/doc/source/nmod_mat.rst
@@ -538,6 +538,9 @@ LU decomposition
 
 
 .. function:: slong nmod_mat_lu(slong * P, nmod_mat_t A, int rank_check)
+              slong nmod_mat_lu_classical(slong * P, nmod_mat_t A, int rank_check)
+              slong nmod_mat_lu_classical_delayed(slong * P, nmod_mat_t A, int rank_check)
+              slong nmod_mat_lu_recursive(slong * P, nmod_mat_t A, int rank_check)
 
     Computes a generalised LU decomposition `LU = PA` of a given
     matrix `A`, returning the rank of `A`.
@@ -555,21 +558,11 @@ LU decomposition
     function will abandon the output matrix in an undefined state and
     return 0 if `A` is detected to be rank-deficient.
 
-    This function calls :func:`nmod_mat_lu_recursive`.
-
-.. function:: slong nmod_mat_lu_classical(slong * P, nmod_mat_t A, int rank_check)
-
-    Computes a generalised LU decomposition `LU = PA` of a given
-    matrix `A`, returning the rank of `A`. The behavior of this function
-    is identical to that of :func:`nmod_mat_lu`. Uses Gaussian elimination.
-
-.. function:: slong nmod_mat_lu_recursive(slong * P, nmod_mat_t A, int rank_check)
-
-    Computes a generalised LU decomposition `LU = PA` of a given
-    matrix `A`, returning the rank of `A`. The behavior of this function
-    is identical to that of :func:`nmod_mat_lu`. Uses recursive block
-    decomposition, switching to classical Gaussian elimination for
-    sufficiently small blocks.
+    The *classical* version uses direct Gaussian elimination.
+    The *classical_delayed* version also uses Gaussian elimination,
+    but performs delayed modular reductions.
+    The *recursive* version uses block recursive decomposition.
+    The default function chooses an algorithm automatically.
 
 
 

--- a/nmod_mat.h
+++ b/nmod_mat.h
@@ -352,6 +352,7 @@ FLINT_DLL void nmod_mat_solve_triu_classical(nmod_mat_t X, const nmod_mat_t U, c
 
 FLINT_DLL slong nmod_mat_lu(slong * P, nmod_mat_t A, int rank_check);
 FLINT_DLL slong nmod_mat_lu_classical(slong * P, nmod_mat_t A, int rank_check);
+FLINT_DLL slong nmod_mat_lu_classical_delayed(slong * P, nmod_mat_t A, int rank_check);
 FLINT_DLL slong nmod_mat_lu_recursive(slong * P, nmod_mat_t A, int rank_check);
 
 /* Nonsingular solving */

--- a/nmod_mat.h
+++ b/nmod_mat.h
@@ -410,9 +410,6 @@ FLINT_DLL void nmod_mat_similarity(nmod_mat_t M, slong r, ulong d);
 #define NMOD_MAT_SOLVE_TRI_ROWS_CUTOFF 64
 #define NMOD_MAT_SOLVE_TRI_COLS_CUTOFF 64
 
-/* Cutoff between classical and recursive LU decomposition */
-#define NMOD_MAT_LU_RECURSIVE_CUTOFF 4
-
 /*
    Suggested initial modulus size for multimodular algorithms. This should
    be chosen so that we get the most number of bits per cycle

--- a/nmod_mat/lu.c
+++ b/nmod_mat/lu.c
@@ -36,7 +36,7 @@ nmod_mat_lu(slong * P, nmod_mat_t A, int rank_check)
         {
             bits = NMOD_BITS(A->mod);
 
-            if (bits >= FLINT_BITS - 2)
+            if (bits >= FLINT_BITS - 1)
                 cutoff = 20;
             else if (bits >= FLINT_BITS / 2 - 2)
                 cutoff = 60;

--- a/nmod_mat/lu.c
+++ b/nmod_mat/lu.c
@@ -37,7 +37,7 @@ nmod_mat_lu(slong * P, nmod_mat_t A, int rank_check)
             bits = NMOD_BITS(A->mod);
 
             if (bits >= FLINT_BITS - 1)
-                cutoff = 20;
+                cutoff = 80;
             else if (bits >= FLINT_BITS / 2 - 2)
                 cutoff = 60;
             else if (bits >= FLINT_BITS / 4 - 1)
@@ -51,7 +51,7 @@ nmod_mat_lu(slong * P, nmod_mat_t A, int rank_check)
 
         nlimbs = _nmod_vec_dot_bound_limbs(n, A->mod);
 
-        if (nlimbs <= 1 || (nlimbs <= 2 && n >= 12))
+        if (nlimbs <= 1 || (nlimbs == 2 && n >= 12) || (nlimbs == 3 && n >= 20))
             return nmod_mat_lu_classical_delayed(P, A, rank_check);
         else
             return nmod_mat_lu_classical(P, A, rank_check);

--- a/nmod_mat/lu.c
+++ b/nmod_mat/lu.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2011, 2021 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -19,5 +19,41 @@
 slong 
 nmod_mat_lu(slong * P, nmod_mat_t A, int rank_check)
 {
-    return nmod_mat_lu_recursive(P, A, rank_check);
+    slong nrows, ncols, n, cutoff;
+    int nlimbs, bits;
+    nrows = A->r;
+    ncols = A->c;
+
+    n = FLINT_MIN(nrows, ncols);
+
+    if (n <= 3)
+    {
+        return nmod_mat_lu_classical(P, A, rank_check);
+    }
+    else
+    {
+        if (n >= 20)
+        {
+            bits = NMOD_BITS(A->mod);
+
+            if (bits >= FLINT_BITS - 2)
+                cutoff = 20;
+            else if (bits >= FLINT_BITS / 2 - 2)
+                cutoff = 60;
+            else if (bits >= FLINT_BITS / 4 - 1)
+                cutoff = 180;
+            else
+                cutoff = 60;
+
+            if (n >= cutoff)
+                return nmod_mat_lu_recursive(P, A, rank_check);
+        }
+
+        nlimbs = _nmod_vec_dot_bound_limbs(n, A->mod);
+
+        if (nlimbs <= 1 || (nlimbs <= 2 && n >= 12))
+            return nmod_mat_lu_classical_delayed(P, A, rank_check);
+        else
+            return nmod_mat_lu_classical(P, A, rank_check);
+    }
 }

--- a/nmod_mat/lu_classical.c
+++ b/nmod_mat/lu_classical.c
@@ -75,12 +75,12 @@ nmod_mat_lu_classical(slong * P, nmod_mat_t A, int rank_check)
         rank++;
 
         d = a[row][col];
-        d = n_invmod(d, mod.n);
+        d = nmod_inv(d, mod);
         length = n - col - 1;
 
         for (i = row + 1; i < m; i++)
         {
-            e = n_mulmod2_preinv(a[i][col], d, mod.n, mod.ninv);
+            e = nmod_mul(a[i][col], d, mod);
             if (length != 0)
                 _nmod_vec_scalar_addmul_nmod(a[i] + col + 1,
                     a[row] + col + 1, length, nmod_neg(e, mod), mod);

--- a/nmod_mat/lu_classical_delayed.c
+++ b/nmod_mat/lu_classical_delayed.c
@@ -1,0 +1,448 @@
+/*
+    Copyright (C) 2021 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "flint.h"
+#include "ulong_extras.h"
+#include "nmod_vec.h"
+#include "nmod_mat.h"
+
+static mp_limb_t
+nmod_set_uiuiui(ulong s2, ulong s1, ulong s0, nmod_t mod)
+{
+    NMOD_RED(s2, s2, mod);
+    NMOD_RED3(s0, s2, s1, s0, mod);
+    return s0;
+}
+
+slong
+nmod_mat_lu_classical_delayed_1(slong * P, nmod_mat_t A, int rank_check)
+{
+    mp_limb_t d, e, f, **a;
+    nmod_t mod;
+    slong i, j, nrows, ncols, rank, row, col, pivot_row, tmp_index;
+    mp_ptr tmp_ptr;
+
+    nrows = A->r;
+    ncols = A->c;
+    a = A->rows;
+    mod = A->mod;
+
+    rank = row = col = 0;
+
+    for (i = 0; i < nrows; i++)
+        P[i] = i;
+
+    while (row < nrows && col < ncols)
+    {
+        /* reduce current column */
+        /* can be skipped on the first iteration */
+        if (col != 0)
+            for (j = row; j < nrows; j++)
+                NMOD_RED(a[j][col], a[j][col], mod);
+
+        pivot_row = -1;
+        for (i = row; i < nrows; i++)
+        {
+            if (a[i][col] != 0)
+            {
+                pivot_row = i;
+                break;
+            }
+        }
+
+        if (pivot_row == -1)
+        {
+            if (rank_check)
+            {
+                rank = 0;
+                break;
+            }
+
+            col++;
+            continue;
+        }
+
+        /* swap rows */
+        if (pivot_row != row)
+        {
+            tmp_ptr = a[pivot_row];
+            a[pivot_row] = a[row];
+            a[row] = tmp_ptr;
+
+            tmp_index = P[pivot_row];
+            P[pivot_row] = P[row];
+            P[row] = tmp_index;
+        }
+
+        /* reduce current pivot row */
+        if (col != 0)
+            for (j = col + 1; j < ncols; j++)
+                NMOD_RED(a[row][j], a[row][j], mod);
+
+        rank++;
+
+        /* eliminate remaining submatrix */
+        d = nmod_inv(a[row][col], mod);
+        for (i = row + 1; i < nrows; i++)
+        {
+            e = nmod_mul(a[i][col], d, mod);
+            f = nmod_neg(e, mod);
+
+            for (j = col + 1; j + 4 < ncols; j += 4)
+            {
+                mp_limb_t x0, x1, x2, x3;
+                x0 = a[row][j + 0];
+                x1 = a[row][j + 1];
+                x2 = a[row][j + 2];
+                x3 = a[row][j + 3];
+                a[i][j + 0] += x0 * f;
+                a[i][j + 1] += x1 * f;
+                a[i][j + 2] += x2 * f;
+                a[i][j + 3] += x3 * f;
+            }
+
+            for ( ; j < ncols; j++)
+                a[i][j] += a[row][j] * f;
+
+            a[i][col] = 0;
+            a[i][rank - 1] = e;
+        }
+        row++;
+        col++;
+    }
+
+    return rank;
+}
+
+slong
+nmod_mat_lu_classical_delayed_2(slong * P, nmod_mat_t A, int rank_check)
+{
+    mp_limb_t d, e, f, **a;
+    nmod_t mod;
+    slong i, j, nrows, ncols, rank, row, col, pivot_row, tmp_index;
+    mp_ptr tmp_ptr;
+    mp_ptr b;
+    TMP_INIT;
+
+    nrows = A->r;
+    ncols = A->c;
+    a = A->rows;
+    mod = A->mod;
+
+    rank = row = col = 0;
+
+    for (i = 0; i < nrows; i++)
+        P[i] = i;
+
+    TMP_START;
+    b = TMP_ALLOC(2 * sizeof(mp_limb_t) * nrows * ncols);
+
+#define UNREDUCED_LO(ii, jj) b[2 * ((ii) * ncols + jj)]
+#define UNREDUCED_HI(ii, jj) b[2 * ((ii) * ncols + jj) + 1]
+
+    for (i = 0; i < nrows; i++)
+    {
+        for (j = 0; j < ncols; j++)
+        {
+            UNREDUCED_LO(i, j) = a[i][j];
+            UNREDUCED_HI(i, j) = 0;
+        }
+    }
+
+    while (row < nrows && col < ncols)
+    {
+        /* reduce current column */
+        /* can be skipped on the first iteration */
+        if (col != 0)
+            for (j = row; j < nrows; j++)
+                NMOD2_RED2(a[j][col], UNREDUCED_HI(j, col), UNREDUCED_LO(j, col), mod);
+
+        pivot_row = -1;
+        for (i = row; i < nrows; i++)
+        {
+            if (a[i][col] != 0)
+            {
+                pivot_row = i;
+                break;
+            }
+        }
+
+        if (pivot_row == -1)
+        {
+            if (rank_check)
+            {
+                rank = 0;
+                break;
+            }
+
+            col++;
+            continue;
+        }
+
+        /* swap rows */
+        if (pivot_row != row)
+        {
+            tmp_ptr = a[pivot_row];
+            a[pivot_row] = a[row];
+            a[row] = tmp_ptr;
+
+            tmp_index = P[pivot_row];
+            P[pivot_row] = P[row];
+            P[row] = tmp_index;
+
+            /* swap rows in unreduced submatrix, and reduce new pivot row */
+            for (j = col + 1; j < ncols; j++)
+            {
+                mp_limb_t hi, lo;
+                lo = UNREDUCED_LO(row, j);
+                hi = UNREDUCED_HI(row, j);
+                NMOD2_RED2(a[row][j], UNREDUCED_HI(pivot_row, j), UNREDUCED_LO(pivot_row, j), mod);
+                UNREDUCED_LO(pivot_row, j) = lo;
+                UNREDUCED_HI(pivot_row, j) = hi;
+            }
+        }
+        else if (row != 0)
+        {
+            /* reduce current pivot row */
+            for (j = col + 1; j < ncols; j++)
+                NMOD2_RED2(a[row][j], UNREDUCED_HI(row, j), UNREDUCED_LO(row, j), mod);
+        }
+
+        rank++;
+
+        /* eliminate remaining submatrix */
+        d = nmod_inv(a[row][col], mod);
+        for (i = row + 1; i < nrows; i++)
+        {
+            e = nmod_mul(a[i][col], d, mod);
+            f = nmod_neg(e, mod);
+
+            if (mod.n <= UWORD(1) << (FLINT_BITS / 2))
+            {
+                for (j = col + 1; j + 4 < ncols; j += 4)
+                {
+                    mp_limb_t x0, x1, x2, x3;
+                    x0 = a[row][j + 0] * f;
+                    x1 = a[row][j + 1] * f;
+                    x2 = a[row][j + 2] * f;
+                    x3 = a[row][j + 3] * f;
+                    add_ssaaaa(UNREDUCED_HI(i, j + 0), UNREDUCED_LO(i, j + 0),
+                               UNREDUCED_HI(i, j + 0), UNREDUCED_LO(i, j + 0), 0, x0);
+                    add_ssaaaa(UNREDUCED_HI(i, j + 1), UNREDUCED_LO(i, j + 1),
+                               UNREDUCED_HI(i, j + 1), UNREDUCED_LO(i, j + 1), 0, x1);
+                    add_ssaaaa(UNREDUCED_HI(i, j + 2), UNREDUCED_LO(i, j + 2),
+                               UNREDUCED_HI(i, j + 2), UNREDUCED_LO(i, j + 2), 0, x2);
+                    add_ssaaaa(UNREDUCED_HI(i, j + 3), UNREDUCED_LO(i, j + 3),
+                               UNREDUCED_HI(i, j + 3), UNREDUCED_LO(i, j + 3), 0, x3);
+                }
+
+                for ( ; j < ncols; j++)
+                {
+                    mp_limb_t hi, lo;
+                    hi = 0;
+                    lo = a[row][j] * f;
+                    add_ssaaaa(UNREDUCED_HI(i, j), UNREDUCED_LO(i, j),
+                               UNREDUCED_HI(i, j), UNREDUCED_LO(i, j), hi, lo);
+                }
+            }
+            else
+            {
+                for (j = col + 1; j + 4 < ncols; j += 4)
+                {
+                    mp_limb_t x0, x1, x2, x3, h0, h1, h2, h3;
+                    umul_ppmm(h0, x0, a[row][j + 0], f);
+                    umul_ppmm(h1, x1, a[row][j + 1], f);
+                    umul_ppmm(h2, x2, a[row][j + 2], f);
+                    umul_ppmm(h3, x3, a[row][j + 3], f);
+                    add_ssaaaa(UNREDUCED_HI(i, j + 0), UNREDUCED_LO(i, j + 0),
+                               UNREDUCED_HI(i, j + 0), UNREDUCED_LO(i, j + 0), h0, x0);
+                    add_ssaaaa(UNREDUCED_HI(i, j + 1), UNREDUCED_LO(i, j + 1),
+                               UNREDUCED_HI(i, j + 1), UNREDUCED_LO(i, j + 1), h1, x1);
+                    add_ssaaaa(UNREDUCED_HI(i, j + 2), UNREDUCED_LO(i, j + 2),
+                               UNREDUCED_HI(i, j + 2), UNREDUCED_LO(i, j + 2), h2, x2);
+                    add_ssaaaa(UNREDUCED_HI(i, j + 3), UNREDUCED_LO(i, j + 3),
+                               UNREDUCED_HI(i, j + 3), UNREDUCED_LO(i, j + 3), h3, x3);
+                }
+
+                for ( ; j < ncols; j++)
+                {
+                    mp_limb_t hi, lo;
+                    umul_ppmm(hi, lo, a[row][j], f);
+                    add_ssaaaa(UNREDUCED_HI(i, j), UNREDUCED_LO(i, j),
+                               UNREDUCED_HI(i, j), UNREDUCED_LO(i, j), hi, lo);
+                }
+            }
+
+            a[i][col] = 0;
+            a[i][rank - 1] = e;
+        }
+        row++;
+        col++;
+    }
+
+    TMP_END;
+    return rank;
+}
+
+slong
+nmod_mat_lu_classical_delayed_3(slong * P, nmod_mat_t A, int rank_check)
+{
+    mp_limb_t d, e, f, **a;
+    nmod_t mod;
+    slong i, j, nrows, ncols, rank, row, col, pivot_row, tmp_index;
+    mp_ptr tmp_ptr;
+    mp_ptr b;
+    TMP_INIT;
+
+    nrows = A->r;
+    ncols = A->c;
+    a = A->rows;
+    mod = A->mod;
+
+    rank = row = col = 0;
+
+    for (i = 0; i < nrows; i++)
+        P[i] = i;
+
+    TMP_START;
+    b = TMP_ALLOC(3 * sizeof(mp_limb_t) * nrows * ncols);
+
+#define UNREDUCED3_L0(ii, jj) b[3 * ((ii) * ncols + jj)]
+#define UNREDUCED3_L1(ii, jj) b[3 * ((ii) * ncols + jj) + 1]
+#define UNREDUCED3_L2(ii, jj) b[3 * ((ii) * ncols + jj) + 2]
+
+    for (i = 0; i < nrows; i++)
+    {
+        for (j = 0; j < ncols; j++)
+        {
+            UNREDUCED3_L0(i, j) = a[i][j];
+            UNREDUCED3_L1(i, j) = 0;
+            UNREDUCED3_L2(i, j) = 0;
+        }
+    }
+
+    while (row < nrows && col < ncols)
+    {
+        /* reduce current column */
+        /* can be skipped on the first iteration */
+        if (col != 0)
+            for (j = row; j < nrows; j++)
+                a[j][col] = nmod_set_uiuiui(UNREDUCED3_L2(j, col),
+                    UNREDUCED3_L1(j, col),
+                    UNREDUCED3_L0(j, col), mod);
+
+        pivot_row = -1;
+        for (i = row; i < nrows; i++)
+        {
+            if (a[i][col] != 0)
+            {
+                pivot_row = i;
+                break;
+            }
+        }
+
+        if (pivot_row == -1)
+        {
+            if (rank_check)
+            {
+                rank = 0;
+                break;
+            }
+
+            col++;
+            continue;
+        }
+
+        /* swap rows */
+        if (pivot_row != row)
+        {
+            tmp_ptr = a[pivot_row];
+            a[pivot_row] = a[row];
+            a[row] = tmp_ptr;
+
+            tmp_index = P[pivot_row];
+            P[pivot_row] = P[row];
+            P[row] = tmp_index;
+
+            /* swap rows in unreduced submatrix, and reduce new pivot row */
+            for (j = col + 1; j < ncols; j++)
+            {
+                mp_limb_t t2, t1, t0;
+                t0 = UNREDUCED3_L0(row, j);
+                t1 = UNREDUCED3_L1(row, j);
+                t2 = UNREDUCED3_L2(row, j);
+
+                a[row][j] = nmod_set_uiuiui(UNREDUCED3_L2(pivot_row, j),
+                            UNREDUCED3_L1(pivot_row, j),
+                            UNREDUCED3_L0(pivot_row, j), mod);
+
+                UNREDUCED3_L0(pivot_row, j) = t0;
+                UNREDUCED3_L1(pivot_row, j) = t1;
+                UNREDUCED3_L2(pivot_row, j) = t2;
+            }
+        }
+        else if (row != 0)
+        {
+            /* reduce current pivot row */
+            for (j = col + 1; j < ncols; j++)
+                a[row][j] = nmod_set_uiuiui(UNREDUCED3_L2(row, j),
+                            UNREDUCED3_L1(row, j),
+                            UNREDUCED3_L0(row, j), mod);
+        }
+
+        rank++;
+
+        /* eliminate remaining submatrix */
+        d = nmod_inv(a[row][col], mod);
+        for (i = row + 1; i < nrows; i++)
+        {
+            e = nmod_mul(a[i][col], d, mod);
+            f = nmod_neg(e, mod);
+
+            for (j = col + 1; j < ncols; j++)
+            {
+                mp_limb_t hi, lo;
+                umul_ppmm(hi, lo, a[row][j], f);
+                add_sssaaaaaa(UNREDUCED3_L2(i, j), UNREDUCED3_L1(i, j), UNREDUCED3_L0(i, j),
+                              UNREDUCED3_L2(i, j), UNREDUCED3_L1(i, j), UNREDUCED3_L0(i, j),
+                              0, hi, lo);
+            }
+
+            a[i][col] = 0;
+            a[i][rank - 1] = e;
+        }
+        row++;
+        col++;
+    }
+
+    TMP_END;
+    return rank;
+}
+
+slong
+nmod_mat_lu_classical_delayed(slong * P, nmod_mat_t A, int rank_check)
+{
+    slong nrows, ncols;
+    int nlimbs;
+
+    nrows = A->r;
+    ncols = A->c;
+    nlimbs = _nmod_vec_dot_bound_limbs(FLINT_MIN(nrows, ncols), A->mod);
+
+    if (nlimbs <= 1)
+        return nmod_mat_lu_classical_delayed_1(P, A, rank_check);
+    else if (nlimbs <= 2)
+        return nmod_mat_lu_classical_delayed_2(P, A, rank_check);
+    else
+        return nmod_mat_lu_classical_delayed_3(P, A, rank_check);
+}

--- a/nmod_mat/lu_recursive.c
+++ b/nmod_mat/lu_recursive.c
@@ -45,14 +45,19 @@ _apply_permutation(slong * AP, nmod_mat_t A, slong * P,
 slong 
 nmod_mat_lu_recursive(slong * P, nmod_mat_t A, int rank_check)
 {
-    slong i, j, m, n, r1, r2, n1;
+    slong i, j, m, n, r1, r2, n1, cutoff;
     nmod_mat_t A0, A00, A01, A10, A11;
     slong * P1;
 
     m = A->r;
     n = A->c;
 
-    if (m < NMOD_MAT_LU_RECURSIVE_CUTOFF || n < NMOD_MAT_LU_RECURSIVE_CUTOFF)
+    if (NMOD_BITS(A->mod) == FLINT_BITS)
+        cutoff = 22;
+    else
+        cutoff = 12;
+
+    if (m < cutoff || n < cutoff)
     {
         r1 = nmod_mat_lu_classical(P, A, rank_check);
         return r1;

--- a/nmod_mat/lu_recursive.c
+++ b/nmod_mat/lu_recursive.c
@@ -45,19 +45,15 @@ _apply_permutation(slong * AP, nmod_mat_t A, slong * P,
 slong 
 nmod_mat_lu_recursive(slong * P, nmod_mat_t A, int rank_check)
 {
-    slong i, j, m, n, r1, r2, n1, cutoff;
+    slong i, j, m, n, r1, r2, n1;
     nmod_mat_t A0, A00, A01, A10, A11;
     slong * P1;
 
     m = A->r;
     n = A->c;
 
-    if (NMOD_BITS(A->mod) == FLINT_BITS)
-        cutoff = 22;
-    else
-        cutoff = 12;
-
-    if (m < cutoff || n < cutoff)
+    /* main cutoffs are in nmod_mat_lu */
+    if (m <= 1 || n <= 1)
     {
         r1 = nmod_mat_lu_classical(P, A, rank_check);
         return r1;

--- a/nmod_mat/profile/p-lu.c
+++ b/nmod_mat/profile/p-lu.c
@@ -1,0 +1,122 @@
+/*
+    Copyright 2009 William Hart
+    Copyright 2010, 2021 Fredrik Johansson
+    Copyright 2020 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "profiler.h"
+#include "flint.h"
+#include "nmod_mat.h"
+#include "ulong_extras.h"
+#include "thread_support.h"
+#include "perm.h"
+
+typedef struct
+{
+    slong n;
+    mp_limb_t modulus;
+    int algorithm;
+} mat_lu_t;
+
+void sample(void * arg, ulong count)
+{
+    mat_lu_t * params = (mat_lu_t *) arg;
+    int algorithm = params->algorithm;
+    slong * P;
+    nmod_mat_t A, LU;
+    ulong i;
+    flint_rand_t state;
+
+    flint_randinit(state);
+
+    nmod_mat_init(A, params->n, params->n, params->modulus);
+    nmod_mat_init(LU, params->n, params->n, params->modulus);
+    nmod_mat_randfull(A, state);
+    P = _perm_init(params->n);
+
+    prof_start();
+
+    if (algorithm == 0)
+        for (i = 0; i < count; i++)
+        {
+            nmod_mat_set(LU, A);
+            nmod_mat_lu(P, LU, 0);
+        }
+    else if (algorithm == 1)
+        for (i = 0; i < count; i++)
+        {
+            nmod_mat_set(LU, A);
+            nmod_mat_lu_classical(P, LU, 0);
+        }
+    else if (algorithm == 2)
+        for (i = 0; i < count; i++)
+        {
+            nmod_mat_set(LU, A);
+            nmod_mat_lu_classical_delayed(P, LU, 0);
+        }
+    else
+        for (i = 0; i < count; i++)
+        {
+            nmod_mat_set(LU, A);
+            nmod_mat_lu_recursive(P, LU, 0);
+        }
+
+    prof_stop();
+
+    nmod_mat_clear(A);
+    nmod_mat_clear(LU);
+    _perm_clear(P);
+
+    flint_randclear(state);
+}
+
+slong bits_tab[] = { 5, 14, 15, 25, 30, 31, 32, 33, 60, 61, 62, 63, 64, 0 };
+
+int main(void)
+{
+    double max;
+    mat_lu_t params;
+    slong i, bits, n;
+
+    flint_printf("nmod_mat_lu:\n");
+
+    flint_set_num_threads(1);
+    flint_printf("threads = %wd\n", flint_get_num_threads());
+
+    for (i = 0; (bits = bits_tab[i]) != 0; i++)
+    {
+        for (n = 4; n <= 1000; n += n/4 + 1)
+        {
+            double min_default = 0, min_classical = 0, min_delayed = 0, min_recursive = 0;
+
+            params.n = n;
+            params.modulus = n_nextprime(UWORD(1) << (bits - 1), 0);
+
+            params.algorithm = 0;
+            prof_repeat(&min_default, &max, sample, &params);
+
+            params.algorithm = 1;
+            prof_repeat(&min_classical, &max, sample, &params);
+
+            params.algorithm = 2;
+            prof_repeat(&min_delayed, &max, sample, &params);
+
+            params.algorithm = 3;
+            prof_repeat(&min_recursive, &max, sample, &params);
+
+            flint_printf("b = %wd  n = %wd  default %.2f us  classical %.2f us  delayed %.2f us  recursive %.2f us\n",
+                bits, n, min_default, min_classical, min_delayed, min_recursive);
+        }
+    }
+
+    return 0;
+}

--- a/nmod_mat/profile/p-mul.c
+++ b/nmod_mat/profile/p-mul.c
@@ -18,7 +18,10 @@
 #include "nmod_mat.h"
 #include "ulong_extras.h"
 #include "thread_support.h"
+
+#if FLINT_HAVE_BLAS
 #include "cblas.h"
+#endif
 
 typedef struct
 {
@@ -113,7 +116,9 @@ int main(void)
             {
                 double min_old, min_new, min_ratio = 100;
 
+#if FLINT_HAVE_BLAS
                 openblas_set_num_threads(blas_num);
+#endif
 
                 flint_printf("[flint %wd, blas %wd]: (", flint_num, blas_num);
 

--- a/nmod_mat/test/t-lu_classical_delayed.c
+++ b/nmod_mat/test/t-lu_classical_delayed.c
@@ -1,0 +1,191 @@
+/*
+    Copyright (C) 2010,2011,2021 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <gmp.h>
+#include "flint.h"
+#include "nmod_vec.h"
+#include "nmod_mat.h"
+#include "ulong_extras.h"
+#include "perm.h"
+
+
+void perm(nmod_mat_t A, slong * P)
+{
+    slong i;
+    mp_ptr * tmp;
+
+    if (A->c == 0 || A->r == 0)
+        return;
+
+    tmp = flint_malloc(sizeof(mp_ptr) * A->r);
+
+    for (i = 0; i < A->r; i++) tmp[P[i]] = A->rows[i];
+    for (i = 0; i < A->r; i++) A->rows[i] = tmp[i];
+
+    flint_free(tmp);
+}
+
+void check(slong * P, nmod_mat_t LU, const nmod_mat_t A, slong rank)
+{
+    nmod_mat_t B, L, U;
+    slong m, n, i, j;
+
+    m = A->r;
+    n = A->c;
+
+    nmod_mat_init(B, m, n, A->mod.n);
+    nmod_mat_init(L, m, m, A->mod.n);
+    nmod_mat_init(U, m, n, A->mod.n);
+
+    rank = FLINT_ABS(rank);
+
+    for (i = rank; i < FLINT_MIN(m, n); i++)
+    {
+        for (j = i; j < n; j++)
+        {
+            if (nmod_mat_entry(LU, i, j) != 0)
+            {
+                flint_printf("FAIL: wrong shape!\n");
+                abort();
+            }
+        }
+    }
+
+    for (i = 0; i < m; i++)
+    {
+        for (j = 0; j < FLINT_MIN(i, n); j++)
+            nmod_mat_entry(L, i, j) = nmod_mat_entry(LU, i, j);
+        if (i < rank)
+            nmod_mat_entry(L, i, i) = UWORD(1);
+        for (j = i; j < n; j++)
+            nmod_mat_entry(U, i, j) = nmod_mat_entry(LU, i, j);
+    }
+
+    nmod_mat_mul(B, L, U);
+    perm(B, P);
+
+    if (!nmod_mat_equal(A, B))
+    {
+        flint_printf("FAIL\n");
+        flint_printf("A:\n");
+        nmod_mat_print_pretty(A);
+        flint_printf("LU:\n");
+        nmod_mat_print_pretty(LU);
+        flint_printf("B:\n");
+        nmod_mat_print_pretty(B);
+        abort();
+    }
+
+    nmod_mat_clear(B);
+    nmod_mat_clear(L);
+    nmod_mat_clear(U);
+}
+
+int
+main(void)
+{
+    slong i;
+
+    FLINT_TEST_INIT(state);
+    
+
+    flint_printf("lu_classical_delayed....");
+    fflush(stdout);
+
+    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
+    {
+        nmod_mat_t A, LU, LU2;
+        mp_limb_t mod;
+        slong m, n, r, d, rank, rank2;
+        slong *P, *P2;
+
+        m = n_randint(state, 20);
+        n = n_randint(state, 20);
+
+        mod = n_randtest_prime(state, 0);
+
+        for (r = 0; r <= FLINT_MIN(m, n); r++)
+        {
+            nmod_mat_init(A, m, n, mod);
+            nmod_mat_randrank(A, state, r);
+
+            if (n_randint(state, 2))
+            {
+                d = n_randint(state, 2*m*n + 1);
+                nmod_mat_randops(A, d, state);
+            }
+
+            nmod_mat_init_set(LU, A);
+            P = flint_malloc(sizeof(slong) * m);
+            rank = nmod_mat_lu_classical_delayed(P, LU, 0);
+
+            if (r != rank)
+            {
+                flint_printf("FAIL:\n");
+                flint_printf("wrong rank!\n");
+                flint_printf("A:");
+                nmod_mat_print_pretty(A);
+                flint_printf("LU:");
+                nmod_mat_print_pretty(LU);
+                abort();
+            }
+
+            check(P, LU, A, rank);
+
+            nmod_mat_init_set(LU2, A);
+            P2 = flint_malloc(sizeof(slong) * m);
+            rank2 = nmod_mat_lu_classical(P2, LU2, 0);
+
+            if (r != rank || !nmod_mat_equal(LU, LU2) || !_perm_equal(P, P2, m))
+            {
+                flint_printf("FAIL (2):\n");
+                flint_printf("A:");
+                nmod_mat_print_pretty(A);
+                flint_printf("LU:");
+                nmod_mat_print_pretty(LU);
+                flint_printf("LU2:");
+                nmod_mat_print_pretty(LU2);
+                abort();
+            }
+
+            nmod_mat_set(LU, A);
+            rank = nmod_mat_lu_classical_delayed(P, LU, 1);
+            nmod_mat_set(LU2, A);
+            rank2 = nmod_mat_lu_classical(P2, LU2, 1);
+
+            if (rank != rank2 || (rank == r && (!nmod_mat_equal(LU, LU2) || !_perm_equal(P, P2, m))))
+            {
+                flint_printf("FAIL (3):\n");
+                flint_printf("A:");
+                nmod_mat_print_pretty(A);
+                flint_printf("r = %wd, rank = %wd, rank2 = %wd\n", r, rank, rank2);
+                flint_printf("LU:");
+                nmod_mat_print_pretty(LU);
+                flint_printf("LU2:");
+                nmod_mat_print_pretty(LU2);
+                abort();
+            }
+
+            nmod_mat_clear(A);
+            nmod_mat_clear(LU);
+            flint_free(P);
+            nmod_mat_clear(LU2);
+            flint_free(P2);
+        }
+    }
+
+    FLINT_TEST_CLEANUP(state);
+    
+    flint_printf("PASS\n");
+    return 0;
+}

--- a/nmod_poly/div_newton.c
+++ b/nmod_poly/div_newton.c
@@ -23,24 +23,17 @@ void _nmod_poly_div_newton(mp_ptr Q, mp_srcptr A, slong lenA,
     const slong lenQ = lenA - lenB + 1;
     mp_ptr Arev, Brev;
 
-    Arev = _nmod_vec_init(2 * lenQ);
+    Arev = _nmod_vec_init(lenQ + FLINT_MIN(lenB, lenQ));
     Brev = Arev + lenQ;
 
     _nmod_poly_reverse(Arev, A + (lenA - lenQ), lenQ, lenQ);
 
     if (lenB >= lenQ)
-    {
         _nmod_poly_reverse(Brev, B + (lenB - lenQ), lenQ, lenQ);
-    }
     else
-    {
         _nmod_poly_reverse(Brev, B, lenB, lenB);
-        flint_mpn_zero(Brev + lenB, lenQ - lenB);
-    }
 
-    /* todo: don't zero pad! */
-    _nmod_poly_div_series(Q, Arev, lenQ, Brev, lenQ, lenQ, mod);
-
+    _nmod_poly_div_series(Q, Arev, lenQ, Brev, lenB, lenQ, mod);
     _nmod_poly_reverse(Q, Q, lenQ, lenQ);
 
     _nmod_vec_clear(Arev);

--- a/nmod_vec/profile/p-mul.c
+++ b/nmod_vec/profile/p-mul.c
@@ -1,0 +1,105 @@
+/*
+    Copyright 2010 William Hart
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "profiler.h"
+#include "flint.h"
+#include "ulong_extras.h"
+#include "nmod_vec.h"
+
+typedef struct
+{
+   flint_bitcnt_t bits;
+   int fullword;
+} info_t;
+
+void sample(void * arg, ulong count)
+{
+   mp_limb_t n;
+   nmod_t mod;
+   info_t * info = (info_t *) arg;
+   flint_bitcnt_t bits = info->bits;
+   int fullword = info->fullword;
+   mp_size_t j;
+   slong i;
+   FLINT_TEST_INIT(state);
+      
+   n = n_randbits(state, bits);
+   if (n == UWORD(0)) n++;
+      
+   nmod_init(&mod, n);
+
+   mp_ptr vec1 = _nmod_vec_init(1000);
+   mp_ptr vec2 = _nmod_vec_init(1000);
+   mp_ptr res = _nmod_vec_init(1000);
+     
+   for (j = 0; j < 1000; j++)
+      vec1[j] = n_randint(state, n);
+
+   for (j = 0; j < 1000; j++)
+      vec2[j] = n_randint(state, n);
+
+   switch (fullword)
+   {
+   case 0:
+      prof_start();
+      for (i = 0; i < count; i++)
+         for (j = 0; j < 1000; j++)
+           res[j] = nmod_mul(vec1[j], vec2[j], mod);
+      prof_stop();
+      break;
+
+   case 1:
+      prof_start();
+      for (i = 0; i < count; i++)
+         for (j = 0; j < 1000; j++)
+           res[j] = _nmod_mul_fullword(vec1[j], vec2[j], mod);
+      prof_stop();
+      break;
+   }
+
+   flint_randclear(state);
+   _nmod_vec_clear(vec1);
+   _nmod_vec_clear(vec2);
+}
+
+int main(void)
+{
+   double min1, min2, max;
+   info_t info;
+   flint_bitcnt_t i;
+
+   for (i = 2; i <= FLINT_BITS; i++)
+   {
+      info.bits = i;
+
+      info.fullword = 0;
+      prof_repeat(&min1, &max, sample, (void *) &info);
+
+      if (i != FLINT_BITS)
+      {
+        flint_printf("bits %wd, mul = %.1lf c/l\n", 
+           i, (min1/(double)FLINT_CLOCK_SCALE_FACTOR)/1000);
+      }
+      else
+      {
+        info.fullword = 1;
+        prof_repeat(&min2, &max, sample, (void *) &info);
+
+        flint_printf("bits %wd, mul = %.1lf c/l, mul_fullword = %.1lf c/l\n", 
+           i, (min1/(double)FLINT_CLOCK_SCALE_FACTOR)/1000,
+              (min2/(double)FLINT_CLOCK_SCALE_FACTOR)/1000);
+      }
+   }
+
+   return 0;
+}

--- a/nmod_vec/profile/p-scalar_addmul.c
+++ b/nmod_vec/profile/p-scalar_addmul.c
@@ -42,12 +42,14 @@ void sample(void * arg, ulong count)
       c = n_randint(state, n);
       for (j = 0; j < length; j++)
          vec[j] = n_randint(state, n);
-      
+      for (j = 0; j < length; j++)
+         vec2[j] = n_randint(state, n);
+
 	  nmod_init(&mod, n);
 
       prof_start();
       for (j = 0; j < 30; j++)
-		 _nmod_vec_scalar_mul_nmod(vec2, vec, length, c, mod);
+		 _nmod_vec_scalar_addmul_nmod(vec2, vec, length, c, mod);
 	  prof_stop();
    }
    

--- a/nmod_vec/scalar_addmul_nmod.c
+++ b/nmod_vec/scalar_addmul_nmod.c
@@ -38,7 +38,7 @@ void _nmod_vec_scalar_addmul_nmod_generic(mp_ptr res, mp_srcptr vec,
     for (i = 0; i < len; i++)
     {
         NMOD_MUL_PRENORM(t, vec[i], c << mod.norm, mod);
-        res[i] = nmod_add(res[i], t, mod);
+        res[i] = _nmod_add(res[i], t, mod);
     }
 }
 
@@ -53,7 +53,7 @@ void _nmod_vec_scalar_addmul_nmod_shoup(mp_ptr res, mp_srcptr vec,
     for (i = 0; i < len; i++)
     {
         t = n_mulmod_shoup(c, vec[i], cinv, mod.n);
-        res[i] = nmod_add(res[i], t, mod);
+        res[i] = _nmod_add(res[i], t, mod);
     }
 }
 

--- a/nmod_vec/scalar_mul_nmod.c
+++ b/nmod_vec/scalar_mul_nmod.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2010 William Hart
+    Copyright (C) 2021 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -15,30 +16,31 @@
 #include "ulong_extras.h"
 #include "nmod_vec.h"
 
+void _nmod_vec_scalar_mul_nmod_fullword(mp_ptr res, mp_srcptr vec, 
+                               slong len, mp_limb_t c, nmod_t mod)
+{
+    slong i;
+
+    for (i = 0; i < len; i++)
+        NMOD_MUL_FULLWORD(res[i], vec[i], c, mod);
+}
+
+void _nmod_vec_scalar_mul_nmod_generic(mp_ptr res, mp_srcptr vec, 
+                               slong len, mp_limb_t c, nmod_t mod)
+{
+    slong i;
+
+    for (i = 0; i < len; i++)
+        NMOD_MUL_PRENORM(res[i], vec[i], c << mod.norm, mod);
+}
+
 void _nmod_vec_scalar_mul_nmod(mp_ptr res, mp_srcptr vec, 
                                slong len, mp_limb_t c, nmod_t mod)
 {
-    if (len < 1)
-        return;
-
-    if (len > 10 && mod.n < UWORD_HALF)
-    {
+    if (NMOD_BITS(mod) == FLINT_BITS)
+        _nmod_vec_scalar_mul_nmod_fullword(res, vec, len, c, mod);
+    else if (len > 10)
         _nmod_vec_scalar_mul_nmod_shoup(res, vec, len, c, mod);
-        return;
-    }
-
-    if (mod.norm >= FLINT_BITS / 2) /* products will fit in a limb */
-    {
-        mpn_mul_1(res, vec, len, c);
-        _nmod_vec_reduce(res, res, len, mod);
-    } else /* products may take two limbs */
-    {
-        slong i;
-        for (i = 0; i < len; i++)
-        {
-            mp_limb_t hi, lo;
-            umul_ppmm(hi, lo, vec[i], c);
-            NMOD_RED2(res[i], hi, lo, mod); /* hi already reduced mod n */
-        }
-    }
+    else 
+        _nmod_vec_scalar_mul_nmod_generic(res, vec, len, c, mod);
 }


### PR DESCRIPTION
```
OLD nmod_mul:          14.7 c/l
NEW nmod_mul:          10.9 c/l   (1.35x speedup)
NEW _nmod_mul_fullword:  8.4 c/l   (1.75x speedup)

OLD nmod_vec_scalar_mul, bits <= 63, len == 4:   17.6 c/l
NEW nmod_vec_scalar_mul, bits <= 63, len == 4:   13.0 c/l   (1.35x speedup)

OLD nmod_vec_scalar_mul, bits <= 63, len == 128:  5.1 c/l
NEW nmod_vec_scalar_mul, bits <= 63, len == 128:  5.1 c/l   (1.00x speedup)

OLD nmod_vec_scalar_mul, bits == 64, len == 4:   17.6 c/l
NEW nmod_vec_scalar_mul, bits == 64, len == 4:   10.4 c/l   (1.69x speedup)

OLD nmod_vec_scalar_mul, bits == 64, len == 128: 21.6 c/l
NEW nmod_vec_scalar_mul, bits == 64, len == 128:  9.8 c/l   (2.20x speedup)

OLD nmod_vec_scalar_addmul, bits <= 32, len == 4:   19.7 c/l
NEW nmod_vec_scalar_addmul, bits <= 32, len == 4:   14.7 c/l   (1.34x speedup)

OLD nmod_vec_scalar_addmul, bits <= 32, len == 128: 14.4 c/l
NEW nmod_vec_scalar_addmul, bits <= 32, len == 128:  9.0 c/l   (1.60x speedup)

OLD nmod_vec_scalar_addmul, bits <= 63, len == 4:   18.8 c/l
NEW nmod_vec_scalar_addmul, bits <= 63, len == 4:   14.7 c/l   (1.28x speedup)

OLD nmod_vec_scalar_addmul, bits <= 63, len == 128: 21.4 c/l
NEW nmod_vec_scalar_addmul, bits <= 63, len == 128:  9.0 c/l   (2.38x speedup)

OLD nmod_vec_scalar_addmul, bits == 64, len == 4:   18.8 c/l
NEW nmod_vec_scalar_addmul, bits == 64, len == 4:   13.2 c/l    (1.42x speedup)

OLD nmod_vec_scalar_addmul, bits == 64, len == 128: 21.4 c/l
NEW nmod_vec_scalar_addmul, bits == 64, len == 128: 13.4 c/l    (1.60x speedup)
```

Comments:
* This is on an ancient laptop (haswell). Someone should verify the results on a newer machine.
* _nmod_mul_fullword is significantly faster than nmod_mul, but I don't think it's worth a branch in nmod_mul to check for this case. Might be better to use this in specific multiplication-dependent functions.
* I tried half-word modulus versions but saw no speedups. Might require use of vector instructions.
* It remains to fix a lot of n_mulmod2_preinv uses.
* Not sure if nmod_mul should be inline. We might want two versions; one for speed, another for code size.
* Can we do addmul faster (avoiding some conditional in the end)? What about addmul with mul_shoup?
* Can we extend mul_shoup to bits == 64?