### PR TITLE
Update Miniconda for 32-bit Appveyor to find GMP

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ skip_commits:
 
 environment:
   global:
-    CONDA_INSTALL_LOCN_32: "C:\\Miniconda36"
+    CONDA_INSTALL_LOCN_32: "C:\\Miniconda37"
     CONDA_INSTALL_LOCN_64: "C:\\Miniconda38-x64"
     VCVARSALL: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat"
   matrix:


### PR DESCRIPTION
Copied from https://github.com/fredrik-johansson/arb/pull/398, so credit goes to @isuruf.