### PR TITLE
Change `configure` file

### DIFF
--- a/configure
+++ b/configure
@@ -4,6 +4,7 @@
 # (C) 2011, William Hart
 # (C) 2012, William Hart, Jean-Pierre Flori, Thomas DuBuisson
 # (C) 2012, Jan Engelhardt
+# (C) 2022, Albin Ahlbäck
 
 PREFIX="/usr/local"
 GMP_DIR="/usr/local"
@@ -63,227 +64,266 @@ FLINT_SOLIB=0
 # 2.8.4 => 16.1.4
 # 2.9.0 => 17.0.0
 
+FLINT_VERSION="2.9.0"
 FLINT_MAJOR=17
 FLINT_MINOR=0
 FLINT_PATCH=0
 
+flint_version()
+{
+    echo "\
+FLINT: Fast Library for Number Theory
+Version $1
+
+Licensed under GNU Lesser General Public License 2.1.\
+    "
+}
+
 usage()
 {
-   echo "Usage: ./configure <options> <args>"
-   echo "   where <options> may be"
-   echo "     -h display usage information"
-   echo "   where <args> may be:"
-   echo "     --prefix=<path>      Specify path to installation location (default: /usr/local)"
-   echo "     --with-mpir=<path>   Specify location of MPIR (default: /usr/local)"
-   echo "     --with-gmp=<path>    Specify location of GMP (default: /usr/local)"
-   echo "     --with-mpfr=<path>   Specify location of MPFR (default: /usr/local)"
-   echo "     --with-blas[=<path>] Use BLAS and specify its location (default: /usr)"
-   echo "     --without-blas       Do not use BLAS (default)"
-   echo "     --with-ntl[=<path>]  Build NTL interface and specify its location (default: /usr/local)"
-   echo "     --without-ntl        Do not build NTL interface (default)"
-   echo "     --extensions=<path>  Specify location of extension modules"
-   echo "     --build=arch-os      Specify architecture/OS combination rather than use values from uname -m/-s"
-   echo "     --enable-shared      Build a shared library (default)"
-   echo "     --disable-shared     Do not build a shared library"
-   echo "     --enable-static      Build a static library (default)"
-   echo "     --disable-static     Do not build a static library"
-   echo "     --single             Faster [non-reentrant if tls or pthread not used] version of library (default)"
-   echo "     --reentrant          Build fully reentrant [with or without tls, with pthread] version of library"
-   echo "     --with-gc=<path>     GC safe build with path to gc"
-   echo "     --enable-pthread     Use pthread (default)"
-   echo "     --disable-pthread    Do not use pthread"
-   echo "     --enable-tls         Use thread-local storage (default)"
-   echo "     --disable-tls        Do not use thread-local storage"
-   echo "     --enable-assert      Enable use of asserts (use for debug builds only)"
-   echo "     --disable-assert     Disable use of asserts (default)"
-   echo "     --enable-cxx         Enable C++ wrapper tests"
-   echo "     --disable-cxx        Disable C++ wrapper tests (default)"
-   echo "     --disable-dependency-tracking Disable gcc automated dependency tracking"
-   echo "     CC=<name>            Use the C compiler with the given name (default: gcc)"
-   echo "     CXX=<name>           Use the C++ compiler with the given name (default: g++)"
-   echo "     AR=<name>            Use the AR library builder with the given name (default: ar)"
-   echo "     LDCONFIG=<name>      Use the given ldconfig tool"
-   echo "     CFLAGS=<flags>       Pass the given flags to the compiler"
-   echo "     CXXFLAGS=<flags>     Pass the given flags to the C++ compiler"
-   echo "     ABI=[32|64]          Tell the compiler to use given ABI (default: empty)"
+    echo "\
+Usage: ./configure [option] [var=value]
+
+Help:
+  -h, --help            Display usage information
+  -V, --version         Display FLINT version
+
+Installation, package and extension paths:
+  --prefix=<path>       Specify path to installation location (default: /usr/local)
+  --with-mpir=<path>    Specify location of MPIR (default: /usr/local)
+  --with-gmp=<path>     Specify location of GMP (default: /usr/local)
+  --with-mpfr=<path>    Specify location of MPFR (default: /usr/local)
+  --with-blas[=<path>]  Use BLAS and specify its location (default: /usr)
+  --with-ntl[=<path>]   Build NTL interface and specify its location (default: /usr/local)
+  --with-gc=<path>      GC safe build with path to gc
+  --extensions=<path>   Specify location of extension modules
+
+Package usages:
+  --without-blas        Do not use BLAS (default)
+  --without-ntl         Do not build NTL interface (default)
+
+Library feature usages:
+  --enable-debugging  Enable use of debugging flag -g
+  --disable-debugging Disable use of debugging flag -g (default)
+  --enable-shared     Build a shared library (default)
+  --disable-shared    Do not build a shared library
+  --enable-static     Build a static library (default)
+  --disable-static    Do not build a static library
+  --single            Faster [non-reentrant if tls or pthread not used] version of library (default)
+  --reentrant         Build fully reentrant [with or without tls, with pthread] version of library
+  --enable-pthread    Use pthread (default)
+  --disable-pthread   Do not use pthread
+  --enable-tls        Use thread-local storage (default)
+  --disable-tls       Do not use thread-local storage
+  --enable-assert     Enable use of asserts (use for debug builds only)
+  --disable-assert    Disable use of asserts (default)
+  --enable-cxx        Enable C++ wrapper tests
+  --disable-cxx       Disable C++ wrapper tests (default)
+  --disable-dependency-tracking
+                      Disable gcc automated dependency tracking
+
+Architecture and OS tuning:
+  --build=<cpu-vendor-os>   Specify building machine (default: guessed)
+
+Environment variables:
+  CC=<name>           Use the C compiler with the given name (default: gcc)
+  CXX=<name>          Use the C++ compiler with the given name (default: g++)
+  AR=<name>           Use the AR library builder with the given name (default: ar)
+  LDCONFIG=<name>     Use the given ldconfig tool
+  CFLAGS=<flags>      Pass the given flags to the compiler
+  CXXFLAGS=<flags>    Pass the given flags to the C++ compiler
+  ABI=[32|64]         Tell the compiler to use given ABI (default: empty)\
+"
 }
 
 absolute_path(){
-   dirlist="$1"
-   retval=""
-   for dir in $dirlist; do
-      case $dir in
-        /*) dir=$dir;;
-        *) dir=$PWD/$dir;;
-      esac
-      retval=$retval" "$dir
-   done
-   echo $retval
+    dirlist="$1"
+    retval=""
+    for dir in $dirlist; do
+        case $dir in
+            /*) dir=$dir;;
+            *) dir=$PWD/$dir;;
+        esac
+        retval=$retval" "$dir
+    done
+    echo $retval
 }
+
+while [ "$1" != "" ]; do
+    PARAM=`echo $1 | sed 's/=.*//'`
+    VALUE=`echo $1 | sed 's/[^=]*//; s/=//'`
+    case "$PARAM" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -V|--version)
+            flint_version $FLINT_VERSION
+            exit 0
+            ;;
+        --prefix)
+            PREFIX=$(absolute_path "$VALUE")
+            ;;
+        --with-mpir|--with-gmp)
+            GMP_DIR=$(absolute_path "$VALUE")
+            ;;
+        --with-mpfr)
+            MPFR_DIR=$(absolute_path "$VALUE")
+            ;;
+        --with-blas)
+            WANT_BLAS=1
+            if [ ! -z "$VALUE" ]; then
+                BLAS_DIR=$(absolute_path "$VALUE")
+            fi
+            ;;
+        --with-ntl)
+            WANT_NTL=1
+            if [ ! -z "$VALUE" ]; then
+                NTL_DIR=$(absolute_path "$VALUE")
+            fi
+            ;;
+        --with-gc)
+            WANT_GC=1
+            if [ ! -z "$VALUE" ]; then
+                GC_DIR="$VALUE"
+            fi
+            ;;
+        --extensions)
+            EXTENSIONS=$(absolute_path "$VALUE")
+            ;;
+        --without-blas)
+            WANT_BLAS=0
+            ;;
+        --without-ntl)
+            WANT_NTL=0
+            ;;
+        --enable-debugging)
+            DEBUGGING_FLAG="-g"
+            ;;
+        --disable-debugging)
+            DEBUGGING_FLAG=""
+            ;;
+        --enable-shared)
+            SHARED=1
+            ;;
+        --disable-shared)
+            SHARED=0
+            ;;
+        --enable-static)
+            STATIC=1
+            ;;
+        --disable-static)
+            STATIC=0
+            ;;
+        --single)
+            REENTRANT=0
+            ;;
+        --reentrant)
+            REENTRANT=1
+            ;;
+        --enable-pthread)
+            PTHREAD=1
+            ;;
+        --disable-pthread)
+            PTHREAD=0
+            ;;
+        --enable-tls)
+            TLS=1
+            WANT_TLS=1;;
+        --disable-tls)
+            TLS=0
+            WANT_TLS=2;;
+        --enable-assert)
+            ASSERT=1
+            ;;
+        --disable-assert)
+            ASSERT=0
+            ;;
+        --enable-cxx)
+            WANT_CXX=1
+            ;;
+        --disable-cxx)
+            WANT_CXX=0
+            ;;
+        --disable-dependency-tracking)
+            WANT_DEPS=0
+            ;; 
+        --build)
+            BUILD="$VALUE"
+            ;;
+        CC)
+            CC="$VALUE"
+            ;;
+        CXX)
+            CXX="$VALUE"
+            ;;
+        AR)
+            AR="$VALUE"
+            ;;
+        LDCONFIG)
+            LDCONFIG="$VALUE"
+            ;;
+        CFLAGS)
+            CFLAGS="$VALUE"
+            ;;
+        CXXFLAGS)
+            CXXFLAGS="$VALUE"
+            ;;
+        ABI)
+            ABI="$VALUE"
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+    shift
+done
+
 
 #begin config.log
 echo "/* This file is autogenerated by ./configure -- do not edit! */" > config.log
 echo "./configure $@" >> config.log
 
-while [ "$1" != "" ]; do
-   PARAM=`echo $1 | sed 's/=.*//'`
-   VALUE=`echo $1 | sed 's/[^=]*//; s/=//'`
-   case "$PARAM" in
-      -h|--help)
-         usage
-         exit 0
-         ;;
-      --with-mpir|--with-gmp)
-         GMP_DIR=$(absolute_path "$VALUE")
-         ;;
-      --with-mpfr)
-         MPFR_DIR=$(absolute_path "$VALUE")
-         ;;
-      --with-ntl)
-         WANT_NTL=1
-         if [ ! -z "$VALUE" ]; then
-            NTL_DIR=$(absolute_path "$VALUE")
-         fi
-         ;;
-      --without-ntl)
-         WANT_NTL=0
-         ;;
-      --with-blas)
-         WANT_BLAS=1
-         if [ ! -z "$VALUE" ]; then
-            BLAS_DIR=$(absolute_path "$VALUE")
-         fi
-         ;;
-      --without-blas)
-         WANT_BLAS=0
-         ;;
-      --extensions)
-         EXTENSIONS=$(absolute_path "$VALUE")
-         ;;
-      --build)
-         BUILD="$VALUE"
-         ;;
-      --prefix)
-         PREFIX=$(absolute_path "$VALUE")
-         ;;
-      --enable-shared)
-         SHARED=1
-         ;;
-      --disable-shared)
-         SHARED=0
-         ;;
-      --enable-static)
-         STATIC=1
-         ;;
-      --disable-static)
-         STATIC=0
-         ;;
-      --single)
-         REENTRANT=0
-         ;;
-      --reentrant)
-         REENTRANT=1
-         ;;
-      --with-gc)
-         WANT_GC=1
-         if [ ! -z "$VALUE" ]; then
-            GC_DIR="$VALUE"
-         fi
-         ;;
-      --enable-pthread)
-         PTHREAD=1
-         ;;
-      --disable-pthread)
-         PTHREAD=0
-         ;;
-      --enable-tls)
-         TLS=1
-         WANT_TLS=1;;
-      --disable-tls)
-         TLS=0
-         WANT_TLS=2;;
-      --enable-assert)
-         ASSERT=1
-         ;;
-      --disable-assert)
-         ASSERT=0
-         ;;
-      --enable-cxx)
-         WANT_CXX=1
-         ;;
-      --disable-cxx)
-         WANT_CXX=0
-         ;;
-      --disable-dependency-tracking)
-         WANT_DEPS=0
-         ;; 
-      AR)
-         AR="$VALUE"
-         ;;
-      CC)
-         CC="$VALUE"
-         ;;
-      LDCONFIG)
-         LDCONFIG="$VALUE"
-         ;;
-      CXX)
-         CXX="$VALUE"
-         ;;
-      CFLAGS)
-         CFLAGS="$VALUE"
-         ;;
-      CXXFLAGS)
-         CXXFLAGS="$VALUE"
-         ;;
-      ABI)
-         ABI="$VALUE"
-         ;;
-      *)
-         usage
-         exit 1
-         ;;
-   esac
-   shift
-done
 
 #find dependencies
 
 LIBS="m"
 
 if [ -d "${GMP_DIR}/lib" ]; then
-   GMP_LIB_DIR="${GMP_DIR}/lib"
-   GMP_INC_DIR="${GMP_DIR}/include"
+    GMP_LIB_DIR="${GMP_DIR}/lib"
+    GMP_INC_DIR="${GMP_DIR}/include"
 elif [ -d "${GMP_DIR}/lib64" ]; then
-   GMP_LIB_DIR="${GMP_DIR}/lib64"
-   GMP_INC_DIR="${GMP_DIR}/include"
+    GMP_LIB_DIR="${GMP_DIR}/lib64"
+    GMP_INC_DIR="${GMP_DIR}/include"
 elif [ -d "${GMP_DIR}/.libs" ]; then
-   GMP_LIB_DIR="${GMP_DIR}/.libs"
-   GMP_INC_DIR="${GMP_DIR}"
+    GMP_LIB_DIR="${GMP_DIR}/.libs"
+    GMP_INC_DIR="${GMP_DIR}"
 else
-   echo "Invalid GMP directory"
-   echo "Invalid GMP directory: ${GMP_DIR}" >> config.log
-   exit 1
+    echo "Invalid GMP directory"
+    echo "Invalid GMP directory: ${GMP_DIR}" >> config.log
+    exit 1
 fi
 LIB_DIRS="${LIB_DIRS} ${GMP_LIB_DIR}"
 INC_DIRS="${INC_DIRS} ${GMP_INC_DIR}"
 LIBS="${LIBS} gmp"
 
 if [ -d "${MPFR_DIR}/lib" ]; then
-   MPFR_LIB_DIR="${MPFR_DIR}/lib"
-   MPFR_INC_DIR="${MPFR_DIR}/include"
+    MPFR_LIB_DIR="${MPFR_DIR}/lib"
+    MPFR_INC_DIR="${MPFR_DIR}/include"
 elif [ -d "${MPFR_DIR}/lib64" ]; then
-   MPFR_LIB_DIR="${MPFR_DIR}/lib64"
-   MPFR_INC_DIR="${MPFR_DIR}/include"
+    MPFR_LIB_DIR="${MPFR_DIR}/lib64"
+    MPFR_INC_DIR="${MPFR_DIR}/include"
 elif [ -d "${MPFR_DIR}/.libs" ]; then
-   MPFR_LIB_DIR="${MPFR_DIR}/.libs"
-   MPFR_INC_DIR="${MPFR_DIR}"
+    MPFR_LIB_DIR="${MPFR_DIR}/.libs"
+    MPFR_INC_DIR="${MPFR_DIR}"
 elif [ -d "${MPFR_DIR}/src/.libs" ]; then
-   MPFR_LIB_DIR="${MPFR_DIR}/src/.libs"
-   MPFR_INC_DIR="${MPFR_DIR}/src"
+    MPFR_LIB_DIR="${MPFR_DIR}/src/.libs"
+    MPFR_INC_DIR="${MPFR_DIR}/src"
 else
-   echo "Invalid MPFR directory"
-   echo "Invalid MPFR directory: ${MPFR_DIR}" >> config.log
-   exit 1
+    echo "Invalid MPFR directory"
+    echo "Invalid MPFR directory: ${MPFR_DIR}" >> config.log
+    exit 1
 fi
 LIB_DIRS="${LIB_DIRS} ${MPFR_LIB_DIR}"
 INC_DIRS="${INC_DIRS} ${MPFR_INC_DIR}"
@@ -292,277 +332,749 @@ LIBS="${LIBS} mpfr"
 #configure extra libraries
 
 if [ "$WANT_NTL" = "1" ]; then
-   if [ -d "${NTL_DIR}/lib" ]; then
-      NTL_LIB_DIR="${NTL_DIR}/lib"
-      NTL_INC_DIR="${NTL_DIR}/include"
-   elif [ -d "${NTL_DIR}/lib64" ]; then
-      NTL_LIB_DIR="${NTL_DIR}/lib64"
-      NTL_INC_DIR="${NTL_DIR}/include"
-   else
-      echo "Invalid NTL directory"
-      echo "Invalid NTL directory: ${NTL_DIR}" >> config.log
-      exit 1
-   fi
-   EXTRA_INC_DIRS="${EXTRA_INC_DIRS} ${NTL_INC_DIR}"
-   EXTRA_LIB_DIRS="${EXTRA_LIB_DIRS} ${NTL_LIB_DIR}"
-   EXTRA_LIBS="${EXTRA_LIBS} ntl"
+    if [ -d "${NTL_DIR}/lib" ]; then
+        NTL_LIB_DIR="${NTL_DIR}/lib"
+        NTL_INC_DIR="${NTL_DIR}/include"
+    elif [ -d "${NTL_DIR}/lib64" ]; then
+        NTL_LIB_DIR="${NTL_DIR}/lib64"
+        NTL_INC_DIR="${NTL_DIR}/include"
+    else
+        echo "Invalid NTL directory"
+        echo "Invalid NTL directory: ${NTL_DIR}" >> config.log
+        exit 1
+    fi
+    EXTRA_INC_DIRS="${EXTRA_INC_DIRS} ${NTL_INC_DIR}"
+    EXTRA_LIB_DIRS="${EXTRA_LIB_DIRS} ${NTL_LIB_DIR}"
+    EXTRA_LIBS="${EXTRA_LIBS} ntl"
 fi
 
 if [ "$WANT_BLAS" = "1" ]; then
-   if [ -d "${BLAS_DIR}/lib/x86_64-linux-gnu/openblas-pthread" ]; then
-      BLAS_LIB_DIR="${BLAS_DIR}/lib/x86_64-linux-gnu"
-      BLAS_INC_DIR="${BLAS_DIR}/include/x86_64-linux-gnu"
-   elif [ -d "${BLAS_DIR}/lib" ]; then
-      BLAS_LIB_DIR="${BLAS_DIR}/lib"
-      BLAS_INC_DIR="${BLAS_DIR}/include"
-   elif [ -d "${BLAS_DIR}" ]; then
-      BLAS_LIB_DIR="${BLAS_DIR}"
-      BLAS_INC_DIR="${BLAS_DIR}"
-   else
-      echo "Invalid BLAS directory"
-      echo "Invalid BLAS directory: ${BLAS_DIR}" >> config.log
-      exit 1
-   fi
-   EXTRA_INC_DIRS="${EXTRA_INC_DIRS} ${BLAS_INC_DIR}"
-   EXTRA_LIB_DIRS="${EXTRA_LIB_DIRS} ${BLAS_LIB_DIR}"
-   EXTRA_LIBS="${EXTRA_LIBS} openblas"
+    if [ -d "${BLAS_DIR}/lib/x86_64-linux-gnu/openblas-pthread" ]; then
+        BLAS_LIB_DIR="${BLAS_DIR}/lib/x86_64-linux-gnu"
+        BLAS_INC_DIR="${BLAS_DIR}/include/x86_64-linux-gnu"
+    elif [ -d "${BLAS_DIR}/lib" ]; then
+        BLAS_LIB_DIR="${BLAS_DIR}/lib"
+        BLAS_INC_DIR="${BLAS_DIR}/include"
+    elif [ -d "${BLAS_DIR}" ]; then
+        BLAS_LIB_DIR="${BLAS_DIR}"
+        BLAS_INC_DIR="${BLAS_DIR}"
+    else
+        echo "Invalid BLAS directory"
+        echo "Invalid BLAS directory: ${BLAS_DIR}" >> config.log
+        exit 1
+    fi
+    EXTRA_INC_DIRS="${EXTRA_INC_DIRS} ${BLAS_INC_DIR}"
+    EXTRA_LIB_DIRS="${EXTRA_LIB_DIRS} ${BLAS_LIB_DIR}"
+    EXTRA_LIBS="${EXTRA_LIBS} openblas"
 fi
 CONFIG_BLAS="#define FLINT_USES_BLAS ${WANT_BLAS}"
 
 if [ "$WANT_GC" = "1" ]; then
-   if [ -d "${GC_DIR}" ]; then
-      GC_LIB_DIR="${GC_DIR}/lib"
-      GC_INC_DIR="${GC_DIR}/include"
-   else
-      echo "Invalid GC directory"
-      echo "Invalid GC directory: ${GC_DIR}" >> config.log
-      exit 1
-   fi
-   EXTRA_INC_DIRS="${EXTRA_INC_DIRS} ${GC_INC_DIR}"
-   EXTRA_LIB_DIRS="${EXTRA_LIB_DIRS} ${GC_LIB_DIR}"
-   EXTRA_LIBS="${EXTRA_LIBS} gc"
+    if [ -d "${GC_DIR}" ]; then
+        GC_LIB_DIR="${GC_DIR}/lib"
+        GC_INC_DIR="${GC_DIR}/include"
+    else
+        echo "Invalid GC directory"
+        echo "Invalid GC directory: ${GC_DIR}" >> config.log
+        exit 1
+    fi
+    EXTRA_INC_DIRS="${EXTRA_INC_DIRS} ${GC_INC_DIR}"
+    EXTRA_LIB_DIRS="${EXTRA_LIB_DIRS} ${GC_LIB_DIR}"
+    EXTRA_LIBS="${EXTRA_LIBS} gc"
 fi
 CONFIG_GC="#define FLINT_USES_GC ${WANT_GC}"
 
 # defaults for CC, CXX and AR
 
 if [ -z "$CC" ]; then
-   CC=gcc
+    CC=gcc
 fi
 
 if [ -z "$CXX" ]; then
-   CXX=g++
+    CXX=g++
 fi
 
 if [ -z "$AR" ]; then
-   AR=ar
+    AR=ar
 fi
 
 #handle gc and reentrant flags
 
 if [ "$WANT_GC" = "1" ]; then
-      TLS=0
-      if [ "$WANT_TLS" = "1" ]; then
-          echo "****WARNING**** GC does not support TLS....disabling TLS"
-	  echo "GC does not support TLS....disabling TLS" >> config.log
-      fi
-      cp fmpz/link/fmpz_gc.c fmpz/fmpz.c
-      cp fmpz-conversions-gc.in fmpz-conversions.h
+    TLS=0
+    if [ "$WANT_TLS" = "1" ]; then
+        echo "****WARNING**** GC does not support TLS....disabling TLS"
+        echo "GC does not support TLS....disabling TLS" >> config.log
+    fi
+    cp fmpz/link/fmpz_gc.c fmpz/fmpz.c
+    cp fmpz-conversions-gc.in fmpz-conversions.h
 else
-   if [ "$REENTRANT" = "1" ]; then
-      cp fmpz/link/fmpz_reentrant.c fmpz/fmpz.c
-      cp fmpz-conversions-reentrant.in fmpz-conversions.h
-   else
-      cp fmpz/link/fmpz_single.c fmpz/fmpz.c
-      cp fmpz-conversions-single.in fmpz-conversions.h
-   fi
+    if [ "$REENTRANT" = "1" ]; then
+        cp fmpz/link/fmpz_reentrant.c fmpz/fmpz.c
+        cp fmpz-conversions-reentrant.in fmpz-conversions.h
+    else
+        cp fmpz/link/fmpz_single.c fmpz/fmpz.c
+        cp fmpz-conversions-single.in fmpz-conversions.h
+    fi
 fi
-# Architecture handler
 
-KERNEL=`uname`
+################################################################################
+################################################################################
+# build handler
+################################################################################
+################################################################################
 
+BUILD_KERNEL=`uname`
+
+echo "Checking build..."
+echo "Checking build..." >> config.log
 if [ -z "$BUILD" ]; then
-   ARCH=`uname -m`
+    # Build was not specified, so try to guess it
 
-   if [ "$(uname | cut -d_ -f1)" = "MSYS" ]; then
-      if [ "$ARCH" = "x86_64" ]; then
-         OS="MINGW64"
-      else
-         OS="MINGW32"
-      fi
-   elif [ "$(uname | cut -d_ -f1)" = "MINGW32" ]; then
-      if [ "$ABI" = "64" ]; then
-         OS="MINGW64"
-      else
-         OS="MINGW32"
-      fi 
-   elif [ "$(uname | cut -d_ -f1)" = "MINGW64" ]; then
-      if [ "$ABI" = "32" ]; then
-         OS="MINGW32"
-      else
-         OS="MINGW64"
-      fi
-   elif [ "$(uname | cut -d_ -f1)" = "CYGWIN" ]; then
-      if [ "$ARCH" = "x86_64" ]; then
-         if [ "$ABI" = "32" ]; then
-            OS="CYGWIN32"
-         else
-            OS="CYGWIN64"
-            ABI="64"
-         fi
-      else
-         OS="CYGWIN32"
-      fi
-   else
-      OS=`uname -s`
-   fi
+    # Set MARCH_FLAG to -march=native -mno-avx512f, where the second option is
+    # to disable AVX512 on those systems that supports it.
+    MARCH_FLAG="-march=native -mno-avx512f"
+
+    ############################################################################
+    # architecture and machine
+    ############################################################################
+    BUILD_ARCH=`uname -m`
+
+    case "$BUILD_ARCH" in
+        x86_64 | amd64)
+            BUILD_MACHINE="x86_64"
+            ;;
+        x86 | i*86 | pc)
+            BUILD_MACHINE="x86"
+            ;;
+        arm8* | arm9* | aarch64* | arm64*)
+            BUILD_MACHINE="aarch64"
+            ;;
+        arm*)
+            BUILD_MACHINE="arm"
+            ;;
+        ia64)
+            BUILD_MACHINE="ia64"
+            ;;
+        sparc | sun4*)
+            BUILD_MACHINE="sparc"
+            ;;
+        sparc64)
+            BUILD_MACHINE="sparc64"
+            ;;
+        ppc64 | powerpc64)
+            BUILD_MACHINE="ppc64"
+            ;;
+        ppc | powerpc | [P|p]ower*)
+            BUILD_MACHINE="ppc"
+            ;;
+        mips64)
+            BUILD_MACHINE="mips64"
+            ;;
+        *)
+            BUILD_MACHINE="unknown"
+            ;;
+    esac
+
+    ############################################################################
+    # OS / operating system
+    ############################################################################
+    if [ "$(uname | cut -d_ -f1)" = "MSYS" ]; then
+        if [ "$BUILD_ARCH" = "x86_64" ]; then
+            BUILD_OS="MINGW64"
+        else
+            BUILD_OS="MINGW32"
+        fi
+    elif [ "$(uname | cut -d_ -f1)" = "MINGW32" ]; then
+        if [ "$ABI" = "64" ]; then
+            BUILD_OS="MINGW64"
+        else
+            BUILD_OS="MINGW32"
+        fi 
+    elif [ "$(uname | cut -d_ -f1)" = "MINGW64" ]; then
+        if [ "$ABI" = "32" ]; then
+            BUILD_OS="MINGW32"
+        else
+            BUILD_OS="MINGW64"
+        fi
+    elif [ "$(uname | cut -d_ -f1)" = "CYGWIN" ]; then
+        if [ "$BUILD_ARCH" = "x86_64" ]; then
+            if [ "$ABI" = "32" ]; then
+                BUILD_OS="CYGWIN32"
+            else
+                BUILD_OS="CYGWIN64"
+                ABI="64"
+            fi
+        else
+            BUILD_OS="CYGWIN32"
+        fi
+    else
+        BUILD_OS=`uname -s`
+    fi
 else
-   ARCH=`echo "$BUILD" | cut -d- -f1`
-   OS=`echo "$BUILD" | cut -d- -f2`
+    # Build was given
+
+    ############################################################################
+    # architecture and machine
+    ############################################################################
+    case $BUILD in
+        ########################################################################
+        # x86
+        ########################################################################
+        i?86*-* | pentium*-* | atom-* | prescott-* | nocona-* | bonnell-* |\
+        silvermont-* | goldmont*-* | tremont-* | core2-* | corei*-* |\
+        nehalem*-* | westmere*-* | sandybridge*-* | ivybridge*-* | haswell*-* |\
+        broadwell*-* | skylake*-* | kabylake*-* | coffeelake*-* | knl*-* |\
+        knm*-* | cascadelake*-* | cannonlake*-* | cooperlake*-* | icelake*-* |\
+        tigerlake*-* | sapphirerapids*-* | rocketlake*-* | alderlake*-* |\
+        k[5-8]*-* | geode*-* | athlon*-* | opteron*-* | k10-* | amdfam10-* |\
+        barcelona-* | bt*-* | bobcat-* | jaguar*-* | bd*-* | bulldozer*-* |\
+        piledriver*-* | steamroller*-* | excavator*-* | zn*-* | zen*-* |\
+        x86_64*-*)
+            case $BUILD in
+                ### intel
+                i386*-*)
+                    MARCH_FLAG="-march=i386"
+                    BUILD_MACHINE="x86"
+                    ;;
+                i486*-*)
+                    MARCH_FLAG="-march=i486"
+                    BUILD_MACHINE="x86"
+                    ;;
+                i586-* | pentium-*)
+                    MARCH_FLAG="-march=pentium"
+                    BUILD_MACHINE="x86"
+                    ;;
+                pentiummmx-*)
+                    MARCH_FLAG="-march=pentium-mmx -march=pentium"
+                    BUILD_MACHINE="x86"
+                    ;;
+                i686-* | pentiumpro-*)
+                    MARCH_FLAG="-march=pentiumpro -march=pentium"
+                    BUILD_MACHINE="x86"
+                    ;;
+                pentium2-*)
+                    MARCH_FLAG="-march=pentium2 -march=pentiumpro"
+                    BUILD_MACHINE="x86"
+                    ;;
+                pentium3-* | pentiumm-*)
+                    MARCH_FLAG="-march=pentium3 -march=pentium2"
+                    BUILD_MACHINE="x86"
+                    ;;
+                i786-* | pentium4-*)
+                    MARCH_FLAG="-march=pentium4"
+                    BUILD_MACHINE="x86"
+                    ;;
+                atom-*)
+                    MARCH_FLAG="-march=atom -march=pentium"
+                    BUILD_MACHINE="x86"
+                    ;;
+                prescott-*)
+                    MARCH_FLAG="-march=prescott"
+                    BUILD_MACHINE="x86"
+                    ;;
+                nocona-*)
+                    MARCH_FLAG="-march=nocona"
+                    BUILD_MACHINE="x86"
+                    ;;
+                bonnell-*)
+                    MARCH_FLAG="-march=bonnell"
+                    BUILD_MACHINE="x86"
+                    ;;
+                silvermont-*)
+                    MARCH_FLAG="-march=silvermont"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                goldmont-*)
+                    MARCH_FLAG="-march=goldmont -march=silvermont"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                goldmont-plus-*)
+                    MARCH_FLAG="-march=goldmont-plus -march=goldmont"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                tremont-*)
+                    MARCH_FLAG="-march=tremont -march=goldmont"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                core2-*)
+                    MARCH_FLAG="-march=core2"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                corei-* | coreinhm-* | nehalem-*)
+                    MARCH_FLAG="-march=nehalem -march=core2"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                coreiwsm-* | westmere-*)
+                    MARCH_FLAG="-march=westmere -march=nehalem"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                coreisbr-* | coreisbrnoavx-* | sandybridge-* |\
+                sandybridgenoavx-*)
+                    MARCH_FLAG="-march=sandybridge -march=westmere"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                coreiibr-* | coreiibrnoavx-* | ivybridge-* | ivybridgenoavx-*)
+                    MARCH_FLAG="-march=ivybridge -march=sandybridge"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                coreihwl-* | coreihwlnoavx-* | haswell-* | haswellnoavx-*)
+                    MARCH_FLAG="-march=haswell -march=ivybridge"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                coreibwl-* | coreibwlnoavx-* | broadwell-* | broadwellnoavx-*)
+                    MARCH_FLAG="-march=broadwell -march=haswell"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                skylake-avx512-*)
+                    MARCH_FLAG="-march=skylake -march=broadwell -mno-avx512f"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                skylake-* | skylakenoavx-* | kabylake-* | kabylakenoavx-* |\
+                coffeelake-* | coffeelakenoavx-*)
+                    MARCH_FLAG="-march=skylake -march=broadwell"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                knl*-*)
+                    MARCH_FLAG="-march=knl -mno-avx512f"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                knm*-*)
+                    MARCH_FLAG="-march=knm -mno-avx512f"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                cascadelake-*)
+                    MARCH_FLAG="-march=cascadelake -march=skylake -mno-avx512f"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                cannonlake-*)
+                    MARCH_FLAG="-march=cannonlake -march=skylake -mno-avx512f"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                cooperlake-*)
+                    MARCH_FLAG="-march=cooperlake -march=cascadelake -mno-avx512f"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                icelake-server-*)
+                    MARCH_FLAG="-march=icelake-server -march=cascadelake -mno-avx512f"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                icelake-* | icelake-client-*)
+                    MARCH_FLAG="-march=icelake-client -march=cannonlake -mno-avx512f"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                tigerlake-*)
+                    MARCH_FLAG="-march=tigerlake -march=cannonlake -mno-avx512f"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                sapphirerapids-*)
+                    MARCH_FLAG="-march=sapphirerapids -march=cannonlake -mno-avx512f"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                rocketlake-*)
+                    MARCH_FLAG="-march=rocketlake -march=skylake"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                alderlake-*)
+                    MARCH_FLAG="-march=alderlake -march=rocketlake"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+
+                ### amd
+                k6-2-* | k62-*)
+                    MARCH_FLAG="-march=k6-2 -march=k6"
+                    BUILD_MACHINE="x86"
+                    ;;
+                k6-3-* | k63-*)
+                    MARCH_FLAG="-march=k6-3 -march=k6"
+                    BUILD_MACHINE="x86"
+                    ;;
+                k6-*)
+                    MARCH_FLAG="-march=k6"
+                    BUILD_MACHINE="x86"
+                    ;;
+                geode-*)
+                    MARCH_FLAG="-march=geode -march=k6-3"
+                    BUILD_MACHINE="x86"
+                    ;;
+                athlon-4-* | athlon-xp-* | athlon-mp-*)
+                    MARCH_FLAG="-march=athlon-4 -march=athlon-xp -march=athlon-mp"
+                    BUILD_MACHINE="x86"
+                    ;;
+                k8*-* | athlon64*-* | opteron*-* | athlon-fx-*)
+                    MARCH_FLAG="-march=k8 -march=athlon64 -march=opteron -march=athlon-fx"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                athlon-* | athlon-tbird-*)
+                    MARCH_FLAG="-march=athlon -march=athlon-tbird"
+                    BUILD_MACHINE="x86"
+                    ;;
+                k10-* | amdfam10-* | barcelona-*)
+                    MARCH_FLAG="-march=amdfam10 -march=barcelona"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                btver1-* | bt1*-* | bobcat-*)
+                    MARCH_FLAG="-march=btver1 -march=amdfam10"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                btver2-* | bt2*-* | jaguar*-*)
+                    MARCH_FLAG="-march=btver2 -march=btver1"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                bdver1-* | bd1*-* | bulldozer*-*)
+                    MARCH_FLAG="-march=bdver1 -march=amdfam10"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                bdver2-* | bd2*-* | piledriver*-*)
+                    MARCH_FLAG="-march=bdver2 -march=bdver1"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                bdver3-* | bd3*-* | steamroller*-*)
+                    MARCH_FLAG="-march=bdver3 -march=bdver2"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                bdver4-* | bd4*-* | excavator*-*)
+                    MARCH_FLAG="-march=bdver4 -march=bdver3"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                znver1-* | zn1*-* | zen-* | zennoavx-*)
+                    MARCH_FLAG="-march=znver1 -march=bdver4"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                znver2-* | zn2*-* | zen2*-*)
+                    MARCH_FLAG="-march=znver2 -march=znver1"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                znver3-* | zn3*-* | zen3*-*)
+                    MARCH_FLAG="-march=znver3 -march=znver2"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+
+                ### others
+                x86_64*-*)
+                    MARCH_FLAG="-march=x86-64"
+                    BUILD_MACHINE="x86_64"
+                    ;;
+                *) # fallback for x86
+                    MARCH_FLAG="-march=i486"
+                    BUILD_MACHINE="x86"
+                    ;;
+            esac
+            ;;
+
+        ########################################################################
+        # arm
+        ########################################################################
+        arm*-* | aarch64*-*)
+            case $1 in
+                armv4-* | armsa1-* | arm7t*-* | arm9t*-* | armv4t*-*)
+                    MARCH_FLAG="-march=armv4"
+                    BUILD_MACHINE="arm"
+                    ;;
+                armv5-* | armxscale-* | arm7ej-* | arm9te-* | arm9e*-* |\
+                arm10*-* | armv5*-*)
+                    MARCH_FLAG="-march=armv5"
+                    BUILD_MACHINE="arm"
+                    ;;
+                armv6t2*-* | arm1156-*)
+                    MARCH_FLAG="-march=armv6t2"
+                    BUILD_MACHINE="arm"
+                    ;;
+                armv6*-* | arm11*-*)
+                    MARCH_FLAG="-march=armv6"
+                    BUILD_MACHINE="arm"
+                    ;;
+                armv7*-* | armcortexa5-* | armcortexa5neon-* | armcortexa8*-* |\
+                armcortexa9*-*)
+                    MARCH_FLAG="-march=armv7-a"
+                    BUILD_MACHINE="arm"
+                    ;;
+                armcortexa7*-* | armcortexa12*-* | armcortexa15*-* |\
+                armcortexa17*-*)
+                    MARCH_FLAG="-march=armv7ve -march=armv7-a"
+                    BUILD_MACHINE="arm"
+                    ;;
+                armv8.1-a-*)
+                    MARCH_FLAG="-march=armv8.1-a"
+                    BUILD_MACHINE="aarch64"
+                    ;;
+                armv8.2-a-*)
+                    MARCH_FLAG="-march=armv8.2-a"
+                    BUILD_MACHINE="aarch64"
+                    ;;
+                armv8.3-a-*)
+                    MARCH_FLAG="-march=armv8.3-a"
+                    BUILD_MACHINE="aarch64"
+                    ;;
+                armv8.4-a-*)
+                    MARCH_FLAG="-march=armv8.4-a"
+                    BUILD_MACHINE="aarch64"
+                    ;;
+                armv8.5-a-*)
+                    MARCH_FLAG="-march=armv8.5-a"
+                    BUILD_MACHINE="aarch64"
+                    ;;
+                armv8.6-a-*)
+                    MARCH_FLAG="-march=armv8.6-a"
+                    BUILD_MACHINE="aarch64"
+                    ;;
+                armv8.7-a-*)
+                    MARCH_FLAG="-march=armv8.7-a"
+                    BUILD_MACHINE="aarch64"
+                    ;;
+                armv8.8-a-*)
+                    MARCH_FLAG="-march=armv8.8-a"
+                    BUILD_MACHINE="aarch64"
+                    ;;
+                armv8*-* | armcortexa53-* | armcortexa53neon-* |\
+                armcortexa55-* | armcortexa55neon-* | armcortexa57*-* |\
+                armcortexa7[2-9]*-* | armexynosm1-* | armthunderx-* |\
+                armxgene1-* | aarch64*-*)
+                    MARCH_FLAG="-march=armv8-a"
+                    BUILD_MACHINE="aarch64"
+                    ;;
+                armv9*-*)
+                    MARCH_FLAG="-march=armv9-a"
+                    BUILD_MACHINE="aarch64"
+                    ;;
+                *)
+                    MARCH_FLAG="-march=armv4"
+                    BUILD_MACHINE="arm"
+                    ;;
+            esac
+            ;;
+
+        ########################################################################
+        # others
+        ########################################################################
+        ia64-* | ia-64-*)
+            BUILD_MACHINE="ia64"
+            ;;
+        sparc-* | sun4*-*)
+            BUILD_MACHINE="sparc"
+            ;;
+        sparc64-*)
+            BUILD_MACHINE="sparc64"
+            ;;
+        ppc64-* | powerpc64-*)
+            BUILD_MACHINE="ppc64"
+            ;;
+        ppc-* | powerpc-* | [P|p]ower*-*)
+            BUILD_MACHINE="ppc"
+            ;;
+        mips64-*)
+            MARCH_FLAG="-march=mips64"
+            BUILD_MACHINE="mips64"
+            ;;
+
+        ########################################################################
+        # unknown
+        ########################################################################
+        *)
+            MARCH_FLAG=""
+            BUILD_MACHINE="unknown"
+            ;;
+    esac
+
+    ############################################################################
+    # OS / operating system
+    ############################################################################
+    case $BUILD in
+        *Linux* | *linux* | *GNU* | *gnu*)
+            BUILD_OS=Linux
+            ;;
+        *FreeBSD* | *freebsd*)
+            BUILD_OS=FreeBSD
+            ;;
+        *OpenBSD* | *openbsd*)
+            BUILD_OS=OpenBSD
+            ;;
+        *MINGW32* | *mingw32*)
+            if [ "$ABI" = "64" ]; then
+                BUILD_OS=MINGW64
+            else
+                BUILD_OS=MINGW32
+            fi
+            ;;
+        *MSYS* | *msys*)
+            if [ "$BUILD_MACHINE" = "x86_64" ]; then
+                BUILD_OS="MINGW64"
+            else
+                BUILD_OS="MINGW32"
+            fi
+            ;;
+        *MINGW64* | *mingw64*)
+            if [ "$ABI" = "32" ]; then
+                BUILD_OS=MINGW32
+            else
+                BUILD_OS=MINGW64
+            fi
+            ;;
+        *CYGWIN* | *cygwin*)
+            if [ "$ABI" != "32" ] && [ "$BUILD_MACHINE" = "x86_64" ]; then
+                BUILD_OS=CYGWIN64
+            else
+                BUILD_OS=CYGWIN32
+            fi
+            ;;
+        *Darwin* | *DARWIN* | *darwin*)
+            BUILD_OS=Darwin
+            ;;
+        *Android* | *android*)
+            BUILD_OS=android
+            ;;
+        *)
+            BUILD_OS=unknown
+            ;;
+    esac
 fi
 
-case "$ARCH" in
-   x86_64 | amd64)
-      MACHINE="x86_64";;
-   x86 | i*86 | pc)
-      MACHINE="x86";;
-   ia64)
-      MACHINE="ia64";;
-   sparc | sun4*)
-      MACHINE="sparc";;
-   sparc64)
-      MACHINE="sparc64";;
-   ppc64 | powerpc64)
-      MACHINE="ppc64";;
-   ppc | powerpc | [P|p]ower*)
-      MACHINE="ppc";;
-   mips64)
-      MACHINE="mips64";;
-   *)
-      MACHINE="unknown";;
-esac
+echo "Set BUILD_MACHINE to '$BUILD_MACHINE'"
+echo "Set BUILD_MACHINE to '$BUILD_MACHINE'" >> config.log
+echo "Set BUILD_OS to '$BUILD_OS'"
+echo "Set BUILD_OS to '$BUILD_OS'" >> config.log
+echo "Set BUILD_KERNEL to '$BUILD_KERNEL'"
+echo "Set BUILD_KERNEL to '$BUILD_KERNEL'" >> config.log
+echo "Set MARCH_FLAG to '$MARCH_FLAG'"
+echo "Set MARCH_FLAG to '$MARCH_FLAG'" >> config.log
+echo "Done with build."
+echo "Done with build." >> config.log
 
-#ABI flag
+
+###############################################################################
+# ABI flag
+###############################################################################
 if [ "$ABI" = "32" ]; then
-   ABI_FLAG="-m32"
-   case "$MACHINE" in
-      x86_64)
-         MACHINE="x86";;
-      sparc64)
-         MACHINE="sparc";;
-      ppc64)
-         MACHINE="ppc";;
-      *)
-         ;;
-   esac
+    ABI_FLAG="-m32"
+    case "$BUILD_MACHINE" in
+        x86_64)
+            BUILD_MACHINE="x86"
+            ;;
+        sparc64)
+            BUILD_MACHINE="sparc"
+            ;;
+        ppc64)
+            BUILD_MACHINE="ppc"
+            ;;
+        aarch64)
+            BUILD_MACHINE="arm"
+            ;;
+        *)
+            ;;
+    esac
 elif [ "$ABI" = "64" ]; then
-   ABI_FLAG="-m64"
-   if [ "$MACHINE" = "sparc" ]; then
-      MACHINE="sparc64"
-   fi
-   if [ "$MACHINE" = "x86" ]; then
-      MACHINE="x86_64"
-   fi
+    ABI_FLAG="-m64"
+    case "$BUILD_MACHINE" in
+        sparc)
+            BUILD_MACHINE="sparc64"
+            ;;
+        x86)
+            BUILD_MACHINE="x86_64"
+            ;;
+        arm)
+            BUILD_MACHINE="aarch64"
+            ;;
+    esac
 fi
 
-if [ "$MACHINE" = "sparc" ] || [ "$MACHINE" = "sparc64" ]; then
-   if [ "$CC" = "gcc" ]; then
-      CC="gcc -mno-relax"
-   fi
+if [ "$BUILD_MACHINE" = "sparc" ] || [ "$BUILD_MACHINE" = "sparc64" ]; then
+    if [ "$CC" = "gcc" ]; then
+        CC="gcc -mno-relax"
+    fi
 fi
 
-echo "Configuring...${MACHINE}-${OS}"
-echo "Configuring...${MACHINE}-${OS}" >> config.log
+echo "Configuring...${BUILD_MACHINE}-${BUILD_OS}"
+echo "Configuring...${BUILD_MACHINE}-${BUILD_OS}" >> config.log
 
 #FLINT shared library
 
 if [ -z "$FLINT_LIB" ]; then
-   case "$OS" in
-      Darwin)
-         FLINT_LIBNAME="libflint.dylib"
-         FLINT_LIB="libflint-$FLINT_MAJOR.dylib"
-         EXTRA_SHARED_FLAGS="-install_name `pwd`/$FLINT_LIB"
-         EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -compatibility_version $FLINT_MAJOR.$FLINT_MINOR"
-         EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -current_version $FLINT_MAJOR.$FLINT_MINOR.$FLINT_PATCH"
-         ;;
-      CYGWIN* | MINGW*)
-         FLINT_LIBNAME="libflint.dll"
-         FLINT_LIB="libflint-$FLINT_MAJOR.dll"
-         EXTRA_SHARED_FLAGS="-static-libgcc"
-         EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -shared"
-         EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -Wl,--export-all-symbols"
-         EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -Wl,-soname,libflint-$FLINT_MAJOR.dll.$FLINT_MINOR.$FLINT_PATCH"
-         FLINT_DLL=1
-         ;;
-      android)
-         FLINT_LIBNAME="libflint.so"
-         FLINT_LIB="libflint.so.$FLINT_MAJOR.$FLINT_MINOR.$FLINT_PATCH"
-         EXTRA_SHARED_FLAGS="-Wl,-soname,libflint.so"
-         FLINT_SOLIB=1
-         ;;
-      *)
-         FLINT_LIBNAME="libflint.so"
-         FLINT_LIB="libflint.so.$FLINT_MAJOR.$FLINT_MINOR.$FLINT_PATCH"
-         EXTRA_SHARED_FLAGS="-Wl,-soname,libflint.so.$FLINT_MAJOR"
-         FLINT_SOLIB=1
-         ;;
-   esac
- EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -Wl,-rpath,$GMP_LIB_DIR"
- EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -Wl,-rpath,$MPFR_LIB_DIR"
+    case "$BUILD_OS" in
+        Darwin)
+            FLINT_LIBNAME="libflint.dylib"
+            FLINT_LIB="libflint-$FLINT_MAJOR.dylib"
+            EXTRA_SHARED_FLAGS="-install_name `pwd`/$FLINT_LIB"
+            EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -compatibility_version $FLINT_MAJOR.$FLINT_MINOR"
+            EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -current_version $FLINT_MAJOR.$FLINT_MINOR.$FLINT_PATCH"
+            ;;
+        CYGWIN* | MINGW*)
+            FLINT_LIBNAME="libflint.dll"
+            FLINT_LIB="libflint-$FLINT_MAJOR.dll"
+            EXTRA_SHARED_FLAGS="-static-libgcc"
+            EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -shared"
+            EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -Wl,--export-all-symbols"
+            EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -Wl,-soname,libflint-$FLINT_MAJOR.dll.$FLINT_MINOR.$FLINT_PATCH"
+            FLINT_DLL=1
+            ;;
+        android)
+            FLINT_LIBNAME="libflint.so"
+            FLINT_LIB="libflint.so.$FLINT_MAJOR.$FLINT_MINOR.$FLINT_PATCH"
+            EXTRA_SHARED_FLAGS="-Wl,-soname,libflint.so"
+            FLINT_SOLIB=1
+            ;;
+        *)
+            FLINT_LIBNAME="libflint.so"
+            FLINT_LIB="libflint.so.$FLINT_MAJOR.$FLINT_MINOR.$FLINT_PATCH"
+            EXTRA_SHARED_FLAGS="-Wl,-soname,libflint.so.$FLINT_MAJOR"
+            FLINT_SOLIB=1
+            ;;
+    esac
+    EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -Wl,-rpath,$GMP_LIB_DIR"
+    EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -Wl,-rpath,$MPFR_LIB_DIR"
 fi
 
 # sometimes LDCONFIG is not to be found in the path. Look at some common places.
-case "$OS" in
-   MINGW*|CYGWIN*|Darwin|FreeBSD)
-      LDCONFIG="true";;
-   *)
-      if [ -z "$LDCONFIG" ]; then
-         LDCONFIG="true"
-         if [ "$FLINT_SOLIB" = "1" ]; then
-            if command -v ldconfig > /dev/null; then
-               LDCONFIG="ldconfig"
-            elif [ -x /sbin/ldconfig ]; then
-               LDCONFIG="/sbin/ldconfig"
+case "$BUILD_OS" in
+    MINGW* | CYGWIN* | Darwin | FreeBSD)
+        LDCONFIG="true";;
+    *)
+        if [ -z "$LDCONFIG" ]; then
+            LDCONFIG="true"
+            if [ "$FLINT_SOLIB" = "1" ]; then
+                if command -v ldconfig > /dev/null; then
+                    LDCONFIG="ldconfig"
+                elif [ -x /sbin/ldconfig ]; then
+                    LDCONFIG="/sbin/ldconfig"
+                fi
             fi
-         fi
-      fi;;
-esac
+            fi;;
+    esac
 
 #extension for executables
 
 if [ -z "$EXEEXT" ]; then
-   case "$OS" in
-      CYGWIN* | MINGW*)
-         EXEEXT=".exe";;
-      *)
-         EXEEXT="";;
-   esac
+    case "$BUILD_OS" in
+        CYGWIN* | MINGW*)
+            EXEEXT=".exe";;
+        *)
+            EXEEXT="";;
+    esac
 fi
 
 #don't build both shared and static lib on MinGW and Cygwin
 
-case "$OS" in
-   CYGWIN* | MINGW*)
-      if [ "$STATIC" = "1" ] && [ "$SHARED" = "1" ]; then
-         echo "Building both static and shared versions of MPIR/GMP on $OS is currently"
-         echo "unsupported, and so is it for MPFR and FLINT."
-         echo "You should pass --disable-shared or --disable-static to configure"
-         echo "depending on the versions of MPIR/GMP and MPFR you built."
-         echo "Both static and shared libraries is not permitted on $OS" >> config.log
-	 exit 1
-      fi
-      ;;
-   *)
-      ;;
+case "$BUILD_OS" in
+    CYGWIN* | MINGW*)
+        if [ "$STATIC" = "1" ] && [ "$SHARED" = "1" ]; then
+            echo "Building both static and shared versions of MPIR/GMP on $BUILD_OS is currently"
+            echo "unsupported, and so is it for MPFR and FLINT."
+            echo "You should pass --disable-shared or --disable-static to configure"
+            echo "depending on the versions of MPIR/GMP and MPFR you built."
+            echo "Both static and shared libraries is not permitted on $BUILD_OS" >> config.log
+            exit 1
+        fi
+        ;;
+    *)
+        ;;
 esac 
 
 #select fft_tuning parameters
 
-case "$MACHINE" in
-   x86_64 | ia64 | sparc64 | ppc64)
-      cp fft_tuning64.in fft_tuning.h;;
-   *)
-      cp fft_tuning32.in fft_tuning.h;;
+case "$BUILD_MACHINE" in
+    x86_64 | ia64 | sparc64 | ppc64 | aarch64)
+        cp fft_tuning64.in fft_tuning.h;;
+    *)
+        cp fft_tuning32.in fft_tuning.h;;
 esac
 
 #test for popcnt flag and set needed CFLAGS
@@ -581,73 +1093,73 @@ return __builtin_popcountl(argc) == 100;
 }" > build/test-popcnt.c
 $CC build/test-popcnt.c -o ./build/test-popcnt > /dev/null 2>&1
 if [ $? -eq 0 ]; then
-   printf "%s\n" "yes"
-   echo "yes" >> config.log
-   CONFIG_POPCNT_INTRINSICS="#define FLINT_USES_POPCNT"
+    printf "%s\n" "yes"
+    echo "yes" >> config.log
+    CONFIG_POPCNT_INTRINSICS="#define FLINT_USES_POPCNT"
 
-   if [ "$MACHINE" = "x86_64" ]; then
-      MSG="Testing native popcount..."
-      printf "%s" "$MSG"
-      printf "%s" "$MSG" >> config.log
-      touch build/test-popcnt.c
-      rm build/test-popcnt
-      $CC -mpopcnt build/test-popcnt.c -o ./build/test-popcnt > /dev/null 2>&1
-      build/test-popcnt > /dev/null 2>&1
-      if [ $? -eq 0 ]; then
-         printf "%s\n" "yes"
-         echo "yes" >> config.log
-	 POPCNT_FLAG="-mpopcnt"
-      else
-         printf "%s\n" "no"
-	 echo "no" >> config.log
-      fi
-      rm -f build/test-popcnt{,.c}
-   #in case -mpopcnt is not available, the test program will use an illegal
-   #instruction and that will print out something on stderr when the if
-   #construction is exited, whence the following "2> /dev/null"
-   fi 2> /dev/null
+    if [ "$BUILD_MACHINE" = "x86_64" ]; then
+        MSG="Testing native popcount..."
+        printf "%s" "$MSG"
+        printf "%s" "$MSG" >> config.log
+        touch build/test-popcnt.c
+        rm build/test-popcnt
+        $CC -mpopcnt build/test-popcnt.c -o ./build/test-popcnt > /dev/null 2>&1
+        build/test-popcnt > /dev/null 2>&1
+        if [ $? -eq 0 ]; then
+            printf "%s\n" "yes"
+            echo "yes" >> config.log
+            POPCNT_FLAG="-mpopcnt"
+        else
+            printf "%s\n" "no"
+            echo "no" >> config.log
+        fi
+        rm -f build/test-popcnt{,.c}
+        #in case -mpopcnt is not available, the test program will use an illegal
+        #instruction and that will print out something on stderr when the if
+        #construction is exited, whence the following "2> /dev/null"
+    fi 2> /dev/null
 else
-   rm -f build/test-popcnt.c
-   printf "%s\n" "no"
-   echo "no" >> config.log
+    rm -f build/test-popcnt.c
+    printf "%s\n" "no"
+    echo "no" >> config.log
 fi
 
 #defaults for CFLAGS
 if [ -z "$CFLAGS" ]; then
-   if [ "$OS" = "MINGW64" ]; then
-      CFLAGS="-std=c99 -O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG"
-      ANSI_FLAG=""
-   elif [ "$OS" = "CYGWIN64" ]; then
-      CFLAGS="-O2 -funroll-loops -g -D _WIN64 $POPCNT_FLAG $ABI_FLAG"
-      ANSI_FLAG=""
-   elif [ "$MACHINE" = "mips64" ]; then
-      CFLAGS="-O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG"
-      ANSI_FLAG=""
-   elif test "$KERNEL" = "FreeBSD" -o "$OS" = "OpenBSD"; then
-      CFLAGS="-std=c99 -pedantic -Wall -O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG"
-      ANSI_FLAG=""
-      CXXFLAGS="-std=c++11 -pedantic -Wall -O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG"
-   else
-      ANSI_FLAG="-ansi"
-      CFLAGS="-pedantic -Wall -O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG"
-   fi
+    if [ "$BUILD_OS" = "MINGW64" ]; then
+        CFLAGS="-std=c99 -O2 $POPCNT_FLAG $ABI_FLAG $DEBUGGING_FLAG $MARCH_FLAG"
+        ANSI_FLAG=""
+    elif [ "$BUILD_OS" = "CYGWIN64" ]; then
+        CFLAGS="-O2 -D _WIN64 $POPCNT_FLAG $ABI_FLAG $DEBUGGING_FLAG $MARCH_FLAG"
+        ANSI_FLAG=""
+    elif [ "$BUILD_MACHINE" = "mips64" ]; then
+        CFLAGS="-O2 $POPCNT_FLAG $ABI_FLAG $DEBUGGING_FLAG $MARCH_FLAG"
+        ANSI_FLAG=""
+    elif test "$BUILD_KERNEL" = "FreeBSD" -o "$BUILD_OS" = "OpenBSD"; then
+        CFLAGS="-std=c99 -pedantic -Wall -O2 $POPCNT_FLAG $ABI_FLAG $DEBUGGING_FLAG $MARCH_FLAG"
+        ANSI_FLAG=""
+        CXXFLAGS="-std=c++11 -pedantic -Wall -O2 $POPCNT_FLAG $ABI_FLAG $DEBUGGING_FLAG $MARCH_FLAG"
+    else
+        ANSI_FLAG="-ansi"
+        CFLAGS="-pedantic -Wall -O2 $POPCNT_FLAG $ABI_FLAG $DEBUGGING_FLAG $MARCH_FLAG"
+    fi
 fi
 
 #this is needed on PPC G5 and does not hurt on other OS Xes
 
-if [ "$KERNEL" = Darwin ]; then
-   CFLAGS="-fno-common $CFLAGS"
+if [ "$BUILD_KERNEL" = Darwin ]; then
+    CFLAGS="-fno-common $CFLAGS"
 fi
 
 #PIC flag
 
 if [ -z "$PIC_FLAG" ]; then
-   case "$OS" in
-      CYGWIN* | MINGW*)
-         ;;
-      *)
-         PIC_FLAG="-fPIC";;
-   esac
+    case "$BUILD_OS" in
+        CYGWIN* | MINGW*)
+            ;;
+        *)
+            PIC_FLAG="-fPIC";;
+    esac
 fi
 
 #test support for thread-local storage
@@ -655,30 +1167,30 @@ fi
 CONFIG_TLS="#define FLINT_USES_TLS 0"
 
 if [ "$TLS" = "1" ]; then
-   mkdir -p build
-   rm -f build/test-tls > /dev/null 2>&1
-   MSG="Testing __thread..."
-   printf "%s" "$MSG"
-   printf "%s" "$MSG" >> config.log
-   echo "__thread int x = 42; int main(int argc, char ** argv) { return x != 42; }" > build/test-tls.c
-   $CC build/test-tls.c -o ./build/test-tls > /dev/null 2>&1
-   if [ $? -eq 0 ]; then
-      build/test-tls > /dev/null 2>&1
-      if [ $? -eq 0 ]; then
-         printf "%s\n" "yes"
-	 echo "yes" >> config.log
-         CONFIG_TLS="#define FLINT_USES_TLS 1"
-      else
-         printf "%s\n" "no"
-	 echo "no" >> config.log
-      fi
-      rm -f build/test-tls{,.c}
-   else
-      rm -f build/test-tls.c
-      printf "%s\n" "no"
-      echo "no" >> config.log
-   #build-tls can segfault on systems where tls is not available
-   fi 2> /dev/null
+    mkdir -p build
+    rm -f build/test-tls > /dev/null 2>&1
+    MSG="Testing __thread..."
+    printf "%s" "$MSG"
+    printf "%s" "$MSG" >> config.log
+    echo "__thread int x = 42; int main(int argc, char ** argv) { return x != 42; }" > build/test-tls.c
+    $CC build/test-tls.c -o ./build/test-tls > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        build/test-tls > /dev/null 2>&1
+        if [ $? -eq 0 ]; then
+            printf "%s\n" "yes"
+            echo "yes" >> config.log
+            CONFIG_TLS="#define FLINT_USES_TLS 1"
+        else
+            printf "%s\n" "no"
+            echo "no" >> config.log
+        fi
+        rm -f build/test-tls{,.c}
+    else
+        rm -f build/test-tls.c
+        printf "%s\n" "no"
+        echo "no" >> config.log
+        #build-tls can segfault on systems where tls is not available
+    fi 2> /dev/null
 fi
 
 #fenv configuration
@@ -713,12 +1225,12 @@ echo "int main(int argc, char ** argv){ union { unsigned int i; char c[4]; } be_
 $CC build/test-endian.c -o ./build/test-endian > /dev/null 2>&1
 build/test-endian > /dev/null 2>&1
 if [ $? -eq 0 ]; then
-  printf "%s\n" "no"
-  echo "no" >> config.log
+    printf "%s\n" "no"
+    echo "no" >> config.log
 else
-  printf "%s\n" "yes"
-  echo "yes" >> config.log
-  CONFIG_BIG_ENDIAN="#define FLINT_BIG_ENDIAN 1"
+    printf "%s\n" "yes"
+    echo "yes" >> config.log
+    CONFIG_BIG_ENDIAN="#define FLINT_BIG_ENDIAN 1"
 fi
 rm -f build/test-endian{,.c}
 
@@ -759,25 +1271,25 @@ EXTRA_INC_DIRS="${EXTRA_INC_DIRS} ${EXTENSIONS}"
 
 INCS="-I\$(CURDIR) -I\$(CURDIR)/build"
 for INC_DIR in ${INC_DIRS} ${EXTRA_INC_DIRS}; do
-   INCS="${INCS} -I${INC_DIR}"
+    INCS="${INCS} -I${INC_DIR}"
 done
 
 #library paths
 
 LLIBS="-L\$(CURDIR)"
 for LIB_DIR in ${LIB_DIRS} ${EXTRA_LIB_DIRS}; do
-   LLIBS="${LLIBS} -L${LIB_DIR}"
+    LLIBS="${LLIBS} -L${LIB_DIR}"
 done
 
 #linker params
 
 if [ "$PTHREAD" = "1" ]; then
-   lLIBS2="-lpthread ${lLIBS2}"
+    lLIBS2="-lpthread ${lLIBS2}"
 fi
 
 
 for LIB in ${EXTRA_LIBS} ${LIBS}; do
-   lLIBS2="-l${LIB} ${lLIBS2}"
+    lLIBS2="-l${LIB} ${lLIBS2}"
 done
 lLIBS="-lflint $lLIBS2"
 LIBS2="$LLIBS $lLIBS2"
@@ -786,11 +1298,11 @@ LIBS="$LLIBS $lLIBS"
 #cxx
 
 if [ "$WANT_CXX" = "1" ]; then
-   EXTRA_BUILD="$EXTRA_BUILD flintxx"
+    EXTRA_BUILD="$EXTRA_BUILD flintxx"
 fi
 
 if [ -z "$CXXFLAGS" ]; then
-   CXXFLAGS="$CFLAGS"
+    CXXFLAGS="$CFLAGS"
 fi
 
 #write out flint-config.h
@@ -807,13 +1319,13 @@ echo "$CONFIG_CPU_SET_T" >> flint-config.h
 echo "#define FLINT_REENTRANT $REENTRANT" >> flint-config.h
 echo "#define FLINT_WANT_ASSERT $ASSERT" >> flint-config.h
 if [ "$FLINT_DLL" = "1" ]; then
-   echo "#ifdef FLINT_USE_DLL" >> flint-config.h
-   echo "#define FLINT_DLL __declspec(dllimport)" >> flint-config.h
-   echo "#else" >> flint-config.h
-   echo "#define FLINT_DLL __declspec(dllexport)" >> flint-config.h
-   echo "#endif" >> flint-config.h
+    echo "#ifdef FLINT_USE_DLL" >> flint-config.h
+    echo "#define FLINT_DLL __declspec(dllimport)" >> flint-config.h
+    echo "#else" >> flint-config.h
+    echo "#define FLINT_DLL __declspec(dllexport)" >> flint-config.h
+    echo "#endif" >> flint-config.h
 else
-   echo "#define FLINT_DLL" >> flint-config.h
+    echo "#define FLINT_DLL" >> flint-config.h
 fi
 
 #write out Makefile
@@ -829,7 +1341,7 @@ echo "FLINT_STATIC=$STATIC" >> Makefile
 echo "FLINT_SHARED=$SHARED" >> Makefile
 echo "FLINT_LIB=$FLINT_LIB" >> Makefile
 echo "FLINT_LIBNAME=$FLINT_LIBNAME" >> Makefile
-echo "OS=$OS" >> Makefile
+echo "OS=$BUILD_OS" >> Makefile
 echo "FLINT_SOLIB=$FLINT_SOLIB" >> Makefile
 echo "FLINT_MAJOR=$FLINT_MAJOR" >> Makefile
 echo "EXEEXT=$EXEEXT" >> Makefile

--- a/doc/source/building.rst
+++ b/doc/source/building.rst
@@ -82,7 +82,7 @@ operating systems.
 The choices for vendor is not used, and can be passed as whatever. This is to be
 somewhat compatible with GMP's configure settings.
 
-The available choices for the CPU is
+The available choices for the CPU are
 
 - ``x86_64``,
 - ``x86``,

--- a/doc/source/building.rst
+++ b/doc/source/building.rst
@@ -46,6 +46,8 @@ where they should be placed by passing ``--prefix=path`` to configure, where
 ``path`` is the directory under which the ``lib`` and ``include`` directories
 exist into which you wish to place the FLINT files when it is installed.
 
+
+
 TLS, reentrancy and single mode
 -------------------------------------------------------------------------------
 
@@ -65,7 +67,45 @@ If you wish to select the single mode, pass the ``--single`` option to
 configure, though note that this is the default. The reentrant mode is selected
 by passing the option ``--reentrant`` to configure.
 
-ABI and architecture support
+
+
+Architecture support
+-------------------------------------------------------------------------------
+
+In some cases, it is necessary to override the CPU/OS defaults. This can be
+done by passing ``--build=cpu-vendor-os`` to configure, for which 
+
+The choices for OS include ``Linux``, ``MINGW32``, ``MINGW64``, ``CYGWIN32``,
+``CYGWIN64``, ``Darwin``, ``FreeBSD``, ``OpenBSD``, ``SunOS`` and numerous other
+operating systems.
+
+The choices for vendor is not used, and can be passed as whatever. This is to be
+somewhat compatible with GMP's configure settings.
+
+The available choices for the CPU is
+
+- ``x86_64``,
+- ``x86``,
+- ``arm``,
+- ``aarch64`` (also known as ``arm64``),
+- ``ia64``,
+- ``sparc``,
+- ``sparc64``,
+- ``ppc``,
+- ``ppc64``,
+- as well as a specific choice of processors in either family ``x86_64``,
+  ``x86``, ``arm`` and ``aarch64``. These include, but are not limited to,
+  architectures such as ``i386``, ``haswell``, ``k6``, ``athlon64``, ``zen2``,
+  ``armv5`` and ``armv8.7-a``. This is specified in order to set the ``-march``
+  flag for the compiler. For specifics, please see the configuration file to see
+  which architectures we support.
+
+Other CPU types are unrecognised and FLINT will build with generic code on those
+machines.
+
+
+
+ABI
 -------------------------------------------------------------------------------
 
 On some systems, e.g. Sparc and some Macs, more than one ABI is available.
@@ -76,19 +116,10 @@ configure.
 To build on MinGW64 it is necessary to pass ``ABI=64`` to configure, as FLINT
 is otherwise unable to distinguish it from MinGW32.
 
-In some cases, it is necessary to override the CPU/OS defaults. This can be
-done by passing ``--build=cpu-os`` to configure.
-
-The available choices for CPU include ``x86_64``, ``x86``, ``ia64``, ``sparc``,
-``sparc64``, ``ppc``, ``ppc64``. Other CPU types are unrecognised and FLINT
-will build with generic code on those machines.
-
-The choices for OS include ``Linux``, ``MINGW32``, ``MINGW64``, ``CYGWIN32``,
-``CYGWIN64``, ``Darwin``, ``FreeBSD``, ``SunOS`` and numerous other operating
-systems.
-
 It is also possible to override the default CC, AR and CFLAGS used by FLINT by
 passing ``CC=full_path_to_compiler``, etc., to FLINT's configure.
+
+
 
 C++ wrapper
 -------------------------------------------------------------------------------
@@ -100,6 +131,8 @@ The ``C++`` wrapper is always available, but tests will only run if
 this option is selected. It is disabled by default (``--disable-cxx``)
 because some ``C++`` compilers internally segfault when compiling the
 tests, or exhaust memory due to the complexity of the ``C++`` code.
+
+
 
 Building, testing, installing and using FLINT
 -------------------------------------------------------------------------------
@@ -180,6 +213,8 @@ If your system supports parallel builds, FLINT will build in parallel, e.g:
 
 On some systems, parallel builds appear to be available but buggy.
 
+
+
 Testing a single module or file
 -------------------------------------------------------------------------------
 
@@ -200,6 +235,8 @@ separated test list) after chosen module name followed by the colon, e.g.:
     make check MOD=ulong_extras:clog,factor,is_prime
     make check MOD="fft fmpz_mat:add_sub,charpoly fq_vec:add"
 
+
+
 Assertion checking
 -------------------------------------------------------------------------------
 
@@ -207,6 +244,8 @@ FLINT has an assert system. If you want a debug build you can pass
 ``--enable-assert`` to configure. However, this will slow FLINT considerably,
 so asserts should not be enabled (``--disable-assert``, the default) for
 deployment.
+
+
 
 Exceptions
 -------------------------------------------------------------------------------
@@ -220,6 +259,8 @@ At the end, all of FLINT's exceptions call ``abort()`` to terminate
 the program. Using ``flint_set_abort(void (*abort_func)(void))``, the
 user can install a function that will be called instead. Similar
 to the exceptions, this should be regarded as experimental.
+
+
 
 Building FLINT2 with Microsoft Visual Studio using solution files
 -------------------------------------------------------------------------------
@@ -316,5 +357,3 @@ you need to use FLINT2 are placed in the directories:
 - ``dll\<Win32|x64>\<Debug|Release>``
 
 depending on the version(s) that have been built.
-
-


### PR DESCRIPTION
- Remove `-funroll-loops` as this enlarge the library size.
- Clarify usage of configuration.
- Add version option for printing FLINT's version by `-V` or `--version`.
- Remove `-g` flag from CFLAGS by default.
- Add option to insert debugging flag.
- Enable `-march=native` by default.
- If `--build` is specified, set `-march` to specified CPU (currently only does this for arm(64) and x86(_64)).
- Add specific support for `arm` and `aarch64` MACHINE architectures since `uname -m` can output `armXXX` ([source](https://unix.stackexchange.com/questions/136407/is-my-linux-arm-32-or-64-bit)). Probably doesn't make a difference in how it compiles, but I thought it could be nice as even legacy architectures like PowerPC are enlisted.
- `--build` option should be compatible with GMP as well as being backwards compatible to FLINT. 

NOTE: I have not tested this on any other systems than Linux systems. And this is a pretty large change. I would merge this PR for FLINT 2.10.0.