### PR TITLE
flint.h: On GCC < 4.9, do not use _Thread_local

### DIFF
--- a/flint.h
+++ b/flint.h
@@ -157,7 +157,10 @@ FLINT_DLL void flint_set_abort(FLINT_NORETURN void (*func)(void));
 #define flint_bitcnt_t ulong
 
 #if FLINT_USES_TLS
-#if __STDC_VERSION__ >= 201112L
+#if defined(__GNUC__) && __STDC_VERSION__ >= 201112L && __GNUC__ == 4 && __GNUC_MINOR__ < 9
+/* GCC 4.7, 4.8 with -std=gnu11 purport to support C11 via __STDC_VERSION__ but lack _Thread_local */
+#define FLINT_TLS_PREFIX __thread
+#elif __STDC_VERSION__ >= 201112L
 #define FLINT_TLS_PREFIX _Thread_local
 #elif defined(_MSC_VER)
 #define FLINT_TLS_PREFIX __declspec(thread)


### PR DESCRIPTION
When building Singular 4.2.1p2 on `ubuntu-trusty`, Singular's configure script does not detect FLINT.
https://trac.sagemath.org/ticket/32907