### PR TITLE
Change mpz_ptr to m[suffix]

### DIFF
--- a/fmpz/abs.c
+++ b/fmpz/abs.c
@@ -28,7 +28,7 @@ fmpz_abs(fmpz_t f1, const fmpz_t f2)
     else  /* coeff is large */
     {
         /* No need to retain value in promotion, as if aliased, both already large */
-        __mpz_struct *mpz_ptr = _fmpz_promote(f1);
-        mpz_abs(mpz_ptr, COEFF_TO_PTR(*f2));
+        __mpz_struct * mf1 = _fmpz_promote(f1);
+        mpz_abs(mf1, COEFF_TO_PTR(*f2));
     }
 }

--- a/fmpz/add_ui.c
+++ b/fmpz/add_ui.c
@@ -36,9 +36,9 @@ void fmpz_add_ui(fmpz_t f, const fmpz_t g, ulong x)
 	}
     else
 	{	
-		__mpz_struct * mpz_ptr2 = _fmpz_promote(f);  /* g is already large */
-		__mpz_struct * mpz_ptr = COEFF_TO_PTR(c);
-		flint_mpz_add_ui(mpz_ptr2, mpz_ptr, x);
+		__mpz_struct * mf = _fmpz_promote(f);  /* g is already large */
+		__mpz_struct * mc = COEFF_TO_PTR(c);
+		flint_mpz_add_ui(mf, mc, x);
 		_fmpz_demote_val(f);  /* cancellation may have occurred */
 	}
 }

--- a/fmpz/addmul.c
+++ b/fmpz/addmul.c
@@ -17,7 +17,7 @@
 void fmpz_addmul(fmpz_t f, const fmpz_t g, const fmpz_t h)
 {
     fmpz c1, c2;
-    __mpz_struct * mpz_ptr;
+    __mpz_struct * mf;
 	
     c1 = *g;
 	
@@ -38,7 +38,7 @@ void fmpz_addmul(fmpz_t f, const fmpz_t g, const fmpz_t h)
 	} 
 
 	/* both g and h are large */
-    mpz_ptr = _fmpz_promote_val(f);
-    mpz_addmul(mpz_ptr, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
+    mf = _fmpz_promote_val(f);
+    mpz_addmul(mf, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
     _fmpz_demote_val(f);  /* cancellation may have occurred	*/
 }

--- a/fmpz/addmul_ui.c
+++ b/fmpz/addmul_ui.c
@@ -78,18 +78,18 @@ fmpz_addmul_ui(fmpz_t f, const fmpz_t g, ulong x)
            or will be big in the end
          */
         {
-            __mpz_struct * mpz_ptr = _fmpz_promote_val(f);
+            __mpz_struct * mf = _fmpz_promote_val(f);
             mpz_t temp;  /* set up a temporary, cheap mpz_t to contain prod */
             temp->_mp_d = prod;
             temp->_mp_size = (c1 < WORD(0) ? -2 : 2);
-            mpz_add(mpz_ptr, mpz_ptr, temp);
+            mpz_add(mf, mf, temp);
             _fmpz_demote_val(f);  /* cancellation may have occurred */
         }
     }
     else  /* c1 is large */
     {
-        __mpz_struct * mpz_ptr = _fmpz_promote_val(f);
-        flint_mpz_addmul_ui(mpz_ptr, COEFF_TO_PTR(c1), x);
+        __mpz_struct * mf = _fmpz_promote_val(f);
+        flint_mpz_addmul_ui(mf, COEFF_TO_PTR(c1), x);
         _fmpz_demote_val(f);  /* cancellation may have occurred */
     }
 }

--- a/fmpz/bit_unpack.c
+++ b/fmpz/bit_unpack.c
@@ -67,19 +67,19 @@ fmpz_bit_unpack(fmpz_t coeff, mp_srcptr arr, flint_bitcnt_t shift,
     }
     else  /* large coefficient */
     {
-        __mpz_struct * mpz_ptr;
+        __mpz_struct * mcoeff;
         mp_limb_t * p;
         ulong l, b;
         
-        mpz_ptr = _fmpz_promote(coeff);
+        mcoeff = _fmpz_promote(coeff);
 
         /* the number of limbs to hold the bitfield _including_ b extra bits */
         l = (bits - 1) / FLINT_BITS + 1;
         b = bits % FLINT_BITS;
 
         /* allocate space for l limbs only */
-        mpz_realloc(mpz_ptr, l);
-        p = mpz_ptr->_mp_d;
+        mpz_realloc(mcoeff, l);
+        p = mcoeff->_mp_d;
 
         /* shift in l limbs */
         if (shift)
@@ -113,7 +113,7 @@ fmpz_bit_unpack(fmpz_t coeff, mp_srcptr arr, flint_bitcnt_t shift,
             while (l && (p[l - 1] == (mp_limb_t) 0))
                 l--;
 
-            mpz_ptr->_mp_size = -l;
+            mcoeff->_mp_size = -l;
 
             sign = 1;
         }
@@ -127,13 +127,13 @@ fmpz_bit_unpack(fmpz_t coeff, mp_srcptr arr, flint_bitcnt_t shift,
             while (l && (p[l - 1] == (mp_limb_t) 0))
                 l--;
 
-            mpz_ptr->_mp_size = l;
+            mcoeff->_mp_size = l;
             sign = 0;
         }
 
         /* negate if required */
         if (negate)
-            mpz_neg(mpz_ptr, mpz_ptr);
+            mpz_neg(mcoeff, mcoeff);
 
         /* coeff may fit in a small */
         _fmpz_demote_val(coeff);
@@ -165,19 +165,19 @@ fmpz_bit_unpack_unsigned(fmpz_t coeff, mp_srcptr arr,
     }
     else  /* large coefficient */
     {
-        __mpz_struct * mpz_ptr;
+        __mpz_struct * mcoeff;
         mp_limb_t * p;
         ulong l, b;
 
-        mpz_ptr = _fmpz_promote(coeff);
+        mcoeff = _fmpz_promote(coeff);
 
         /* the number of limbs to hold the bitfield _including_ b extra bits */
         l = (bits - 1) / FLINT_BITS + 1;
         b = bits % FLINT_BITS;
 
         /* allocate space for l limbs only */
-        mpz_realloc(mpz_ptr, l);
-        p = mpz_ptr->_mp_d;
+        mpz_realloc(mcoeff, l);
+        p = mcoeff->_mp_d;
 
         /* shift in l limbs */
         if (shift)
@@ -200,7 +200,7 @@ fmpz_bit_unpack_unsigned(fmpz_t coeff, mp_srcptr arr,
         while (l && (p[l - 1] == (mp_limb_t) 0))
             l--;
 
-        mpz_ptr->_mp_size = l;
+        mcoeff->_mp_size = l;
 
         /* coeff may fit in a small */
         _fmpz_demote_val(coeff);

--- a/fmpz/cdiv_q.c
+++ b/fmpz/cdiv_q.c
@@ -50,23 +50,23 @@ fmpz_cdiv_q(fmpz_t f, const fmpz_t g, const fmpz_t h)
     }
     else  /* g is large */
     {
-        __mpz_struct * mpz_ptr = _fmpz_promote(f);
+        __mpz_struct * mf = _fmpz_promote(f);
 
         if (!COEFF_IS_MPZ(c2))  /* h is small */
         {
             if (c2 > 0)  /* h > 0 */
             {
-                flint_mpz_cdiv_q_ui(mpz_ptr, COEFF_TO_PTR(c1), c2);
+                flint_mpz_cdiv_q_ui(mf, COEFF_TO_PTR(c1), c2);
             }
             else
             {
-                flint_mpz_fdiv_q_ui(mpz_ptr, COEFF_TO_PTR(c1), -c2);
-                mpz_neg(mpz_ptr, mpz_ptr);
+                flint_mpz_fdiv_q_ui(mf, COEFF_TO_PTR(c1), -c2);
+                mpz_neg(mf, mf);
             }
         }
         else  /* both are large */
         {
-            mpz_cdiv_q(mpz_ptr, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
+            mpz_cdiv_q(mf, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
         }
         _fmpz_demote_val(f);  /* division by h may result in small value */
     }

--- a/fmpz/cdiv_q_2exp.c
+++ b/fmpz/cdiv_q_2exp.c
@@ -25,8 +25,8 @@ void fmpz_cdiv_q_2exp(fmpz_t f, const fmpz_t g, ulong exp)
     }
     else  /*g is large */
     {
-        __mpz_struct * mpz_ptr = _fmpz_promote(f);  /* g is already large */
-        mpz_cdiv_q_2exp(mpz_ptr, COEFF_TO_PTR(d), exp);
+        __mpz_struct * mf = _fmpz_promote(f);  /* g is already large */
+        mpz_cdiv_q_2exp(mf, COEFF_TO_PTR(d), exp);
         _fmpz_demote_val(f);  /* division may make value small */
     }
 }

--- a/fmpz/cdiv_q_si.c
+++ b/fmpz/cdiv_q_si.c
@@ -39,16 +39,16 @@ fmpz_cdiv_q_si(fmpz_t f, const fmpz_t g, slong h)
     }
     else                        /* g is large */
     {
-        __mpz_struct *mpz_ptr = _fmpz_promote(f);
+        __mpz_struct * mf = _fmpz_promote(f);
 
         if (c2 > 0)
         {
-            flint_mpz_cdiv_q_ui(mpz_ptr, COEFF_TO_PTR(c1), c2);
+            flint_mpz_cdiv_q_ui(mf, COEFF_TO_PTR(c1), c2);
         }
         else
         {
-            flint_mpz_fdiv_q_ui(mpz_ptr, COEFF_TO_PTR(c1), -(ulong) c2);
-            mpz_neg(mpz_ptr, mpz_ptr);
+            flint_mpz_fdiv_q_ui(mf, COEFF_TO_PTR(c1), -(ulong) c2);
+            mpz_neg(mf, mf);
         }
         _fmpz_demote_val(f);    /* division by h may result in small value */
     }

--- a/fmpz/cdiv_q_ui.c
+++ b/fmpz/cdiv_q_ui.c
@@ -47,9 +47,9 @@ fmpz_cdiv_q_ui(fmpz_t f, const fmpz_t g, ulong h)
     }
     else                        /* g is large */
     {
-        __mpz_struct *mpz_ptr = _fmpz_promote(f);
+        __mpz_struct * mf = _fmpz_promote(f);
 
-        flint_mpz_cdiv_q_ui(mpz_ptr, COEFF_TO_PTR(c1), c2);
+        flint_mpz_cdiv_q_ui(mf, COEFF_TO_PTR(c1), c2);
         _fmpz_demote_val(f);    /* division by h may result in small value */
     }
 }

--- a/fmpz/cdiv_qr.c
+++ b/fmpz/cdiv_qr.c
@@ -63,27 +63,27 @@ void fmpz_cdiv_qr(fmpz_t f, fmpz_t s, const fmpz_t g, const fmpz_t h)
     }
     else                        /* g is large */
     {
-        __mpz_struct *mpz_ptr, *mpz_ptr2;
+        __mpz_struct * mf, * ms;
 
         _fmpz_promote(f); /* must not hang on to ptr whilst promoting s */
-        mpz_ptr2 = _fmpz_promote(s);
-		mpz_ptr  = COEFF_TO_PTR(*f);
+        ms = _fmpz_promote(s);
+        mf  = COEFF_TO_PTR(*f);
 
-		if (!COEFF_IS_MPZ(c2))  /* h is small */
+        if (!COEFF_IS_MPZ(c2))  /* h is small */
         {
             if (c2 > 0)         /* h > 0 */
             {
-                flint_mpz_cdiv_qr_ui(mpz_ptr, mpz_ptr2, COEFF_TO_PTR(c1), c2);
+                flint_mpz_cdiv_qr_ui(mf, ms, COEFF_TO_PTR(c1), c2);
             }
             else
             {
-                flint_mpz_fdiv_qr_ui(mpz_ptr, mpz_ptr2, COEFF_TO_PTR(c1), -c2);
-                mpz_neg(mpz_ptr, mpz_ptr);
+                flint_mpz_fdiv_qr_ui(mf, ms, COEFF_TO_PTR(c1), -c2);
+                mpz_neg(mf, mf);
             }
         }
         else                    /* both are large */
         {
-            mpz_cdiv_qr(mpz_ptr, mpz_ptr2, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
+            mpz_cdiv_qr(mf, ms, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
         }
         _fmpz_demote_val(f);    /* division by h may result in small value */
         _fmpz_demote_val(s);    /* division by h may result in small value */

--- a/fmpz/cdiv_r_2exp.c
+++ b/fmpz/cdiv_r_2exp.c
@@ -33,19 +33,19 @@ void fmpz_cdiv_r_2exp(fmpz_t f, const fmpz_t g, ulong exp)
             }
             else
             {
-                __mpz_struct * mpz_ptr = _fmpz_promote(f);
+                __mpz_struct * mf = _fmpz_promote(f);
 
-                flint_mpz_set_ui(mpz_ptr, 1);
-                mpz_mul_2exp(mpz_ptr, mpz_ptr, exp);
-                flint_mpz_sub_ui(mpz_ptr, mpz_ptr, d);
-                mpz_neg(mpz_ptr, mpz_ptr);
+                flint_mpz_set_ui(mf, 1);
+                mpz_mul_2exp(mf, mf, exp);
+                flint_mpz_sub_ui(mf, mf, d);
+                mpz_neg(mf, mf);
             }
         }
     }
     else  /*g is large */
     {
-        __mpz_struct * mpz_ptr = _fmpz_promote(f);  /* g is already large */
-        mpz_cdiv_r_2exp(mpz_ptr, COEFF_TO_PTR(d), exp);
+        __mpz_struct * mf = _fmpz_promote(f);  /* g is already large */
+        mpz_cdiv_r_2exp(mf, COEFF_TO_PTR(d), exp);
         _fmpz_demote_val(f);  /* division may make value small */
     }
 }

--- a/fmpz/divexact.c
+++ b/fmpz/divexact.c
@@ -34,18 +34,18 @@ fmpz_divexact(fmpz_t f, const fmpz_t g, const fmpz_t h)
     }
     else  /* g is large */
     {
-        __mpz_struct * mpz_ptr = _fmpz_promote(f);
+        __mpz_struct * mf = _fmpz_promote(f);
 
         if (!COEFF_IS_MPZ(c2))  /* h is small */
         {
             if (c2 > 0)  /* h > 0 */
             {
-                flint_mpz_divexact_ui(mpz_ptr, COEFF_TO_PTR(c1), c2);
+                flint_mpz_divexact_ui(mf, COEFF_TO_PTR(c1), c2);
                 _fmpz_demote_val(f);  /* division by h may result in small value */
             }
             else
             {
-                flint_mpz_divexact_ui(mpz_ptr, COEFF_TO_PTR(c1), -c2);
+                flint_mpz_divexact_ui(mf, COEFF_TO_PTR(c1), -c2);
                 _fmpz_demote_val(f);  /* division by h may result in small value */
 
                 fmpz_neg(f, f);
@@ -53,7 +53,7 @@ fmpz_divexact(fmpz_t f, const fmpz_t g, const fmpz_t h)
         }
         else  /* both are large */
         {
-            mpz_divexact(mpz_ptr, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
+            mpz_divexact(mf, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
             _fmpz_demote_val(f);  /* division by h may result in small value */
         }
     }

--- a/fmpz/divexact_si.c
+++ b/fmpz/divexact_si.c
@@ -33,16 +33,16 @@ void fmpz_divexact_si(fmpz_t f, const fmpz_t g, slong h)
     }
     else  /* g is large */
     {
-        __mpz_struct * mpz_ptr = _fmpz_promote(f);
+        __mpz_struct * mf = _fmpz_promote(f);
 
         if (h > 0)
         {
-            flint_mpz_divexact_ui(mpz_ptr, COEFF_TO_PTR(c1), h);
+            flint_mpz_divexact_ui(mf, COEFF_TO_PTR(c1), h);
             _fmpz_demote_val(f);  /* division by h may result in small value */
         }
         else
         {
-            flint_mpz_divexact_ui(mpz_ptr, COEFF_TO_PTR(c1), -h);
+            flint_mpz_divexact_ui(mf, COEFF_TO_PTR(c1), -h);
             _fmpz_demote_val(f);  /* division by h may result in small value */
             fmpz_neg(f, f);
         }

--- a/fmpz/divexact_ui.c
+++ b/fmpz/divexact_ui.c
@@ -33,9 +33,9 @@ void fmpz_divexact_ui(fmpz_t f, const fmpz_t g, ulong h)
     }
     else  /* g is large */
     {
-        __mpz_struct * mpz_ptr = _fmpz_promote(f);
+        __mpz_struct * mf = _fmpz_promote(f);
 
-        flint_mpz_divexact_ui(mpz_ptr, COEFF_TO_PTR(c1), h);
+        flint_mpz_divexact_ui(mf, COEFF_TO_PTR(c1), h);
         _fmpz_demote_val(f);  /* division by h may result in small value */
     }
 }

--- a/fmpz/divides.c
+++ b/fmpz/divides.c
@@ -22,83 +22,83 @@ fmpz_divides(fmpz_t q, const fmpz_t g, const fmpz_t h)
     fmpz c1 = *g;
     fmpz c2 = *h;
     int res, negate = 0;
-    
+
     if (fmpz_is_zero(h))
     {
         res = fmpz_is_zero(g);
-	
-	fmpz_zero(q);
-	
-	return res;
+
+        fmpz_zero(q);
+
+        return res;
     }
 
     if (!COEFF_IS_MPZ(c1))      /* g is small */
     {	
-	if (!COEFF_IS_MPZ(c2))  /* h is also small */
+        if (!COEFF_IS_MPZ(c2))  /* h is also small */
         {
             mp_limb_t qz;
 
-	    if (c1 < 0)
+            if (c1 < 0)
             {
-	        c1 = -c1;
-	        negate ^= 1;
-	    }
-	    if (c2 < 0)
-	    {
-	        c2 = -c2;
-	        negate ^= 1;
-	    }
-            
-	    res = n_divides(&qz, c1, c2);
-            fmpz_set_ui(q, qz);
-	    if (negate)
-	        fmpz_neg(q, q);
-
-	    return res;
-        }
-        else                    /* h is large and g is small */
-        {
-            res = fmpz_is_zero(g);
-
-	    fmpz_zero(q);
-            
-	    return res;
-        }
-    }
-    else                        /* g is large */
-    {
-        __mpz_struct *mpz_ptr = _fmpz_promote(q);
-
-	if (!COEFF_IS_MPZ(c2))  /* h is small */
-        {
-            mp_limb_t r;
-
-	    if (c2 < 0)
+                c1 = -c1;
+                negate ^= 1;
+            }
+            if (c2 < 0)
             {
                 c2 = -c2;
                 negate ^= 1;
             }
 
-            r = flint_mpz_tdiv_q_ui(mpz_ptr, COEFF_TO_PTR(c1), c2);
+            res = n_divides(&qz, c1, c2);
+            fmpz_set_ui(q, qz);
+            if (negate)
+                fmpz_neg(q, q);
+
+            return res;
+        }
+        else                    /* h is large and g is small */
+        {
+            res = fmpz_is_zero(g);
+
+            fmpz_zero(q);
+
+            return res;
+        }
+    }
+    else                        /* g is large */
+    {
+        __mpz_struct * mq = _fmpz_promote(q);
+
+        if (!COEFF_IS_MPZ(c2))  /* h is small */
+        {
+            mp_limb_t r;
+
+            if (c2 < 0)
+            {
+                c2 = -c2;
+                negate ^= 1;
+            }
+
+            r = flint_mpz_tdiv_q_ui(mq, COEFF_TO_PTR(c1), c2);
 
             res = (r == 0);
         }
         else                    /* both are large */
         {
             mpz_t r;
-	    mpz_ptr  = _fmpz_promote(q);
+            mq  = _fmpz_promote(q);
 
             mpz_init(r);
 
-            mpz_tdiv_qr(mpz_ptr, r, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
+            mpz_tdiv_qr(mq, r, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
 
             res = mpz_sgn(r) == 0;
 
-	    mpz_clear(r);
+            mpz_clear(r);
         }
 
         if (!res)
-            mpz_set_ui(mpz_ptr, 0);
+            mpz_set_ui(mq, 0);
 
         _fmpz_demote_val(q);
 

--- a/fmpz/fdiv_q.c
+++ b/fmpz/fdiv_q.c
@@ -50,23 +50,23 @@ fmpz_fdiv_q(fmpz_t f, const fmpz_t g, const fmpz_t h)
     }
     else                        /* g is large */
     {
-        __mpz_struct *mpz_ptr = _fmpz_promote(f);
+        __mpz_struct * mf = _fmpz_promote(f);
 
         if (!COEFF_IS_MPZ(c2))  /* h is small */
         {
             if (c2 > 0)         /* h > 0 */
             {
-                flint_mpz_fdiv_q_ui(mpz_ptr, COEFF_TO_PTR(c1), c2);
+                flint_mpz_fdiv_q_ui(mf, COEFF_TO_PTR(c1), c2);
             }
             else
             {
-                flint_mpz_cdiv_q_ui(mpz_ptr, COEFF_TO_PTR(c1), -c2);
-                mpz_neg(mpz_ptr, mpz_ptr);
+                flint_mpz_cdiv_q_ui(mf, COEFF_TO_PTR(c1), -c2);
+                mpz_neg(mf, mf);
             }
         }
         else                    /* both are large */
         {
-            mpz_fdiv_q(mpz_ptr, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
+            mpz_fdiv_q(mf, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
         }
         _fmpz_demote_val(f);    /* division by h may result in small value */
     }

--- a/fmpz/fdiv_q_2exp.c
+++ b/fmpz/fdiv_q_2exp.c
@@ -24,8 +24,8 @@ void fmpz_fdiv_q_2exp(fmpz_t f, const fmpz_t g, ulong exp)
     }
     else  /*g is large */
     {
-        __mpz_struct * mpz_ptr = _fmpz_promote(f);  /* g is already large */
-        mpz_fdiv_q_2exp(mpz_ptr, COEFF_TO_PTR(d), exp);
+        __mpz_struct * mf = _fmpz_promote(f);  /* g is already large */
+        mpz_fdiv_q_2exp(mf, COEFF_TO_PTR(d), exp);
         _fmpz_demote_val(f);  /* division may make value small */
     }
 }

--- a/fmpz/fdiv_q_si.c
+++ b/fmpz/fdiv_q_si.c
@@ -40,16 +40,16 @@ fmpz_fdiv_q_si(fmpz_t f, const fmpz_t g, slong h)
     }
     else                        /* g is large */
     {
-        __mpz_struct *mpz_ptr = _fmpz_promote(f);
+        __mpz_struct * mf = _fmpz_promote(f);
 
         if (c2 > 0)
         {
-            flint_mpz_fdiv_q_ui(mpz_ptr, COEFF_TO_PTR(c1), c2);
+            flint_mpz_fdiv_q_ui(mf, COEFF_TO_PTR(c1), c2);
         }
         else
         {
-            flint_mpz_cdiv_q_ui(mpz_ptr, COEFF_TO_PTR(c1), -(ulong) c2);
-            mpz_neg(mpz_ptr, mpz_ptr);
+            flint_mpz_cdiv_q_ui(mf, COEFF_TO_PTR(c1), -(ulong) c2);
+            mpz_neg(mf, mf);
         }
         _fmpz_demote_val(f);    /* division by h may result in small value */
     }

--- a/fmpz/fdiv_q_ui.c
+++ b/fmpz/fdiv_q_ui.c
@@ -47,9 +47,9 @@ fmpz_fdiv_q_ui(fmpz_t f, const fmpz_t g, ulong h)
     }
     else                        /* g is large */
     {
-        __mpz_struct *mpz_ptr = _fmpz_promote(f);
+        __mpz_struct * mf = _fmpz_promote(f);
 
-        flint_mpz_fdiv_q_ui(mpz_ptr, COEFF_TO_PTR(c1), c2);
+        flint_mpz_fdiv_q_ui(mf, COEFF_TO_PTR(c1), c2);
         _fmpz_demote_val(f);    /* division by h may result in small value */
     }
 }

--- a/fmpz/fdiv_qr.c
+++ b/fmpz/fdiv_qr.c
@@ -65,27 +65,27 @@ fmpz_fdiv_qr(fmpz_t f, fmpz_t s, const fmpz_t g, const fmpz_t h)
     }
     else                        /* g is large */
     {
-        __mpz_struct *mpz_ptr, *mpz_ptr2;
+        __mpz_struct * mf, * ms;
 
         _fmpz_promote(f); /* must not hang on to ptr whilst promoting s */
-        mpz_ptr2 = _fmpz_promote(s);
-		mpz_ptr  = COEFF_TO_PTR(*f);
+        ms = _fmpz_promote(s);
+		mf  = COEFF_TO_PTR(*f);
 
 		if (!COEFF_IS_MPZ(c2))  /* h is small */
         {
             if (c2 > 0)         /* h > 0 */
             {
-                flint_mpz_fdiv_qr_ui(mpz_ptr, mpz_ptr2, COEFF_TO_PTR(c1), c2);
+                flint_mpz_fdiv_qr_ui(mf, ms, COEFF_TO_PTR(c1), c2);
             }
             else
             {
-                flint_mpz_cdiv_qr_ui(mpz_ptr, mpz_ptr2, COEFF_TO_PTR(c1), -c2);
-                mpz_neg(mpz_ptr, mpz_ptr);
+                flint_mpz_cdiv_qr_ui(mf, ms, COEFF_TO_PTR(c1), -c2);
+                mpz_neg(mf, mf);
             }
         }
         else                    /* both are large */
         {
-            mpz_fdiv_qr(mpz_ptr, mpz_ptr2, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
+            mpz_fdiv_qr(mf, ms, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
         }
         _fmpz_demote_val(f);    /* division by h may result in small value */
         _fmpz_demote_val(s);    /* division by h may result in small value */

--- a/fmpz/fdiv_qr_preinvn.c
+++ b/fmpz/fdiv_qr_preinvn.c
@@ -23,111 +23,111 @@
 void _mpz_tdiv_qr_preinvn(mpz_ptr q, mpz_ptr r, 
                           mpz_srcptr a, mpz_srcptr d, const fmpz_preinvn_t inv)
 {
-   slong size1 = a->_mp_size, size2 = d->_mp_size;
-   ulong usize1 = FLINT_ABS(size1);
-   ulong usize2 = FLINT_ABS(size2);
-   ulong qsize = usize1 - usize2 + 1;
-   int nm = (inv->norm != 0);
-   TMP_INIT;
+    slong size1 = a->_mp_size, size2 = d->_mp_size;
+    ulong usize1 = FLINT_ABS(size1);
+    ulong usize2 = FLINT_ABS(size2);
+    ulong qsize = usize1 - usize2 + 1;
+    int nm = (inv->norm != 0);
+    TMP_INIT;
 
-   mp_ptr qp, rp, ap, dp, tp, sp;
+    mp_ptr qp, rp, ap, dp, tp, sp;
 
-   if (r->_mp_alloc < usize1 + nm)
-      mpz_realloc2(r, (usize1 + nm)*FLINT_BITS);
+    if (r->_mp_alloc < usize1 + nm)
+        mpz_realloc2(r, (usize1 + nm)*FLINT_BITS);
 
-   if (usize1 < usize2) /* special case preinv code can't deal with */
-   {
-      mpz_set(r, a); /* remainder equals numerator */
-      q->_mp_size = 0; /* quotient is zero */
-      
-      return;
-   }
+    if (usize1 < usize2) /* special case preinv code can't deal with */
+    {
+        mpz_set(r, a); /* remainder equals numerator */
+        q->_mp_size = 0; /* quotient is zero */
 
-   if (q->_mp_alloc < qsize + nm)
-      mpz_realloc2(q, (qsize + nm)*FLINT_BITS);
+        return;
+    }
 
-   dp = d->_mp_d;
-   ap = a->_mp_d;
-   qp = q->_mp_d;
-   rp = r->_mp_d;
+    if (q->_mp_alloc < qsize + nm)
+        mpz_realloc2(q, (qsize + nm)*FLINT_BITS);
 
-   TMP_START;
-   if ((r == d || q == d) && !nm) /* we have alias with d */
-   {
-      tp = TMP_ALLOC(usize2*FLINT_BITS);
-      mpn_copyi(tp, dp, usize2);
-      dp = tp; 
-   }
-   
-   if (r == a || q == a) /* we have alias with a */
-   {
-      tp = TMP_ALLOC(usize1*FLINT_BITS);
-      mpn_copyi(tp, ap, usize1);
-      ap = tp; 
-   }
+    dp = d->_mp_d;
+    ap = a->_mp_d;
+    qp = q->_mp_d;
+    rp = r->_mp_d;
 
-   /* 
-      TODO: speedup mpir's mullow and mulhigh and use in 
-      flint_mpn_divrem_preinvn so we can remove this first 
-      case here
-   */
-   if (usize2 == 2 || (usize2 > 15 && usize2 < 120)) 
-      mpn_tdiv_qr(qp, rp, 0, ap, usize1, dp, usize2);
-   else {
-      if (nm) {
-         tp = TMP_ALLOC(usize2*FLINT_BITS);
-         mpn_lshift(tp, dp, usize2, inv->norm);
-         dp = tp; 
+    TMP_START;
+    if ((r == d || q == d) && !nm) /* we have alias with d */
+    {
+        tp = TMP_ALLOC(usize2*FLINT_BITS);
+        mpn_copyi(tp, dp, usize2);
+        dp = tp; 
+    }
 
-         rp[usize1] = mpn_lshift(rp, ap, usize1, inv->norm);
-         if (rp[usize1] != 0) usize1++, qsize++;
-         sp = rp;
-      } else
-         sp = ap;
+    if (r == a || q == a) /* we have alias with a */
+    {
+        tp = TMP_ALLOC(usize1*FLINT_BITS);
+        mpn_copyi(tp, ap, usize1);
+        ap = tp; 
+    }
 
-      qp[qsize - 1] = flint_mpn_divrem_preinvn(qp, rp, sp, usize1, dp, usize2, inv->dinv);
-   
-      if (nm)
-         mpn_rshift(rp, rp, usize2, inv->norm);
-   }
-         
-   qsize -= (qp[qsize - 1] == 0);
-   MPN_NORM(rp, usize2);
+    /* 
+       TODO: speedup mpir's mullow and mulhigh and use in 
+       flint_mpn_divrem_preinvn so we can remove this first 
+       case here
+    */
+    if (usize2 == 2 || (usize2 > 15 && usize2 < 120)) 
+        mpn_tdiv_qr(qp, rp, 0, ap, usize1, dp, usize2);
+    else {
+        if (nm) {
+            tp = TMP_ALLOC(usize2*FLINT_BITS);
+            mpn_lshift(tp, dp, usize2, inv->norm);
+            dp = tp; 
 
-   q->_mp_size = ((size1 ^ size2) < 0 ? -qsize : qsize);
-   r->_mp_size = (size1 < 0 ? -usize2 : usize2);
+            rp[usize1] = mpn_lshift(rp, ap, usize1, inv->norm);
+            if (rp[usize1] != 0) usize1++, qsize++;
+            sp = rp;
+        } else
+            sp = ap;
 
-   TMP_END;
+        qp[qsize - 1] = flint_mpn_divrem_preinvn(qp, rp, sp, usize1, dp, usize2, inv->dinv);
+
+        if (nm)
+            mpn_rshift(rp, rp, usize2, inv->norm);
+    }
+
+    qsize -= (qp[qsize - 1] == 0);
+    MPN_NORM(rp, usize2);
+
+    q->_mp_size = ((size1 ^ size2) < 0 ? -qsize : qsize);
+    r->_mp_size = (size1 < 0 ? -usize2 : usize2);
+
+    TMP_END;
 }
 
 void _mpz_fdiv_qr_preinvn(mpz_ptr q, mpz_ptr r, 
                           mpz_srcptr a, mpz_srcptr d, const fmpz_preinvn_t inv)
 {
-   slong size1 = a->_mp_size;
-   slong size2 = d->_mp_size;
-   ulong usize2 = FLINT_ABS(size2);
-   mpz_t t;
-   TMP_INIT;
+    slong size1 = a->_mp_size;
+    slong size2 = d->_mp_size;
+    ulong usize2 = FLINT_ABS(size2);
+    mpz_t t;
+    TMP_INIT;
 
-   TMP_START;
-   if (q == d || r == d) /* we need d later, so make sure it doesn't alias */
-   {
-      t->_mp_d = TMP_ALLOC(usize2*FLINT_BITS);
-      t->_mp_size = d->_mp_size;
-      t->_mp_alloc = d->_mp_alloc;
-      mpn_copyi(t->_mp_d, d->_mp_d, usize2);
-      d = t;
-   }
+    TMP_START;
+    if (q == d || r == d) /* we need d later, so make sure it doesn't alias */
+    {
+        t->_mp_d = TMP_ALLOC(usize2*FLINT_BITS);
+        t->_mp_size = d->_mp_size;
+        t->_mp_alloc = d->_mp_alloc;
+        mpn_copyi(t->_mp_d, d->_mp_d, usize2);
+        d = t;
+    }
 
-   _mpz_tdiv_qr_preinvn(q, r, a, d, inv);
+    _mpz_tdiv_qr_preinvn(q, r, a, d, inv);
 
-   if ((size1 ^ size2) < 0 && r->_mp_size != 0)
-   {
-      flint_mpz_sub_ui(q, q, 1);
-      mpz_add(r, r, d);
-   }
+    if ((size1 ^ size2) < 0 && r->_mp_size != 0)
+    {
+        flint_mpz_sub_ui(q, q, 1);
+        mpz_add(r, r, d);
+    }
 
-   TMP_END;
+    TMP_END;
 }
 
 void
@@ -168,20 +168,20 @@ fmpz_fdiv_qr_preinvn(fmpz_t f, fmpz_t s, const fmpz_t g,
     }
     else /* g is large */
     {
-        __mpz_struct *mpz_ptr, *mpz_ptr2;
-        
+        __mpz_struct * mf, * ms;
+
         if (!COEFF_IS_MPZ(c2))  /* h is small */
-           fmpz_fdiv_qr(f, s, g, h);
+            fmpz_fdiv_qr(f, s, g, h);
         else
         {
-           _fmpz_promote(f); /* must not hang on to ptr whilst promoting s */
-           mpz_ptr2 = _fmpz_promote(s);
-		     mpz_ptr  = COEFF_TO_PTR(*f);
+            _fmpz_promote(f); /* must not hang on to ptr whilst promoting s */
+            ms = _fmpz_promote(s);
+            mf  = COEFF_TO_PTR(*f);
 
-           _mpz_fdiv_qr_preinvn(mpz_ptr, mpz_ptr2, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2), inv);
+            _mpz_fdiv_qr_preinvn(mf, ms, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2), inv);
 
-           _fmpz_demote_val(f);    /* division by h may result in small value */
-           _fmpz_demote_val(s);    /* division by h may result in small value */
+            _fmpz_demote_val(f);    /* division by h may result in small value */
+            _fmpz_demote_val(s);    /* division by h may result in small value */
         }
     }
 }

--- a/fmpz/fdiv_r.c
+++ b/fmpz/fdiv_r.c
@@ -59,22 +59,22 @@ fmpz_fdiv_r(fmpz_t f, const fmpz_t g, const fmpz_t h)
     }
     else                        /* g is large */
     {
-        __mpz_struct * mpz_ptr = _fmpz_promote(f);
+        __mpz_struct * mf = _fmpz_promote(f);
 
         if (!COEFF_IS_MPZ(c2))  /* h is small */
         {
             if (c2 > 0)         /* h > 0 */
             {
-                flint_mpz_fdiv_r_ui(mpz_ptr, COEFF_TO_PTR(c1), c2);
+                flint_mpz_fdiv_r_ui(mf, COEFF_TO_PTR(c1), c2);
             }
             else
             {
-                flint_mpz_cdiv_r_ui(mpz_ptr, COEFF_TO_PTR(c1), -c2);
+                flint_mpz_cdiv_r_ui(mf, COEFF_TO_PTR(c1), -c2);
             }
         }
         else                    /* both are large */
         {
-            mpz_fdiv_r(mpz_ptr, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
+            mpz_fdiv_r(mf, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
         }
         _fmpz_demote_val(f);    /* division by h may result in small value */
     }

--- a/fmpz/fdiv_r_2exp.c
+++ b/fmpz/fdiv_r_2exp.c
@@ -33,18 +33,18 @@ void fmpz_fdiv_r_2exp(fmpz_t f, const fmpz_t g, ulong exp)
             }
             else
             {
-                __mpz_struct * mpz_ptr = _fmpz_promote(f);
+                __mpz_struct * mf = _fmpz_promote(f);
 
-                flint_mpz_set_ui(mpz_ptr, 1);
-                mpz_mul_2exp(mpz_ptr, mpz_ptr, exp);
-                flint_mpz_sub_ui(mpz_ptr, mpz_ptr, -d);
+                flint_mpz_set_ui(mf, 1);
+                mpz_mul_2exp(mf, mf, exp);
+                flint_mpz_sub_ui(mf, mf, -d);
             }
         }
     }
     else  /*g is large */
     {
-        __mpz_struct * mpz_ptr = _fmpz_promote(f);  /* g is already large */
-        mpz_fdiv_r_2exp(mpz_ptr, COEFF_TO_PTR(d), exp);
+        __mpz_struct * mf = _fmpz_promote(f);  /* g is already large */
+        mpz_fdiv_r_2exp(mf, COEFF_TO_PTR(d), exp);
         _fmpz_demote_val(f);  /* division may make value small */
     }
 }

--- a/fmpz/gcd.c
+++ b/fmpz/gcd.c
@@ -76,8 +76,8 @@ fmpz_gcd(fmpz_t f, const fmpz_t g, const fmpz_t h)
         {
             /* TODO: Change to mpn_gcd in order to save some calculations that
              * have already been already made. */
-            __mpz_struct * mpz_ptr = _fmpz_promote(f);
-            mpz_gcd(mpz_ptr, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
+            __mpz_struct * mf = _fmpz_promote(f);
+            mpz_gcd(mf, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
             _fmpz_demote_val(f);
         }
     }

--- a/fmpz/init2.c
+++ b/fmpz/init2.c
@@ -19,9 +19,9 @@ fmpz_init2(fmpz_t f, ulong limbs)
 {
     if (limbs)
     {
-        __mpz_struct *mpz_ptr = _fmpz_new_mpz();
-        *f = PTR_TO_COEFF(mpz_ptr);
-        _mpz_realloc(mpz_ptr, limbs);
+        __mpz_struct * mf = _fmpz_new_mpz();
+        *f = PTR_TO_COEFF(mf);
+        _mpz_realloc(mf, limbs);
     }
     else
     {

--- a/fmpz/inlines.c
+++ b/fmpz/inlines.c
@@ -141,7 +141,7 @@ void __fmpz_neg(fmpz_t f1, const fmpz_t f2)
     else                        /* coeff is large */
     {
         /* No need to retain value in promotion, as if aliased, both already large */
-        __mpz_struct *mpz_ptr = _fmpz_promote(f1);
-        mpz_neg(mpz_ptr, COEFF_TO_PTR(*f2));
+        __mpz_struct * mf1 = _fmpz_promote(f1);
+        mpz_neg(mf1, COEFF_TO_PTR(*f2));
     }
 }

--- a/fmpz/invmod.c
+++ b/fmpz/invmod.c
@@ -65,7 +65,7 @@ fmpz_invmod(fmpz_t f, const fmpz_t g, const fmpz_t h)
         else                    /* h is large and g is small */
         {
             __mpz_struct temp;  /* put g into a temporary mpz_t */
-            __mpz_struct *mpz_ptr;
+            __mpz_struct * mf;
 
             if (c1 < WORD(0))
             {
@@ -81,8 +81,8 @@ fmpz_invmod(fmpz_t f, const fmpz_t g, const fmpz_t h)
                 temp._mp_size = 1;
             }
 
-            mpz_ptr = _fmpz_promote(f);
-            val = mpz_invert(mpz_ptr, &temp, COEFF_TO_PTR(c2));
+            mf = _fmpz_promote(f);
+            val = mpz_invert(mf, &temp, COEFF_TO_PTR(c2));
             _fmpz_demote_val(f);    /* inverse mod h may result in small value */
 
             return val;
@@ -110,8 +110,8 @@ fmpz_invmod(fmpz_t f, const fmpz_t g, const fmpz_t h)
         }
         else                    /* both are large */
         {
-            __mpz_struct *mpz_ptr = _fmpz_promote(f);
-            val = mpz_invert(mpz_ptr, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
+            __mpz_struct * mf = _fmpz_promote(f);
+            val = mpz_invert(mf, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
             _fmpz_demote_val(f);    /* reduction mod h may result in small value */
 
             return val;

--- a/fmpz/link/fmpz_gc.c
+++ b/fmpz/link/fmpz_gc.c
@@ -131,9 +131,9 @@ __mpz_struct * _fmpz_promote(fmpz_t f)
 {
     if (!COEFF_IS_MPZ(*f)) /* f is small so promote it first */
     {
-        __mpz_struct * mpz_ptr = _fmpz_new_mpz();
-        (*f) = PTR_TO_COEFF(mpz_ptr);
-        return mpz_ptr;
+        __mpz_struct * mf = _fmpz_new_mpz();
+        (*f) = PTR_TO_COEFF(mf);
+        return mf;
     }
     else /* f is large already, just return the pointer */
         return COEFF_TO_PTR(*f);
@@ -144,10 +144,10 @@ __mpz_struct * _fmpz_promote_val(fmpz_t f)
     fmpz c = (*f);
     if (!COEFF_IS_MPZ(c)) /* f is small so promote it */
     {
-        __mpz_struct * mpz_ptr = _fmpz_new_mpz();
-        (*f) = PTR_TO_COEFF(mpz_ptr);
-        flint_mpz_set_si(mpz_ptr, c);
-        return mpz_ptr;
+        __mpz_struct * mf = _fmpz_new_mpz();
+        (*f) = PTR_TO_COEFF(mf);
+        flint_mpz_set_si(mf, c);
+        return mf;
     }
     else /* f is large already, just return the pointer */
         return COEFF_TO_PTR(c);
@@ -155,12 +155,12 @@ __mpz_struct * _fmpz_promote_val(fmpz_t f)
 
 void _fmpz_demote_val(fmpz_t f)
 {
-    __mpz_struct * mpz_ptr = COEFF_TO_PTR(*f);
-    int size = mpz_ptr->_mp_size;
+    __mpz_struct * mf = COEFF_TO_PTR(*f);
+    int size = mf->_mp_size;
 
     if (size == 1 || size == -1)
     {
-        ulong uval = mpz_ptr->_mp_d[0];
+        ulong uval = mf->_mp_d[0];
 
         if (uval <= (ulong) COEFF_MAX)
         {

--- a/fmpz/link/fmpz_reentrant.c
+++ b/fmpz/link/fmpz_reentrant.c
@@ -16,9 +16,9 @@
 
 __mpz_struct * _fmpz_new_mpz(void)
 {
-    __mpz_struct * mpz_ptr = (__mpz_struct *) flint_malloc(sizeof(__mpz_struct));
-    mpz_init2(mpz_ptr, 2*FLINT_BITS);
-    return mpz_ptr;
+    __mpz_struct * mf = (__mpz_struct *) flint_malloc(sizeof(__mpz_struct));
+    mpz_init2(mf, 2*FLINT_BITS);
+    return mf;
 }
 
 void _fmpz_clear_mpz(fmpz f)
@@ -39,9 +39,9 @@ __mpz_struct * _fmpz_promote(fmpz_t f)
 {
     if (!COEFF_IS_MPZ(*f))  /* f is small so promote it first */
     {
-        __mpz_struct * mpz_ptr = _fmpz_new_mpz();
-        *f = PTR_TO_COEFF(mpz_ptr);
-        return mpz_ptr;
+        __mpz_struct * mf = _fmpz_new_mpz();
+        *f = PTR_TO_COEFF(mf);
+        return mf;
     }
     else  /* f is large already, just return the pointer */
         return COEFF_TO_PTR(*f);
@@ -52,10 +52,10 @@ __mpz_struct * _fmpz_promote_val(fmpz_t f)
     fmpz c = *f;
     if (!COEFF_IS_MPZ(c))  /* f is small so promote it */
     {
-        __mpz_struct * mpz_ptr = _fmpz_new_mpz();
-        *f = PTR_TO_COEFF(mpz_ptr);
-        flint_mpz_set_si(mpz_ptr, c);
-        return mpz_ptr;
+        __mpz_struct * mf = _fmpz_new_mpz();
+        *f = PTR_TO_COEFF(mf);
+        flint_mpz_set_si(mf, c);
+        return mf;
     }
     else  /* f is large already, just return the pointer */
         return COEFF_TO_PTR(*f);
@@ -63,12 +63,12 @@ __mpz_struct * _fmpz_promote_val(fmpz_t f)
 
 void _fmpz_demote_val(fmpz_t f)
 {
-    __mpz_struct * mpz_ptr = COEFF_TO_PTR(*f);
-    int size = mpz_ptr->_mp_size;
+    __mpz_struct * mf = COEFF_TO_PTR(*f);
+    int size = mf->_mp_size;
 
     if (!(((unsigned int) size + 1U) & ~2U))  /* size +-1 */
     {
-        ulong uval = mpz_ptr->_mp_d[0];
+        ulong uval = mf->_mp_d[0];
 
         if (uval <= (ulong) COEFF_MAX)
         {
@@ -87,9 +87,9 @@ void _fmpz_demote_val(fmpz_t f)
 
 void _fmpz_init_readonly_mpz(fmpz_t f, const mpz_t z)
 {
-   __mpz_struct * mpz_ptr = (__mpz_struct *) flint_malloc(sizeof(__mpz_struct));
-    *f = PTR_TO_COEFF(mpz_ptr);
-    *mpz_ptr = *z;
+   __mpz_struct * mf = (__mpz_struct *) flint_malloc(sizeof(__mpz_struct));
+    *f = PTR_TO_COEFF(mf);
+    *mf = *z;
 }
 
 void _fmpz_clear_readonly_mpz(mpz_t z)

--- a/fmpz/link/fmpz_single.c
+++ b/fmpz/link/fmpz_single.c
@@ -209,9 +209,9 @@ __mpz_struct * _fmpz_promote(fmpz_t f)
 {
     if (!COEFF_IS_MPZ(*f)) /* f is small so promote it first */
     {
-        __mpz_struct * mpz_ptr = _fmpz_new_mpz();
-        (*f) = PTR_TO_COEFF(mpz_ptr);
-        return mpz_ptr;
+        __mpz_struct * mf = _fmpz_new_mpz();
+        (*f) = PTR_TO_COEFF(mf);
+        return mf;
     }
     else /* f is large already, just return the pointer */
         return COEFF_TO_PTR(*f);
@@ -222,10 +222,10 @@ __mpz_struct * _fmpz_promote_val(fmpz_t f)
     fmpz c = (*f);
     if (!COEFF_IS_MPZ(c)) /* f is small so promote it */
     {
-        __mpz_struct * mpz_ptr = _fmpz_new_mpz();
-        (*f) = PTR_TO_COEFF(mpz_ptr);
-        flint_mpz_set_si(mpz_ptr, c);
-        return mpz_ptr;
+        __mpz_struct * mf = _fmpz_new_mpz();
+        (*f) = PTR_TO_COEFF(mf);
+        flint_mpz_set_si(mf, c);
+        return mf;
     }
     else /* f is large already, just return the pointer */
         return COEFF_TO_PTR(c);
@@ -233,12 +233,12 @@ __mpz_struct * _fmpz_promote_val(fmpz_t f)
 
 void _fmpz_demote_val(fmpz_t f)
 {
-    __mpz_struct * mpz_ptr = COEFF_TO_PTR(*f);
-    int size = mpz_ptr->_mp_size;
+    __mpz_struct * mf = COEFF_TO_PTR(*f);
+    int size = mf->_mp_size;
 
     if (size == 1 || size == -1)
     {
-        ulong uval = mpz_ptr->_mp_d[0];
+        ulong uval = mf->_mp_d[0];
 
         if (uval <= (ulong) COEFF_MAX)
         {

--- a/fmpz/mod.c
+++ b/fmpz/mod.c
@@ -60,8 +60,8 @@ fmpz_mod(fmpz_t f, const fmpz_t g, const fmpz_t h)
         }
         else                    /* both are large */
         {
-            __mpz_struct *mpz_ptr = _fmpz_promote(f);
-            mpz_mod(mpz_ptr, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
+            __mpz_struct * mf = _fmpz_promote(f);
+            mpz_mod(mf, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
             _fmpz_demote_val(f);    /* reduction mod h may result in small value */
         }
     }

--- a/fmpz/mul_2exp.c
+++ b/fmpz/mul_2exp.c
@@ -33,14 +33,14 @@ fmpz_mul_2exp(fmpz_t f, const fmpz_t g, ulong exp)
         }
         else                    /* result is large */
         {
-            __mpz_struct *mpz_ptr = _fmpz_promote(f);   /* g is saved */
-            flint_mpz_set_si(mpz_ptr, d);
-            mpz_mul_2exp(mpz_ptr, mpz_ptr, exp);
+            __mpz_struct * mf = _fmpz_promote(f);   /* g is saved */
+            flint_mpz_set_si(mf, d);
+            mpz_mul_2exp(mf, mf, exp);
         }
     }
     else                        /* g is large */
     {
-        __mpz_struct *mpz_ptr = _fmpz_promote(f);   /* g is already large */
-        mpz_mul_2exp(mpz_ptr, COEFF_TO_PTR(d), exp);
+        __mpz_struct * mf = _fmpz_promote(f);   /* g is already large */
+        mpz_mul_2exp(mf, COEFF_TO_PTR(d), exp);
     }
 }

--- a/fmpz/mul_si.c
+++ b/fmpz/mul_si.c
@@ -30,7 +30,7 @@ fmpz_mul_si(fmpz_t f, const fmpz_t g, slong x)
     }
     else                        /* c2 is large */
     {
-        __mpz_struct * mpz_ptr;
+        __mpz_struct * mf;
         if (!COEFF_IS_MPZ(*f))
         {
             if (x == 0)
@@ -39,8 +39,8 @@ fmpz_mul_si(fmpz_t f, const fmpz_t g, slong x)
                 return;
             }
             
-            mpz_ptr = _fmpz_new_mpz();
-            *f = PTR_TO_COEFF(mpz_ptr);
+            mf = _fmpz_new_mpz();
+            *f = PTR_TO_COEFF(mf);
         }
         else
         {
@@ -51,9 +51,9 @@ fmpz_mul_si(fmpz_t f, const fmpz_t g, slong x)
                 return;
             }
 
-            mpz_ptr = COEFF_TO_PTR(*f);
+            mf = COEFF_TO_PTR(*f);
         }
 
-        flint_mpz_mul_si(mpz_ptr, COEFF_TO_PTR(c2), x);
+        flint_mpz_mul_si(mf, COEFF_TO_PTR(c2), x);
     }
 }

--- a/fmpz/mul_si_tdiv_q_2exp.c
+++ b/fmpz/mul_si_tdiv_q_2exp.c
@@ -65,21 +65,21 @@ fmpz_mul_si_tdiv_q_2exp(fmpz_t f, const fmpz_t g, slong x, ulong exp)
        }
        else /* result takes two limbs */
        {
-           __mpz_struct *mpz_ptr = _fmpz_promote(f);
+           __mpz_struct * mf = _fmpz_promote(f);
 
            /* two limbs, least significant first, native endian, no
 nails, stored in prod */
-           mpz_import(mpz_ptr, 2, -1, sizeof(mp_limb_t), 0, 0, prod);
+           mpz_import(mf, 2, -1, sizeof(mp_limb_t), 0, 0, prod);
            if ((c2 ^ x) < WORD(0))
-               mpz_neg(mpz_ptr, mpz_ptr);
+               mpz_neg(mf, mf);
        }
    }
    else /* c2 is large */
    {
-       __mpz_struct *mpz_ptr = _fmpz_promote(f); /* ok without val as
+       __mpz_struct * mf = _fmpz_promote(f); /* ok without val as
             if aliased both are large */
-       flint_mpz_mul_si(mpz_ptr, COEFF_TO_PTR(c2), x);
-       mpz_tdiv_q_2exp(mpz_ptr, mpz_ptr, exp);
+       flint_mpz_mul_si(mf, COEFF_TO_PTR(c2), x);
+       mpz_tdiv_q_2exp(mf, mf, exp);
        _fmpz_demote_val(f);  /* value may be small */
    }
 }

--- a/fmpz/mul_tdiv_q_2exp.c
+++ b/fmpz/mul_tdiv_q_2exp.c
@@ -19,7 +19,7 @@ void
 fmpz_mul_tdiv_q_2exp(fmpz_t f, const fmpz_t g, const fmpz_t h, ulong exp)
 {
     fmpz c1, c2;
-    __mpz_struct *mpz_ptr;
+    __mpz_struct * mf;
 
     c1 = *g;
 
@@ -37,13 +37,13 @@ fmpz_mul_tdiv_q_2exp(fmpz_t f, const fmpz_t g, const fmpz_t h, ulong exp)
         return;
     }
 
-    mpz_ptr = _fmpz_promote(f); /* h is saved, g is already large */
+    mf = _fmpz_promote(f); /* h is saved, g is already large */
 
     if (!COEFF_IS_MPZ(c2))      /* g is large, h is small */
-        flint_mpz_mul_si(mpz_ptr, COEFF_TO_PTR(c1), c2);
+        flint_mpz_mul_si(mf, COEFF_TO_PTR(c1), c2);
     else                        /* c1 and c2 are large */
-        mpz_mul(mpz_ptr, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
+        mpz_mul(mf, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
 
-    mpz_tdiv_q_2exp(mpz_ptr, mpz_ptr, exp);
+    mpz_tdiv_q_2exp(mf, mf, exp);
     _fmpz_demote_val(f);  /* division may make value small */
 }

--- a/fmpz/mul_ui.c
+++ b/fmpz/mul_ui.c
@@ -34,7 +34,7 @@ fmpz_mul_ui(fmpz_t f, const fmpz_t g, ulong x)
     }
     else                        /* c2 is large */
     {
-        __mpz_struct * mpz_ptr;
+        __mpz_struct * mf;
         if (!COEFF_IS_MPZ(*f))
         {
             if (x == 0)
@@ -43,8 +43,8 @@ fmpz_mul_ui(fmpz_t f, const fmpz_t g, ulong x)
                 return;
             }
             
-            mpz_ptr = _fmpz_new_mpz();
-            *f = PTR_TO_COEFF(mpz_ptr);
+            mf = _fmpz_new_mpz();
+            *f = PTR_TO_COEFF(mf);
         }
         else
         {
@@ -55,9 +55,9 @@ fmpz_mul_ui(fmpz_t f, const fmpz_t g, ulong x)
                 return;
             }
 
-            mpz_ptr = COEFF_TO_PTR(*f);
+            mf = COEFF_TO_PTR(*f);
         }
 
-        flint_mpz_mul_ui(mpz_ptr, COEFF_TO_PTR(c2), x);
+        flint_mpz_mul_ui(mf, COEFF_TO_PTR(c2), x);
     }
 }

--- a/fmpz/pow_ui.c
+++ b/fmpz/pow_ui.c
@@ -41,10 +41,10 @@ fmpz_pow_ui(fmpz_t f, const fmpz_t g, ulong exp)
         }
         else
         {
-            __mpz_struct *mpz_ptr = _fmpz_promote_val(f);
+            __mpz_struct * mf = _fmpz_promote_val(f);
 
-            flint_mpz_set_ui(mpz_ptr, u1);
-            flint_mpz_pow_ui(mpz_ptr, mpz_ptr, exp);
+            flint_mpz_set_ui(mf, u1);
+            flint_mpz_pow_ui(mf, mf, exp);
             _fmpz_demote_val(f);    /* may actually fit into a small after all */
         }
 
@@ -53,8 +53,8 @@ fmpz_pow_ui(fmpz_t f, const fmpz_t g, ulong exp)
     }
     else
     {
-        __mpz_struct *mpz_ptr = _fmpz_promote_val(f);
-        flint_mpz_pow_ui(mpz_ptr, COEFF_TO_PTR(c1), exp);
+        __mpz_struct * mf = _fmpz_promote_val(f);
+        flint_mpz_pow_ui(mf, COEFF_TO_PTR(c1), exp);
         /* no need to demote as it can't get smaller */
     }
 }

--- a/fmpz/powm.c
+++ b/fmpz/powm.c
@@ -51,13 +51,13 @@ void fmpz_powm(fmpz_t f, const fmpz_t g, const fmpz_t e, const fmpz_t m)
         {
             ulong g1 = fmpz_fdiv_ui(g, *m);
             mpz_t g2, m2;
-            __mpz_struct *mpz_ptr;
+            __mpz_struct * mf;
 
             flint_mpz_init_set_ui(g2, g1);
             flint_mpz_init_set_ui(m2, *m);
-            mpz_ptr = _fmpz_promote(f);
+            mf = _fmpz_promote(f);
 
-            mpz_powm(mpz_ptr, g2, COEFF_TO_PTR(*e), m2);
+            mpz_powm(mf, g2, COEFF_TO_PTR(*e), m2);
 
             mpz_clear(g2);
             mpz_clear(m2);
@@ -68,21 +68,21 @@ void fmpz_powm(fmpz_t f, const fmpz_t g, const fmpz_t e, const fmpz_t m)
             if (!COEFF_IS_MPZ(*g))  /* g is small */
             {
                 mpz_t g2;
-                __mpz_struct *mpz_ptr;
+                __mpz_struct * mf;
 
                 flint_mpz_init_set_si(g2, *g);
-                mpz_ptr = _fmpz_promote(f);
+                mf = _fmpz_promote(f);
 
-                mpz_powm(mpz_ptr, g2, COEFF_TO_PTR(*e), COEFF_TO_PTR(*m));
+                mpz_powm(mf, g2, COEFF_TO_PTR(*e), COEFF_TO_PTR(*m));
 
                 mpz_clear(g2);
                 _fmpz_demote_val(f);
             }
             else  /* g is large */
             {
-                __mpz_struct *mpz_ptr = _fmpz_promote(f);
+                __mpz_struct * mf = _fmpz_promote(f);
 
-                mpz_powm(mpz_ptr, 
+                mpz_powm(mf, 
                     COEFF_TO_PTR(*g), COEFF_TO_PTR(*e), COEFF_TO_PTR(*m));
                 _fmpz_demote_val(f);
             }

--- a/fmpz/preinvn_init.c
+++ b/fmpz/preinvn_init.c
@@ -36,16 +36,16 @@ void fmpz_preinvn_init(fmpz_preinvn_t inv, const fmpz_t f)
       inv->n = 1;
    } else /* c is big */
    {
-      __mpz_struct * mpz_ptr = COEFF_TO_PTR(c);
-      slong size = FLINT_ABS(mpz_ptr->_mp_size);
+      __mpz_struct * mc = COEFF_TO_PTR(c);
+      slong size = FLINT_ABS(mc->_mp_size);
       inv->dinv = flint_malloc(size*sizeof(mp_limb_t));
-      count_leading_zeros(norm, mpz_ptr->_mp_d[size - 1]);
+      count_leading_zeros(norm, mc->_mp_d[size - 1]);
       if (norm) 
       {
          t = flint_malloc(size*sizeof(mp_limb_t));
-         mpn_lshift(t, mpz_ptr->_mp_d, size, norm);
+         mpn_lshift(t, mc->_mp_d, size, norm);
       } else
-         t = mpz_ptr->_mp_d;
+         t = mc->_mp_d;
 
       flint_mpn_preinvn(inv->dinv, t, size);
       

--- a/fmpz/primorial.c
+++ b/fmpz/primorial.c
@@ -133,7 +133,7 @@ fmpz_primorial(fmpz_t res, ulong n)
 {
     mp_size_t len, pi;
     ulong bits;
-    __mpz_struct * mpz_ptr;
+    __mpz_struct * mres;
     const mp_limb_t * primes;
 
     if (n <= LARGEST_ULONG_PRIMORIAL)
@@ -150,10 +150,10 @@ fmpz_primorial(fmpz_t res, ulong n)
     primes = n_primes_arr_readonly(pi);
     bits = FLINT_BIT_COUNT(primes[pi - 1]);
     
-    mpz_ptr = _fmpz_promote(res);
-    mpz_realloc2(mpz_ptr, pi*bits);
+    mres = _fmpz_promote(res);
+    mpz_realloc2(mres, pi*bits);
     
-    len = mpn_prod_limbs(mpz_ptr->_mp_d, primes, pi, bits);
-    mpz_ptr->_mp_size = len;
+    len = mpn_prod_limbs(mres->_mp_d, primes, pi, bits);
+    mres->_mp_size = len;
 }
 

--- a/fmpz/randbits.c
+++ b/fmpz/randbits.c
@@ -29,13 +29,13 @@ fmpz_randbits(fmpz_t f, flint_rand_t state, flint_bitcnt_t bits)
     }
     else
     {
-        __mpz_struct *mpz_ptr = _fmpz_promote(f);
+        __mpz_struct *mf = _fmpz_promote(f);
         _flint_rand_init_gmp(state);
-        mpz_urandomb(mpz_ptr, state->gmp_state, bits);
-        mpz_setbit(mpz_ptr, bits - 1);
+        mpz_urandomb(mf, state->gmp_state, bits);
+        mpz_setbit(mf, bits - 1);
 
         if (n_randint(state, 2))
-            mpz_neg(mpz_ptr, mpz_ptr);
+            mpz_neg(mf, mf);
 
         _fmpz_demote_val(f);
     }

--- a/fmpz/randm.c
+++ b/fmpz/randm.c
@@ -30,12 +30,12 @@ fmpz_randm(fmpz_t f, flint_rand_t state, const fmpz_t m)
     }
     else
     {
-        __mpz_struct *mpz_ptr = _fmpz_promote(f);
+        __mpz_struct * mf = _fmpz_promote(f);
 
         _flint_rand_init_gmp(state);
-        mpz_urandomm(mpz_ptr, state->gmp_state, COEFF_TO_PTR(*m));
+        mpz_urandomm(mf, state->gmp_state, COEFF_TO_PTR(*m));
         if (sgn < 0)
-            mpz_neg(mpz_ptr, mpz_ptr);
+            mpz_neg(mf, mf);
         _fmpz_demote_val(f);
     }
 }

--- a/fmpz/randprime.c
+++ b/fmpz/randprime.c
@@ -27,13 +27,13 @@ void fmpz_randprime(fmpz_t f, flint_rand_t state, flint_bitcnt_t bits, int prove
          * but it has different semantics from n_randbits,
          * and in particular may return integers with fewer bits.
          */
-        __mpz_struct *mpz_ptr = _fmpz_promote(f);
+        __mpz_struct * mf = _fmpz_promote(f);
         _flint_rand_init_gmp(state);
 
         do
         {
-            mpz_urandomb(mpz_ptr, state->gmp_state, bits - 1);
-            mpz_setbit(mpz_ptr, bits - 1);
+            mpz_urandomb(mf, state->gmp_state, bits - 1);
+            mpz_setbit(mf, bits - 1);
 
             fmpz_nextprime(f, f, proved);
         } while (fmpz_bits(f) != bits);

--- a/fmpz/randtest.c
+++ b/fmpz/randtest.c
@@ -56,10 +56,10 @@ fmpz_randtest_unsigned(fmpz_t f, flint_rand_t state, flint_bitcnt_t bits)
     }
     else
     {
-        __mpz_struct *mpz_ptr = _fmpz_promote(f);
+        __mpz_struct * mf = _fmpz_promote(f);
 
         _flint_rand_init_gmp(state);
-        mpz_rrandomb(mpz_ptr, state->gmp_state, bits);
+        mpz_rrandomb(mf, state->gmp_state, bits);
         _fmpz_demote_val(f);
     }
 }

--- a/fmpz/set.c
+++ b/fmpz/set.c
@@ -27,7 +27,7 @@ fmpz_set(fmpz_t f, const fmpz_t g)
     }
     else                        /* g is large */
     {
-        __mpz_struct *mpz_ptr = _fmpz_promote(f);
-        mpz_set(mpz_ptr, COEFF_TO_PTR(*g));
+        __mpz_struct * mf = _fmpz_promote(f);
+        mpz_set(mf, COEFF_TO_PTR(*g));
     }
 }

--- a/fmpz/set_mpz.c
+++ b/fmpz/set_mpz.c
@@ -37,14 +37,14 @@ fmpz_set_mpz(fmpz_t f, const mpz_t x)
         }
         else                    /* x is large but one limb */
         {
-            __mpz_struct *mpz_ptr = _fmpz_promote(f);
-            flint_mpz_set_ui(mpz_ptr, uval);
-            mpz_neg(mpz_ptr, mpz_ptr);
+            __mpz_struct * mf = _fmpz_promote(f);
+            flint_mpz_set_ui(mf, uval);
+            mpz_neg(mf, mf);
         }
     }
     else                        /* x is more than one limb */
     {
-        __mpz_struct *mpz_ptr = _fmpz_promote(f);
-        mpz_set(mpz_ptr, x);
+        __mpz_struct * mf = _fmpz_promote(f);
+        mpz_set(mf, x);
     }
 }

--- a/fmpz/sqrt.c
+++ b/fmpz/sqrt.c
@@ -28,8 +28,8 @@ void fmpz_sqrt(fmpz_t f, const fmpz_t g)
         fmpz_set_ui(f, n_sqrt(*g));
     else
     {
-        __mpz_struct * mpz_ptr = _fmpz_promote(f);
-        mpz_sqrt(mpz_ptr, COEFF_TO_PTR(*g));
+        __mpz_struct * mf = _fmpz_promote(f);
+        mpz_sqrt(mf, COEFF_TO_PTR(*g));
         _fmpz_demote_val(f);
     }
 }

--- a/fmpz/sub_ui.c
+++ b/fmpz/sub_ui.c
@@ -37,10 +37,10 @@ fmpz_sub_ui(fmpz_t f, const fmpz_t g, ulong x)
     }
     else
     {
-        __mpz_struct *mpz_ptr, *mpz_ptr2;
-        mpz_ptr2 = _fmpz_promote(f);    /* g is already large */
-        mpz_ptr = COEFF_TO_PTR(c);
-        flint_mpz_sub_ui(mpz_ptr2, mpz_ptr, x);
+        __mpz_struct * mc, * mf;
+        mf = _fmpz_promote(f);    /* g is already large */
+        mc = COEFF_TO_PTR(c);
+        flint_mpz_sub_ui(mf, mc, x);
         _fmpz_demote_val(f);    /* cancellation may have occurred */
     }
 }

--- a/fmpz/submul.c
+++ b/fmpz/submul.c
@@ -37,8 +37,8 @@ fmpz_submul(fmpz_t f, const fmpz_t g, const fmpz_t h)
         }
         else                    /* both g and h are large */
         {
-            __mpz_struct *mpz_ptr = _fmpz_promote_val(f);
-            mpz_submul(mpz_ptr, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
+            __mpz_struct * mf = _fmpz_promote_val(f);
+            mpz_submul(mf, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
             _fmpz_demote_val(f);    /* cancellation may have occurred */
         }
     }

--- a/fmpz/submul_ui.c
+++ b/fmpz/submul_ui.c
@@ -34,7 +34,7 @@ fmpz_submul_ui(fmpz_t f, const fmpz_t g, ulong x)
         mp_limb_t prod[2];
         ulong uc1 = FLINT_ABS(c1);
 
-        __mpz_struct * mpz_ptr;
+        __mpz_struct * mf;
         mpz_t temp;
 
         umul_ppmm(prod[1], prod[0], uc1, x);    /* compute product */
@@ -67,17 +67,17 @@ fmpz_submul_ui(fmpz_t f, const fmpz_t g, ulong x)
            in all remaining cases res is either big already, 
            or will be big in the end
          */
-        mpz_ptr = _fmpz_promote_val(f);
+        mf = _fmpz_promote_val(f);
         /* set up a temporary, cheap mpz_t to contain prod */
         temp->_mp_d = prod;
         temp->_mp_size = (c1 < WORD(0) ? -2 : 2);
-        mpz_sub(mpz_ptr, mpz_ptr, temp);
+        mpz_sub(mf, mf, temp);
         _fmpz_demote_val(f);    /* cancellation may have occurred */
     }
     else                        /* c1 is large */
     {
-        __mpz_struct *mpz_ptr = _fmpz_promote_val(f);
-        flint_mpz_submul_ui(mpz_ptr, COEFF_TO_PTR(c1), x);
+        __mpz_struct * mf = _fmpz_promote_val(f);
+        flint_mpz_submul_ui(mf, COEFF_TO_PTR(c1), x);
         _fmpz_demote_val(f);    /* cancellation may have occurred */
     }
 }

--- a/fmpz/tdiv_q.c
+++ b/fmpz/tdiv_q.c
@@ -36,23 +36,23 @@ fmpz_tdiv_q(fmpz_t f, const fmpz_t g, const fmpz_t h)
     }
     else                        /* g is large */
     {
-        __mpz_struct *mpz_ptr = _fmpz_promote(f);
+        __mpz_struct * mf = _fmpz_promote(f);
 
         if (!COEFF_IS_MPZ(c2))  /* h is small */
         {
             if (c2 > 0)         /* h > 0 */
             {
-                flint_mpz_tdiv_q_ui(mpz_ptr, COEFF_TO_PTR(c1), c2);
+                flint_mpz_tdiv_q_ui(mf, COEFF_TO_PTR(c1), c2);
             }
             else
             {
-                flint_mpz_tdiv_q_ui(mpz_ptr, COEFF_TO_PTR(c1), -c2);
-                mpz_neg(mpz_ptr, mpz_ptr);
+                flint_mpz_tdiv_q_ui(mf, COEFF_TO_PTR(c1), -c2);
+                mpz_neg(mf, mf);
             }
         }
         else                    /* both are large */
         {
-            mpz_tdiv_q(mpz_ptr, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
+            mpz_tdiv_q(mf, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
         }
         _fmpz_demote_val(f);    /* division by h may result in small value */
     }

--- a/fmpz/tdiv_q_2exp.c
+++ b/fmpz/tdiv_q_2exp.c
@@ -30,8 +30,8 @@ void fmpz_tdiv_q_2exp(fmpz_t f, const fmpz_t g, ulong exp)
     }
     else  /*g is large */
     {
-        __mpz_struct * mpz_ptr = _fmpz_promote(f);  /* g is already large */
-        mpz_tdiv_q_2exp(mpz_ptr, COEFF_TO_PTR(d), exp);
+        __mpz_struct * mf = _fmpz_promote(f);  /* g is already large */
+        mpz_tdiv_q_2exp(mf, COEFF_TO_PTR(d), exp);
         _fmpz_demote_val(f);  /* division may make value small */
     }
 }

--- a/fmpz/tdiv_q_si.c
+++ b/fmpz/tdiv_q_si.c
@@ -34,16 +34,16 @@ fmpz_tdiv_q_si(fmpz_t f, const fmpz_t g, slong h)
     }
     else                        /* g is large */
     {
-        __mpz_struct *mpz_ptr = _fmpz_promote(f);
+        __mpz_struct * mf = _fmpz_promote(f);
 
         if (c2 > 0)
         {
-            flint_mpz_tdiv_q_ui(mpz_ptr, COEFF_TO_PTR(c1), c2);
+            flint_mpz_tdiv_q_ui(mf, COEFF_TO_PTR(c1), c2);
         }
         else
         {
-            flint_mpz_tdiv_q_ui(mpz_ptr, COEFF_TO_PTR(c1), -(ulong) c2);
-            mpz_neg(mpz_ptr, mpz_ptr);
+            flint_mpz_tdiv_q_ui(mf, COEFF_TO_PTR(c1), -(ulong) c2);
+            mpz_neg(mf, mf);
         }
         _fmpz_demote_val(f);    /* division by h may result in small value */
     }

--- a/fmpz/tdiv_q_ui.c
+++ b/fmpz/tdiv_q_ui.c
@@ -44,9 +44,9 @@ fmpz_tdiv_q_ui(fmpz_t f, const fmpz_t g, ulong h)
     }
     else                        /* g is large */
     {
-        __mpz_struct *mpz_ptr = _fmpz_promote(f);
+        __mpz_struct * mf = _fmpz_promote(f);
 
-        flint_mpz_tdiv_q_ui(mpz_ptr, COEFF_TO_PTR(c1), c2);
+        flint_mpz_tdiv_q_ui(mf, COEFF_TO_PTR(c1), c2);
         _fmpz_demote_val(f);    /* division by h may result in small value */
     }
 }

--- a/fmpz/tdiv_qr.c
+++ b/fmpz/tdiv_qr.c
@@ -46,27 +46,27 @@ fmpz_tdiv_qr(fmpz_t f, fmpz_t s, const fmpz_t g, const fmpz_t h)
     }
     else                        /* g is large */
     {
-        __mpz_struct *mpz_ptr, *mpz_ptr2;
+        __mpz_struct * mf, * ms;
 
         _fmpz_promote(f); /* must not hang on to ptr whilst promoting s */
-        mpz_ptr2 = _fmpz_promote(s);
-		mpz_ptr  = COEFF_TO_PTR(*f);
+        ms = _fmpz_promote(s);
+        mf  = COEFF_TO_PTR(*f);
 
-		if (!COEFF_IS_MPZ(c2))  /* h is small */
+        if (!COEFF_IS_MPZ(c2))  /* h is small */
         {
             if (c2 > 0)         /* h > 0 */
             {
-                flint_mpz_tdiv_qr_ui(mpz_ptr, mpz_ptr2, COEFF_TO_PTR(c1), c2);
+                flint_mpz_tdiv_qr_ui(mf, ms, COEFF_TO_PTR(c1), c2);
             }
             else
             {
-                flint_mpz_tdiv_qr_ui(mpz_ptr, mpz_ptr2, COEFF_TO_PTR(c1), -c2);
-                mpz_neg(mpz_ptr, mpz_ptr);
+                flint_mpz_tdiv_qr_ui(mf, ms, COEFF_TO_PTR(c1), -c2);
+                mpz_neg(mf, mf);
             }
         }
         else                    /* both are large */
         {
-            mpz_tdiv_qr(mpz_ptr, mpz_ptr2, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
+            mpz_tdiv_qr(mf, ms, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
         }
         _fmpz_demote_val(f);    /* division by h may result in small value */
         _fmpz_demote_val(s);    /* division by h may result in small value */

--- a/fmpz/tdiv_r_2exp.c
+++ b/fmpz/tdiv_r_2exp.c
@@ -32,8 +32,8 @@ void fmpz_tdiv_r_2exp(fmpz_t f, const fmpz_t g, ulong exp)
     }
     else  /*g is large */
     {
-        __mpz_struct * mpz_ptr = _fmpz_promote(f);  /* g is already large */
-        mpz_tdiv_r_2exp(mpz_ptr, COEFF_TO_PTR(d), exp);
+        __mpz_struct * mf = _fmpz_promote(f);  /* g is already large */
+        mpz_tdiv_r_2exp(mf, COEFF_TO_PTR(d), exp);
         _fmpz_demote_val(f);  /* division may make value small */
     }
 }

--- a/fmpz_factor/ecm.c
+++ b/fmpz_factor/ecm.c
@@ -51,7 +51,7 @@ fmpz_factor_ecm(fmpz_t f, mp_limb_t curves, mp_limb_t B1, mp_limb_t B2,
     mp_limb_t P, num, maxP, mmin, mmax, mdiff, prod, maxj, n_size, cy;
     int i, j, ret;
     ecm_t ecm_inf;
-    __mpz_struct *fac, *mpz_ptr;
+    __mpz_struct *fac, *mptr;
     mp_ptr n, mpsig;
 
     TMP_INIT;
@@ -81,12 +81,12 @@ fmpz_factor_ecm(fmpz_t f, mp_limb_t curves, mp_limb_t B1, mp_limb_t B2,
     }
     else
     {
-        mpz_ptr = COEFF_TO_PTR(* n_in);
-        count_leading_zeros(ecm_inf->normbits, mpz_ptr->_mp_d[n_size - 1]);
+        mptr = COEFF_TO_PTR(* n_in);
+        count_leading_zeros(ecm_inf->normbits, mptr->_mp_d[n_size - 1]);
         if (ecm_inf->normbits)
-           mpn_lshift(n, mpz_ptr->_mp_d, n_size, ecm_inf->normbits);
+           mpn_lshift(n, mptr->_mp_d, n_size, ecm_inf->normbits);
         else
-           flint_mpn_copyi(n, mpz_ptr->_mp_d, n_size);
+           flint_mpn_copyi(n, mptr->_mp_d, n_size);
     }
 
     flint_mpn_preinvn(ecm_inf->ninv, n, n_size);
@@ -193,16 +193,16 @@ fmpz_factor_ecm(fmpz_t f, mp_limb_t curves, mp_limb_t B1, mp_limb_t B2,
         }
         else
         {
-            mpz_ptr = COEFF_TO_PTR(*sig);
+            mptr = COEFF_TO_PTR(*sig);
 
             if (ecm_inf->normbits)
             {
-                cy = mpn_lshift(mpsig, mpz_ptr->_mp_d, mpz_ptr->_mp_size, ecm_inf->normbits);
+                cy = mpn_lshift(mpsig, mptr->_mp_d, mptr->_mp_size, ecm_inf->normbits);
                 if (cy)
-                    mpsig[mpz_ptr->_mp_size] = cy;
+                    mpsig[mptr->_mp_size] = cy;
             } else
             {
-                flint_mpn_copyi(mpsig, mpz_ptr->_mp_d, mpz_ptr->_mp_size);
+                flint_mpn_copyi(mpsig, mptr->_mp_d, mptr->_mp_size);
             }
         }
 

--- a/fmpz_factor/pollard_brent.c
+++ b/fmpz_factor/pollard_brent.c
@@ -27,7 +27,7 @@ fmpz_factor_pollard_brent(fmpz_t p_factor, flint_rand_t state, fmpz_t n_in,
     fmpz_t fa, fy, maxa, maxy;
     mp_ptr a, y, n, ninv, temp;
     mp_limb_t n_size, normbits, ans, val, size, cy;
-    __mpz_struct *fac, *mpz_ptr;
+    __mpz_struct *fac, *mptr;
     int ret;
 
     TMP_INIT;
@@ -97,9 +97,9 @@ fmpz_factor_pollard_brent(fmpz_t p_factor, flint_rand_t state, fmpz_t n_in,
             }
             else
             {
-                mpz_ptr = COEFF_TO_PTR(*fy);
-                temp = mpz_ptr->_mp_d;
-                size = mpz_ptr->_mp_size;
+                mptr = COEFF_TO_PTR(*fy);
+                temp = mptr->_mp_d;
+                size = mptr->_mp_size;
 		cy = mpn_lshift(y, temp, size, normbits);
                 if (cy)
                     y[size] = cy;
@@ -114,9 +114,9 @@ fmpz_factor_pollard_brent(fmpz_t p_factor, flint_rand_t state, fmpz_t n_in,
             }
             else
             {
-                mpz_ptr = COEFF_TO_PTR(*fa);
-                temp = mpz_ptr->_mp_d;
-                size = mpz_ptr->_mp_size;
+                mptr = COEFF_TO_PTR(*fa);
+                temp = mptr->_mp_d;
+                size = mptr->_mp_size;
 		cy = mpn_lshift(a, temp, size, normbits);
                 if (cy)
                     a[size] = cy;

--- a/fmpz_factor/pollard_brent_single.c
+++ b/fmpz_factor/pollard_brent_single.c
@@ -171,7 +171,7 @@ fmpz_factor_pollard_brent_single(fmpz_t p_factor, fmpz_t n_in, fmpz_t yi,
     mp_ptr a, y, n, ninv, temp;
     mp_limb_t n_size, normbits, ans, size, cy;
     mp_limb_t al, yl, val, valinv;
-    __mpz_struct *fac, *mpz_ptr;
+    __mpz_struct *fac, *mptr;
     int ret;
 
     TMP_INIT;
@@ -202,7 +202,7 @@ fmpz_factor_pollard_brent_single(fmpz_t p_factor, fmpz_t n_in, fmpz_t yi,
         return ret;
     }
 
-    mpz_ptr = COEFF_TO_PTR(*yi);
+    mptr = COEFF_TO_PTR(*yi);
     temp = COEFF_TO_PTR(*n_in)->_mp_d;
     count_leading_zeros(normbits, temp[n_size - 1]);
 
@@ -241,9 +241,9 @@ fmpz_factor_pollard_brent_single(fmpz_t p_factor, fmpz_t n_in, fmpz_t yi,
         }
         else
         {
-            mpz_ptr = COEFF_TO_PTR(*yi);
-            temp = mpz_ptr->_mp_d;
-            size = mpz_ptr->_mp_size;    
+            mptr = COEFF_TO_PTR(*yi);
+            temp = mptr->_mp_d;
+            size = mptr->_mp_size;    
             cy = mpn_lshift(y, temp, size, normbits);
 
             if (cy)
@@ -259,9 +259,9 @@ fmpz_factor_pollard_brent_single(fmpz_t p_factor, fmpz_t n_in, fmpz_t yi,
         }
         else
         {
-            mpz_ptr = COEFF_TO_PTR(*ai);
-            temp = mpz_ptr->_mp_d;
-            size = mpz_ptr->_mp_size;
+            mptr = COEFF_TO_PTR(*ai);
+            temp = mptr->_mp_d;
+            size = mptr->_mp_size;
             cy = mpn_lshift(a, temp, size, normbits);
             if (cy)
                 a[size] = cy;

--- a/fmpz_poly/gcd_heuristic.c
+++ b/fmpz_poly/gcd_heuristic.c
@@ -30,13 +30,13 @@ mp_size_t flint_mpn_tdiv_q_fmpz_inplace(mp_ptr arrayg, mp_size_t limbsg, fmpz_t 
 	else 
    {
       mp_size_t tlimbs;
-      __mpz_struct * mpz_ptr = COEFF_TO_PTR(*gc);
+      __mpz_struct * mgc = COEFF_TO_PTR(*gc);
       
       mp_ptr temp = flint_malloc(limbsg*sizeof(mp_limb_t));
       flint_mpn_copyi(temp, arrayg, limbsg);
       
-      mpn_tdiv_q(arrayg, temp, limbsg, mpz_ptr->_mp_d, mpz_ptr->_mp_size);
-      tlimbs = limbsg - mpz_ptr->_mp_size + 1;
+      mpn_tdiv_q(arrayg, temp, limbsg, mgc->_mp_d, mgc->_mp_size);
+      tlimbs = limbsg - mgc->_mp_size + 1;
       tlimbs -= (arrayg[tlimbs - 1] == 0);
       
       flint_free(temp);

--- a/fmpz_vec/get_fft.c
+++ b/fmpz_vec/get_fft.c
@@ -45,14 +45,14 @@ slong _fmpz_vec_get_fft(mp_limb_t ** coeffs_f,
 				coeff = (mp_limb_t *) coeffs_m;
 		} else /* coeff is an mpz_t */
 		{
-			__mpz_struct * mpz_ptr = COEFF_TO_PTR(c);
-		   size_j = mpz_ptr->_mp_size;
+			__mpz_struct * mc = COEFF_TO_PTR(c);
+		   size_j = mc->_mp_size;
 			if (size_j < 0) 
 			{
 				signed_c = 1;
 				size_j = -size_j;
 			}
-			coeff = mpz_ptr->_mp_d;
+			coeff = mc->_mp_d;
 		}
 
 		if (signed_c) sign = -1;

--- a/fmpz_vec/height_index.c
+++ b/fmpz_vec/height_index.c
@@ -45,9 +45,9 @@ _fmpz_vec_height_index(const fmpz * vec, slong len)
             }
             else
             {
-                __mpz_struct * mpz_ptr = COEFF_TO_PTR(c);
-                max_d = mpz_ptr->_mp_d;
-                max_mpz_limbs = mpz_ptr->_mp_size;
+                __mpz_struct * mc = COEFF_TO_PTR(c);
+                max_d = mc->_mp_d;
+                max_mpz_limbs = mc->_mp_size;
                 max_mpz_limbs = FLINT_ABS(max_mpz_limbs);
                 max_i = i;
                 i++;
@@ -62,14 +62,14 @@ _fmpz_vec_height_index(const fmpz * vec, slong len)
             /* we have found at least one mpz, so only look for those */
             if (COEFF_IS_MPZ(c))
             {
-                __mpz_struct * mpz_ptr = COEFF_TO_PTR(c);
-                mpz_limbs = mpz_ptr->_mp_size;
+                __mpz_struct * mc = COEFF_TO_PTR(c);
+                mpz_limbs = mc->_mp_size;
                 mpz_limbs = FLINT_ABS(mpz_limbs);
                 if (mpz_limbs > max_mpz_limbs ||
                     ((mpz_limbs == max_mpz_limbs) &&
-                    (mpn_cmp(mpz_ptr->_mp_d, max_d, max_mpz_limbs) > 0)))
+                    (mpn_cmp(mc->_mp_d, max_d, max_mpz_limbs) > 0)))
                 {
-                    max_d = mpz_ptr->_mp_d;
+                    max_d = mc->_mp_d;
                     max_mpz_limbs = mpz_limbs;
                     max_i = i;
                 }

--- a/fmpz_vec/set_fft.c
+++ b/fmpz_vec/set_fft.c
@@ -22,14 +22,14 @@ void _fmpz_vec_set_fft(fmpz * coeffs_m, slong length,
 {
     slong i, size;
     mp_limb_t * data;
-    __mpz_struct * mpz_ptr;
+    __mpz_struct * mcoeffs_m;
 
     if (sign)
     {
         for (i = 0; i < length; i++)
         {
-            mpz_ptr = _fmpz_promote(coeffs_m);
-            data = FLINT_MPZ_REALLOC(mpz_ptr, limbs);
+            mcoeffs_m = _fmpz_promote(coeffs_m);
+            data = FLINT_MPZ_REALLOC(mcoeffs_m, limbs);
 
 			if ((coeffs_f[i][limbs - 1] >> (FLINT_BITS - 1)) || coeffs_f[i][limbs])
             {
@@ -37,7 +37,7 @@ void _fmpz_vec_set_fft(fmpz * coeffs_m, slong length,
                 mpn_add_1(data, data, limbs, WORD(1));
                 size = limbs;
                 while ((size) && (data[size - 1] == 0)) size--; /* normalise */
-                mpz_ptr->_mp_size = -size;
+                mcoeffs_m->_mp_size = -size;
                 if (size >= WORD(-1)) _fmpz_demote_val(coeffs_m); /* coefficient may be small*/
             }
             else
@@ -45,7 +45,7 @@ void _fmpz_vec_set_fft(fmpz * coeffs_m, slong length,
                 flint_mpn_copyi(data, coeffs_f[i], limbs);
                 size = limbs;
                 while ((size) && (data[size - 1] == WORD(0))) size--; /* normalise */
-                mpz_ptr->_mp_size = size;
+                mcoeffs_m->_mp_size = size;
                 if (size <= 1) _fmpz_demote_val(coeffs_m); /* coefficient may be small */
             }
 
@@ -56,12 +56,12 @@ void _fmpz_vec_set_fft(fmpz * coeffs_m, slong length,
     {
         for (i = 0; i < length; i++)
         {
-            mpz_ptr = _fmpz_promote(coeffs_m);
-            data = FLINT_MPZ_REALLOC(mpz_ptr, limbs);
+            mcoeffs_m = _fmpz_promote(coeffs_m);
+            data = FLINT_MPZ_REALLOC(mcoeffs_m, limbs);
             flint_mpn_copyi(data, coeffs_f[i], limbs); 
             size = limbs;
             while ((size) && (data[size - 1] == WORD(0))) size--; /* normalise */
-            mpz_ptr->_mp_size = size;
+            mcoeffs_m->_mp_size = size;
             if (size <= 1) _fmpz_demote_val(coeffs_m); /* coefficient may be small */
 
             coeffs_m++;

--- a/interfaces/NTL-interface.cpp
+++ b/interfaces/NTL-interface.cpp
@@ -37,9 +37,9 @@ static void fmpz_set_limbs(fmpz_t f, mp_srcptr x, mp_size_t limbs)
         fmpz_set_ui(f, x[0]);
     else
     {
-        __mpz_struct *mpz_ptr = _fmpz_promote(f);
+        __mpz_struct *mf = _fmpz_promote(f);
 
-        mpz_import(mpz_ptr, limbs, -1, sizeof(mp_limb_t), 0, 0, x);
+        mpz_import(mf, limbs, -1, sizeof(mp_limb_t), 0, 0, x);
     }
 }
 


### PR DESCRIPTION
where suffix is depending on the variable it represents. For example if
the variable is f, the __mpz_struct * will be called mf.

Let me know if this is good. This is how I usually like to name them.

Edit: Solves #1047 