### PR TITLE
Remove trailing whitespaces and unused variable

### DIFF
--- a/fmpz/mul_2exp.c
+++ b/fmpz/mul_2exp.c
@@ -41,7 +41,6 @@ fmpz_mul_2exp(fmpz_t f, const fmpz_t g, ulong exp)
         ulong expred = exp % FLINT_BITS;
         int alloc = 1 + exp / FLINT_BITS + ((c1bits + expred) > FLINT_BITS);
         mp_limb_t * limbs;
-        slong tmp;
 
         /* Ensure enough limbs are allocated for f */
         if (!COEFF_IS_MPZ(*f))

--- a/fq_nmod_mpoly/derivative.c
+++ b/fq_nmod_mpoly/derivative.c
@@ -119,7 +119,7 @@ void fq_nmod_mpoly_derivative(
 
         len1 = _fq_nmod_mpoly_derivative_mp(poly1->coeffs, poly1->exps,
                                   poly2->coeffs, poly2->exps, poly2->length,
-                                   bits, N, offset,        oneexp, ctx->fqctx);        
+                                   bits, N, offset,        oneexp, ctx->fqctx);
     }
 
     _fq_nmod_mpoly_set_length(poly1, len1, ctx);

--- a/fq_nmod_mpoly/div_monagan_pearce.c
+++ b/fq_nmod_mpoly/div_monagan_pearce.c
@@ -65,10 +65,10 @@ static int _fq_nmod_mpoly_div_monagan_pearce(
     mask = bits <= FLINT_BITS ? mpoly_overflow_mask_sp(bits) : 0;
 
     Qlen = 0;
-   
+
     /* s is the number of terms * (latest quotient) we should put into heap */
     s = Blen;
-   
+
     /* insert (-1, 0, Aexps[0]) into heap */
     x = chain + 0;
     x->i = -WORD(1);
@@ -81,7 +81,7 @@ static int _fq_nmod_mpoly_div_monagan_pearce(
     /* precompute leading cofficient info */
     n_fq_inv(lc_minus_inv, Bcoeffs + d*0, fqctx);
     _n_fq_neg(lc_minus_inv, lc_minus_inv, d, fqctx->mod);
-   
+
     while (heap_len > 1)
     {
         _fq_nmod_mpoly_fit_length(&Qcoeffs, &Q->coeffs_alloc, d,
@@ -317,7 +317,7 @@ void fq_nmod_mpoly_div_monagan_pearce(
             flint_free(Bexps);
         Bexps = (ulong *) flint_malloc(N*B->length*sizeof(ulong));
         mpoly_repack_monomials(Bexps, Qbits, B->exps, B->bits, B->length, ctx->minfo);
-        freeBexps = 1; 
+        freeBexps = 1;
     }
 
     /* deal with aliasing */

--- a/fq_nmod_mpoly/gcd_zippel2.c
+++ b/fq_nmod_mpoly/gcd_zippel2.c
@@ -829,7 +829,7 @@ choose_main:
                     fq_nmod_mpoly_repack_bits_inplace(rAbar, bits, ctx);
                     fq_nmod_mpoly_repack_bits_inplace(rBbar, bits, ctx);
                     break;
-                }                
+                }
             }
             else
             {
@@ -1079,7 +1079,7 @@ choose_main:
                     goto choose_betas;
 
                 success = n_fq_bpoly_gcd_brown_smprime(Gev, Abarev, Bbarev,
-                                                     Aev, Bev, ctx->fqctx, St);        
+                                                     Aev, Bev, ctx->fqctx, St);
                 if (!success)
                     goto cleanup;
 
@@ -1325,7 +1325,7 @@ gcd_is_trivial:
     fq_nmod_mpoly_set(rBbar, B, ctx);
 
     success = 1;
-    
+
     goto cleanup;
 }
 
@@ -2205,7 +2205,7 @@ got_alpha_m:
                     goto choose_betas_last;
 
                 success = n_fq_bpoly_gcd_brown_smprime(Gev, Abarev, Bbarev,
-                                                   Aev, Bev, lgctx->fqctx, St);        
+                                                   Aev, Bev, lgctx->fqctx, St);
                 if (!success)
                     goto cleanup;
 
@@ -2389,7 +2389,7 @@ gcd_is_trivial:
     fq_nmod_mpoly_set(rBbar, B, smctx);
 
     success = 1;
-    
+
     goto cleanup;
 }
 

--- a/fq_nmod_mpoly/pow_ui.c
+++ b/fq_nmod_mpoly/pow_ui.c
@@ -64,7 +64,7 @@ int fq_nmod_mpoly_pow_ui(
     exp_bits = _fmpz_vec_max_bits(maxBfields, ctx->minfo->nfields);
     exp_bits = mpoly_fix_bits(exp_bits + 1, ctx->minfo);
     fq_nmod_mpoly_fit_length_reset_bits(A, 1, exp_bits, ctx);
-    
+
     n_fq_pow_ui(A->coeffs, B->coeffs, k, ctx->fqctx);
     mpoly_pack_vec_fmpz(A->exps + 0, maxBfields, exp_bits, ctx->minfo->nfields, 1);
     _fq_nmod_mpoly_set_length(A, 1, ctx);


### PR DESCRIPTION
I was wrong about the `__GNU__` thing.