### PR TITLE
move fmpq_poly_struct.den

### DIFF
--- a/fmpq_poly.h
+++ b/fmpq_poly.h
@@ -36,9 +36,9 @@
 typedef struct
 {
     fmpz * coeffs;
-    fmpz_t den;
     slong alloc;
     slong length;
+    fmpz_t den;
 } fmpq_poly_struct;
 
 typedef fmpq_poly_struct fmpq_poly_t[1];


### PR DESCRIPTION
One of the most annoying parts of fmpq_poly_t is that - while it ostensibly has an fmpz_poly in it - the fmpq_poly_struct has no fmpz_poly_struct in it. With this pr we can at least do the evil reinterpret cast from fmpq_poly_struct* to fmpz_poly_struct*.