### PR TITLE
[WIP] Pointers

### DIFF
--- a/aprcl.h
+++ b/aprcl.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2015, Vladimir Glazchev
+    Copyright (C) 2015 Vladimir Glazchev
 
     This file is part of FLINT.
 
@@ -32,9 +32,11 @@ typedef struct
     n_factor_t rs;
     fmpz_factor_t qs;
     int * qs_used;
-} _aprcl_config;
+} aprcl_config_struct;
 
-typedef _aprcl_config aprcl_config[1];
+typedef aprcl_config_struct aprcl_config_t[1];
+typedef aprcl_config_struct * aprcl_config_ptr;
+typedef const aprcl_config_struct * aprcl_config_srcptr;
 
 /* Z[unity_root_q, unity_root_p]/(n) struct */
 typedef struct
@@ -43,9 +45,11 @@ typedef struct
     ulong p;
     ulong q;
     fmpz_mod_ctx_t ctx;
-} _unity_zpq;
+} unity_zpq_struct;
 
-typedef _unity_zpq unity_zpq[1];
+typedef unity_zpq_struct unity_zpq_t[1];
+typedef unity_zpq_struct * unity_zpq_ptr;
+typedef const unity_zpq_struct * unity_zpq_srcptr;
 
 /* Z[unity_root]/(n) struct */
 typedef struct
@@ -54,9 +58,11 @@ typedef struct
     ulong p;
     ulong exp;
     fmpz_mod_ctx_t ctx;
-} _unity_zp;
+} unity_zp_struct;
 
-typedef _unity_zp unity_zp[1];
+typedef unity_zp_struct unity_zp_t[1];
+typedef unity_zp_struct * unity_zp_ptr;
+typedef const unity_zp_struct * unity_zp_srcptr;
 
 /* Primality test status */
 typedef enum
@@ -68,7 +74,7 @@ typedef enum
 } primality_test_status;
 
 /* Useful functions */
-FLINT_DLL int _aprcl_p_ind(const aprcl_config conf, ulong p);
+FLINT_DLL int _aprcl_p_ind(aprcl_config_srcptr conf, ulong p);
 
 FLINT_DLL ulong aprcl_p_power_in_q(ulong q, ulong p);
 
@@ -84,19 +90,19 @@ FLINT_DLL int aprcl_is_mul_coprime_ui_fmpz(ulong x, const fmpz_t y, const fmpz_t
 FLINT_DLL int aprcl_is_prime(const fmpz_t n);
 
 /* Gauss test configuration */
-FLINT_DLL void aprcl_config_gauss_init(aprcl_config conf, const fmpz_t n);
+FLINT_DLL void aprcl_config_gauss_init(aprcl_config_ptr conf, const fmpz_t n);
 
-FLINT_DLL void aprcl_config_gauss_init_min_R(aprcl_config conf,
+FLINT_DLL void aprcl_config_gauss_init_min_R(aprcl_config_ptr conf,
         const fmpz_t n, ulong R);
 
-FLINT_DLL void aprcl_config_gauss_clear(aprcl_config conf);
+FLINT_DLL void aprcl_config_gauss_clear(aprcl_config_ptr conf);
 
 /* Jacobi test configuration */
 FLINT_DLL ulong aprcl_R_value(const fmpz_t n);
 
-FLINT_DLL void aprcl_config_jacobi_init(aprcl_config conf, const fmpz_t n);
+FLINT_DLL void aprcl_config_jacobi_init(aprcl_config_ptr conf, const fmpz_t n);
 
-FLINT_DLL void aprcl_config_jacobi_clear(aprcl_config conf);
+FLINT_DLL void aprcl_config_jacobi_clear(aprcl_config_ptr conf);
 
 /*  Gauss sums primality test */
 FLINT_DLL int aprcl_is_prime_gauss(const fmpz_t n);
@@ -104,7 +110,7 @@ FLINT_DLL int aprcl_is_prime_gauss(const fmpz_t n);
 FLINT_DLL int aprcl_is_prime_gauss_min_R(const fmpz_t n, ulong R);
 
 FLINT_DLL primality_test_status _aprcl_is_prime_gauss(const fmpz_t n,
-        const aprcl_config config);
+        aprcl_config_srcptr config);
 
 FLINT_DLL int _aprcl_is_gausspower_2q_equal_first(ulong q, const fmpz_t n);
 
@@ -116,19 +122,19 @@ FLINT_DLL slong _aprcl_is_gausspower_from_unity_p(ulong q, ulong r, const fmpz_t
 FLINT_DLL int aprcl_is_prime_jacobi(const fmpz_t n);
 
 FLINT_DLL primality_test_status _aprcl_is_prime_jacobi(const fmpz_t n,
-        const aprcl_config config);
+        aprcl_config_srcptr config);
 
-FLINT_DLL slong _aprcl_is_prime_jacobi_check_pk(const unity_zp j,
+FLINT_DLL slong _aprcl_is_prime_jacobi_check_pk(unity_zp_srcptr j,
         const fmpz_t u, ulong v);
 
 FLINT_DLL slong _aprcl_is_prime_jacobi_check_21(ulong q,
         const fmpz_t n);
 
-FLINT_DLL slong _aprcl_is_prime_jacobi_check_22(const unity_zp j,
+FLINT_DLL slong _aprcl_is_prime_jacobi_check_22(unity_zp_srcptr j,
         const fmpz_t u, ulong v, ulong q);
 
-FLINT_DLL slong _aprcl_is_prime_jacobi_check_2k(const unity_zp j, const unity_zp j2_1,
-        const unity_zp j2_2, const fmpz_t u, ulong v);
+FLINT_DLL slong _aprcl_is_prime_jacobi_check_2k(unity_zp_srcptr j, unity_zp_srcptr j2_1,
+        unity_zp_srcptr j2_2, const fmpz_t u, ulong v);
 
 FLINT_DLL int _aprcl_is_prime_jacobi_additional_test(const fmpz_t n, ulong p);
 
@@ -144,56 +150,56 @@ FLINT_DLL int aprcl_is_prime_final_division(const fmpz_t n, const fmpz_t s, ulon
 */
 
 /* Memory management */
-FLINT_DLL void unity_zp_init(unity_zp f, ulong p, ulong exp, const fmpz_t n);
+FLINT_DLL void unity_zp_init(unity_zp_ptr f, ulong p, ulong exp, const fmpz_t n);
 
-FLINT_DLL void unity_zp_clear(unity_zp f);
+FLINT_DLL void unity_zp_clear(unity_zp_ptr f);
 
-FLINT_DLL void unity_zp_copy(unity_zp f, const unity_zp g);
+FLINT_DLL void unity_zp_copy(unity_zp_ptr f, unity_zp_srcptr g);
 
-FLINT_DLL void unity_zp_swap(unity_zp f, unity_zp g);
+FLINT_DLL void unity_zp_swap(unity_zp_ptr f, unity_zp_ptr g);
 
-FLINT_DLL void unity_zp_set_zero(unity_zp f);
+FLINT_DLL void unity_zp_set_zero(unity_zp_ptr f);
 
 /* Comparison */
-FLINT_DLL slong unity_zp_is_unity(unity_zp f);
+FLINT_DLL slong unity_zp_is_unity(unity_zp_ptr f);
 
-FLINT_DLL int unity_zp_equal(unity_zp f, unity_zp g);
+FLINT_DLL int unity_zp_equal(unity_zp_ptr f, unity_zp_ptr g);
 
 /* Output */
-FLINT_DLL void unity_zp_print(const unity_zp f);
+FLINT_DLL void unity_zp_print(unity_zp_srcptr f);
 
 /* Coefficient management */
-FLINT_DLL void unity_zp_coeff_set_fmpz(unity_zp f, ulong ind, const fmpz_t x);
+FLINT_DLL void unity_zp_coeff_set_fmpz(unity_zp_ptr f, ulong ind, const fmpz_t x);
 
-FLINT_DLL void unity_zp_coeff_set_ui(unity_zp f, ulong ind, ulong x);
+FLINT_DLL void unity_zp_coeff_set_ui(unity_zp_ptr f, ulong ind, ulong x);
 
-FLINT_DLL void unity_zp_coeff_add_fmpz(unity_zp f, ulong ind, const fmpz_t x);
+FLINT_DLL void unity_zp_coeff_add_fmpz(unity_zp_ptr f, ulong ind, const fmpz_t x);
 
-FLINT_DLL void unity_zp_coeff_add_ui(unity_zp f, ulong ind, ulong x);
+FLINT_DLL void unity_zp_coeff_add_ui(unity_zp_ptr f, ulong ind, ulong x);
 
-FLINT_DLL void unity_zp_coeff_inc(unity_zp f, ulong ind);
+FLINT_DLL void unity_zp_coeff_inc(unity_zp_ptr f, ulong ind);
 
-FLINT_DLL void unity_zp_coeff_dec(unity_zp f, ulong ind);
+FLINT_DLL void unity_zp_coeff_dec(unity_zp_ptr f, ulong ind);
 
 /* Scalar multiplication */
-FLINT_DLL void unity_zp_mul_scalar_fmpz(unity_zp f,
-        const unity_zp g, const fmpz_t s);
+FLINT_DLL void unity_zp_mul_scalar_fmpz(unity_zp_ptr f,
+        unity_zp_srcptr g, const fmpz_t s);
 
-FLINT_DLL void unity_zp_mul_scalar_ui(unity_zp f, const unity_zp g, ulong s);
+FLINT_DLL void unity_zp_mul_scalar_ui(unity_zp_ptr f, unity_zp_srcptr g, ulong s);
 
 /* Addition */
-FLINT_DLL void unity_zp_add(unity_zp f, const unity_zp g, const unity_zp h);
+FLINT_DLL void unity_zp_add(unity_zp_ptr f, unity_zp_srcptr g, unity_zp_srcptr h);
 
 /* General multiplication and squaring */
-FLINT_DLL void unity_zp_mul(unity_zp f, const unity_zp g, const unity_zp h);
+FLINT_DLL void unity_zp_mul(unity_zp_ptr f, unity_zp_srcptr g, unity_zp_srcptr h);
 
-FLINT_DLL void unity_zp_sqr(unity_zp f, const unity_zp g);
+FLINT_DLL void unity_zp_sqr(unity_zp_ptr f, unity_zp_srcptr g);
 
 /* Special multiplication and squaring */
-FLINT_DLL void unity_zp_mul_inplace(unity_zp f,
-        const unity_zp g, const unity_zp h, fmpz_t * t);
+FLINT_DLL void unity_zp_mul_inplace(unity_zp_ptr f,
+        unity_zp_srcptr g, unity_zp_srcptr h, fmpz_t * t);
 
-FLINT_DLL void unity_zp_sqr_inplace(unity_zp f, const unity_zp g, fmpz_t * t);
+FLINT_DLL void unity_zp_sqr_inplace(unity_zp_ptr f, unity_zp_srcptr g, fmpz_t * t);
 
 FLINT_DLL void unity_zp_ar1(fmpz_t * t);
 
@@ -203,85 +209,85 @@ FLINT_DLL void unity_zp_ar3(fmpz_t * t);
 
 FLINT_DLL void unity_zp_ar4(fmpz_t * t);
 
-FLINT_DLL void unity_zp_mul3(unity_zp f,
-        const unity_zp g, const unity_zp h, fmpz_t * t);
+FLINT_DLL void unity_zp_mul3(unity_zp_ptr f,
+        unity_zp_srcptr g, unity_zp_srcptr h, fmpz_t * t);
 
-FLINT_DLL void unity_zp_mul9(unity_zp f,
-        const unity_zp g, const unity_zp h, fmpz_t * t);
+FLINT_DLL void unity_zp_mul9(unity_zp_ptr f,
+        unity_zp_srcptr g, unity_zp_srcptr h, fmpz_t * t);
 
-FLINT_DLL void unity_zp_mul4(unity_zp f,
-        const unity_zp g, const unity_zp h, fmpz_t * t);
+FLINT_DLL void unity_zp_mul4(unity_zp_ptr f,
+        unity_zp_srcptr g, unity_zp_srcptr h, fmpz_t * t);
 
-FLINT_DLL void unity_zp_mul8(unity_zp f,
-        const unity_zp g, const unity_zp h, fmpz_t * t);
+FLINT_DLL void unity_zp_mul8(unity_zp_ptr f,
+        unity_zp_srcptr g, unity_zp_srcptr h, fmpz_t * t);
 
-FLINT_DLL void unity_zp_mul16(unity_zp f,
-        const unity_zp g, const unity_zp h, fmpz_t * t);
+FLINT_DLL void unity_zp_mul16(unity_zp_ptr f,
+        unity_zp_srcptr g, unity_zp_srcptr h, fmpz_t * t);
 
-FLINT_DLL void unity_zp_mul5(unity_zp f,
-        const unity_zp g, const unity_zp h, fmpz_t * t);
+FLINT_DLL void unity_zp_mul5(unity_zp_ptr f,
+        unity_zp_srcptr g, unity_zp_srcptr h, fmpz_t * t);
 
-FLINT_DLL void unity_zp_mul7(unity_zp f,
-        const unity_zp g, const unity_zp h, fmpz_t * t);
+FLINT_DLL void unity_zp_mul7(unity_zp_ptr f,
+        unity_zp_srcptr g, unity_zp_srcptr h, fmpz_t * t);
 
-FLINT_DLL void unity_zp_mul11(unity_zp f,
-        const unity_zp g, const unity_zp h, fmpz_t * t);
+FLINT_DLL void unity_zp_mul11(unity_zp_ptr f,
+        unity_zp_srcptr g, unity_zp_srcptr h, fmpz_t * t);
 
-FLINT_DLL void unity_zp_sqr3(unity_zp f, const unity_zp g, fmpz_t * t);
+FLINT_DLL void unity_zp_sqr3(unity_zp_ptr f, unity_zp_srcptr g, fmpz_t * t);
 
-FLINT_DLL void unity_zp_sqr9(unity_zp f, const unity_zp g, fmpz_t * t);
+FLINT_DLL void unity_zp_sqr9(unity_zp_ptr f, unity_zp_srcptr g, fmpz_t * t);
 
-FLINT_DLL void unity_zp_sqr4(unity_zp f, const unity_zp g, fmpz_t * t);
+FLINT_DLL void unity_zp_sqr4(unity_zp_ptr f, unity_zp_srcptr g, fmpz_t * t);
 
-FLINT_DLL void unity_zp_sqr8(unity_zp f, const unity_zp g, fmpz_t * t);
+FLINT_DLL void unity_zp_sqr8(unity_zp_ptr f, unity_zp_srcptr g, fmpz_t * t);
 
-FLINT_DLL void unity_zp_sqr16(unity_zp f, const unity_zp g, fmpz_t * t);
+FLINT_DLL void unity_zp_sqr16(unity_zp_ptr f, unity_zp_srcptr g, fmpz_t * t);
 
-FLINT_DLL void unity_zp_sqr5(unity_zp f, const unity_zp g, fmpz_t * t);
+FLINT_DLL void unity_zp_sqr5(unity_zp_ptr f, unity_zp_srcptr g, fmpz_t * t);
 
-FLINT_DLL void unity_zp_sqr7(unity_zp f, const unity_zp g, fmpz_t * t);
+FLINT_DLL void unity_zp_sqr7(unity_zp_ptr f, unity_zp_srcptr g, fmpz_t * t);
 
-FLINT_DLL void unity_zp_sqr11(unity_zp f, const unity_zp g, fmpz_t * t);
+FLINT_DLL void unity_zp_sqr11(unity_zp_ptr f, unity_zp_srcptr g, fmpz_t * t);
 
 /* Powering functions */
-FLINT_DLL void unity_zp_pow_fmpz(unity_zp f,
-        const unity_zp g, const fmpz_t pow);
+FLINT_DLL void unity_zp_pow_fmpz(unity_zp_ptr f,
+        unity_zp_srcptr g, const fmpz_t pow);
 
-FLINT_DLL void unity_zp_pow_ui(unity_zp f, const unity_zp g, ulong pow);
+FLINT_DLL void unity_zp_pow_ui(unity_zp_ptr f, unity_zp_srcptr g, ulong pow);
 
 FLINT_DLL ulong _unity_zp_pow_select_k(const fmpz_t n);
 
-FLINT_DLL void unity_zp_pow_2k_fmpz(unity_zp f,
-        const unity_zp g, const fmpz_t pow);
+FLINT_DLL void unity_zp_pow_2k_fmpz(unity_zp_ptr f,
+        unity_zp_srcptr g, const fmpz_t pow);
 
-FLINT_DLL void unity_zp_pow_2k_ui(unity_zp f, const unity_zp g, ulong pow);
+FLINT_DLL void unity_zp_pow_2k_ui(unity_zp_ptr f, unity_zp_srcptr g, ulong pow);
 
-FLINT_DLL void unity_zp_pow_sliding_fmpz(unity_zp f,
-        unity_zp g, const fmpz_t pow);
+FLINT_DLL void unity_zp_pow_sliding_fmpz(unity_zp_ptr f,
+        unity_zp_ptr g, const fmpz_t pow);
 
 /* Cyclotomic reduction */
-FLINT_DLL void _unity_zp_reduce_cyclotomic_divmod(unity_zp f);
+FLINT_DLL void _unity_zp_reduce_cyclotomic_divmod(unity_zp_ptr f);
 
-FLINT_DLL void _unity_zp_reduce_cyclotomic(unity_zp f);
+FLINT_DLL void _unity_zp_reduce_cyclotomic(unity_zp_ptr f);
 
-FLINT_DLL void unity_zp_reduce_cyclotomic(unity_zp f, const unity_zp g);
+FLINT_DLL void unity_zp_reduce_cyclotomic(unity_zp_ptr f, unity_zp_srcptr g);
 
 /* Automorphism and inverse computation */
-FLINT_DLL void unity_zp_aut(unity_zp f, const unity_zp g, ulong x);
+FLINT_DLL void unity_zp_aut(unity_zp_ptr f, unity_zp_srcptr g, ulong x);
 
-FLINT_DLL void unity_zp_aut_inv(unity_zp f, const unity_zp g, ulong x);
+FLINT_DLL void unity_zp_aut_inv(unity_zp_ptr f, unity_zp_srcptr g, ulong x);
 
 /* Jacobi sum computation. */
 FLINT_DLL mp_ptr aprcl_f_table(const ulong q);
 
-FLINT_DLL void _unity_zp_jacobi_sum_pq_general(unity_zp f,
+FLINT_DLL void _unity_zp_jacobi_sum_pq_general(unity_zp_ptr f,
         const mp_ptr table, ulong p, ulong q, ulong k, ulong a, ulong b);
 
-FLINT_DLL void unity_zp_jacobi_sum_pq(unity_zp f, ulong q, ulong p);
+FLINT_DLL void unity_zp_jacobi_sum_pq(unity_zp_ptr f, ulong q, ulong p);
 
-FLINT_DLL void unity_zp_jacobi_sum_2q_one(unity_zp f, ulong q);
+FLINT_DLL void unity_zp_jacobi_sum_2q_one(unity_zp_ptr f, ulong q);
 
-FLINT_DLL void unity_zp_jacobi_sum_2q_two(unity_zp f, ulong q);
+FLINT_DLL void unity_zp_jacobi_sum_2q_two(unity_zp_ptr f, ulong q);
 
 
 /* 
@@ -290,68 +296,68 @@ FLINT_DLL void unity_zp_jacobi_sum_2q_two(unity_zp f, ulong q);
 */
 
 /* Memory management */
-FLINT_DLL void unity_zpq_init(unity_zpq f, ulong q, ulong p, const fmpz_t n);
+FLINT_DLL void unity_zpq_init(unity_zpq_ptr f, ulong q, ulong p, const fmpz_t n);
 
-FLINT_DLL void unity_zpq_clear(unity_zpq f);
+FLINT_DLL void unity_zpq_clear(unity_zpq_ptr f);
 
-FLINT_DLL void unity_zpq_copy(unity_zpq f, const unity_zpq g);
+FLINT_DLL void unity_zpq_copy(unity_zpq_ptr f, unity_zpq_srcptr g);
 
-FLINT_DLL void unity_zpq_swap(unity_zpq f, unity_zpq g);
+FLINT_DLL void unity_zpq_swap(unity_zpq_ptr f, unity_zpq_ptr g);
 
 /* Comparison */
-FLINT_DLL int unity_zpq_equal(const unity_zpq f, const unity_zpq g);
+FLINT_DLL int unity_zpq_equal(unity_zpq_srcptr f, unity_zpq_srcptr g);
 
-FLINT_DLL slong unity_zpq_p_unity(const unity_zpq f);
+FLINT_DLL slong unity_zpq_p_unity(unity_zpq_srcptr f);
 
-FLINT_DLL int unity_zpq_is_p_unity(const unity_zpq f);
+FLINT_DLL int unity_zpq_is_p_unity(unity_zpq_srcptr f);
 
-FLINT_DLL int unity_zpq_is_p_unity_generator(const unity_zpq f);
+FLINT_DLL int unity_zpq_is_p_unity_generator(unity_zpq_srcptr f);
 
 /* Coefficient management */
-FLINT_DLL void unity_zpq_coeff_set_fmpz(unity_zpq f,
+FLINT_DLL void unity_zpq_coeff_set_fmpz(unity_zpq_ptr f,
         slong i, slong j, const fmpz_t x);
 
-FLINT_DLL void unity_zpq_coeff_set_ui(unity_zpq f,
+FLINT_DLL void unity_zpq_coeff_set_ui(unity_zpq_ptr f,
         slong i, slong j, ulong x);
 
-FLINT_DLL void unity_zpq_coeff_add(unity_zpq f,
+FLINT_DLL void unity_zpq_coeff_add(unity_zpq_ptr f,
         slong i, slong j, const fmpz_t x);
 
-FLINT_DLL void unity_zpq_coeff_add_ui(unity_zpq f,
+FLINT_DLL void unity_zpq_coeff_add_ui(unity_zpq_ptr f,
         slong i, slong j, ulong x);
 
 /* Scalar multiplication */
-FLINT_DLL void unity_zpq_scalar_mul_ui(unity_zpq f,
-        const unity_zpq g, ulong s);
+FLINT_DLL void unity_zpq_scalar_mul_ui(unity_zpq_ptr f,
+        unity_zpq_srcptr g, ulong s);
 
 /* Addition and multiplication */
-FLINT_DLL void unity_zpq_add(unity_zpq f,
-        const unity_zpq g, const unity_zpq h);
+FLINT_DLL void unity_zpq_add(unity_zpq_ptr f,
+        unity_zpq_srcptr g, unity_zpq_srcptr h);
 
-FLINT_DLL void unity_zpq_mul(unity_zpq f,
-        const unity_zpq g, const unity_zpq h);
+FLINT_DLL void unity_zpq_mul(unity_zpq_ptr f,
+        unity_zpq_srcptr g, unity_zpq_srcptr h);
 
-FLINT_DLL void _unity_zpq_mul_unity_p(unity_zpq f);
+FLINT_DLL void _unity_zpq_mul_unity_p(unity_zpq_ptr f);
 
 FLINT_DLL void unity_zpq_mul_unity_p_pow(
-        unity_zpq f, const unity_zpq g, slong p);
+        unity_zpq_ptr f, unity_zpq_srcptr g, slong p);
 
 /* Powering */
-FLINT_DLL void unity_zpq_pow(unity_zpq f,
-        const unity_zpq g, const fmpz_t p);
+FLINT_DLL void unity_zpq_pow(unity_zpq_ptr f,
+        unity_zpq_srcptr g, const fmpz_t p);
 
-FLINT_DLL void unity_zpq_pow_ui(unity_zpq f,
-        const unity_zpq g, ulong pow);
+FLINT_DLL void unity_zpq_pow_ui(unity_zpq_ptr f,
+        unity_zpq_srcptr g, ulong pow);
 
 /* Gauss sum computation */
-FLINT_DLL void unity_zpq_gauss_sum(unity_zpq f,
+FLINT_DLL void unity_zpq_gauss_sum(unity_zpq_ptr f,
         ulong q, ulong p);
 
-FLINT_DLL void unity_zpq_gauss_sum_character_pow(unity_zpq f,
+FLINT_DLL void unity_zpq_gauss_sum_character_pow(unity_zpq_ptr f,
         ulong q, ulong p, ulong pow);
 
 FLINT_DLL void unity_zpq_gauss_sum_sigma_pow(
-        unity_zpq f, ulong q, ulong p);
+        unity_zpq_ptr f, ulong q, ulong p);
 
 #ifdef __cplusplus
 }

--- a/aprcl/config_gauss.c
+++ b/aprcl/config_gauss.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 static void
-_aprcl_config_gauss_update(aprcl_config conf)
+_aprcl_config_gauss_update(aprcl_config_ptr conf)
 {
     ulong prime = 2;
 
@@ -35,7 +35,7 @@ _aprcl_config_gauss_update(aprcl_config conf)
 }
 
 void
-aprcl_config_gauss_init(aprcl_config conf, const fmpz_t n)
+aprcl_config_gauss_init(aprcl_config_ptr conf, const fmpz_t n)
 {
     fmpz_t s2;
 
@@ -59,7 +59,7 @@ aprcl_config_gauss_init(aprcl_config conf, const fmpz_t n)
 }
 
 void
-aprcl_config_gauss_init_min_R(aprcl_config conf, const fmpz_t n, ulong R)
+aprcl_config_gauss_init_min_R(aprcl_config_ptr conf, const fmpz_t n, ulong R)
 {
     fmpz_t s2;
 
@@ -84,7 +84,7 @@ aprcl_config_gauss_init_min_R(aprcl_config conf, const fmpz_t n, ulong R)
 }
 
 void
-aprcl_config_gauss_clear(aprcl_config conf)
+aprcl_config_gauss_clear(aprcl_config_ptr conf)
 {
     fmpz_clear(conf->s);
     fmpz_factor_clear(conf->qs);

--- a/aprcl/config_gauss.c
+++ b/aprcl/config_gauss.c
@@ -50,8 +50,8 @@ aprcl_config_gauss_init(aprcl_config_ptr conf, const fmpz_t n)
         _aprcl_config_gauss_update(conf);
         fmpz_mul(s2, conf->s, conf->s);
     }
-    n_factor_init(&conf->rs);
-    n_factor(&conf->rs, conf->R, 1);
+    n_factor_init(conf->rs);
+    n_factor(conf->rs, conf->R, 1);
 
     conf->qs_used = NULL;  /* not used */
 
@@ -75,8 +75,8 @@ aprcl_config_gauss_init_min_R(aprcl_config_ptr conf, const fmpz_t n, ulong R)
         fmpz_mul(s2, conf->s, conf->s);
     }
 
-    n_factor_init(&conf->rs);
-    n_factor(&conf->rs, conf->R, 1);
+    n_factor_init(conf->rs);
+    n_factor(conf->rs, conf->R, 1);
 
     conf->qs_used = NULL;  /* not used */
 

--- a/aprcl/config_jacobi.c
+++ b/aprcl/config_jacobi.c
@@ -67,7 +67,7 @@ aprcl_R_value(const fmpz_t n)
 }
 
 static void
-_aprcl_config_jacobi_reduce_s2(aprcl_config conf, const fmpz_t n)
+_aprcl_config_jacobi_reduce_s2(aprcl_config_ptr conf, const fmpz_t n)
 {
     ulong i, j, q;
     double * w;
@@ -142,7 +142,7 @@ _aprcl_config_jacobi_reduce_s2(aprcl_config conf, const fmpz_t n)
 }
 
 static void
-_aprcl_config_jacobi_update(aprcl_config conf)
+_aprcl_config_jacobi_update(aprcl_config_ptr conf)
 {
     ulong prime = 2;
 
@@ -176,7 +176,7 @@ _aprcl_config_jacobi_update(aprcl_config conf)
 
 /* Computes s = \prod q^(k + 1) ; q - prime, q - 1 | R; q^k | R and q^(k + 1) not | R */
 void
-aprcl_config_jacobi_init(aprcl_config conf, const fmpz_t n)
+aprcl_config_jacobi_init(aprcl_config_ptr conf, const fmpz_t n)
 {
     fmpz_init(conf->s);
     fmpz_factor_init(conf->qs);
@@ -191,7 +191,7 @@ aprcl_config_jacobi_init(aprcl_config conf, const fmpz_t n)
 }
 
 void
-aprcl_config_jacobi_clear(aprcl_config conf)
+aprcl_config_jacobi_clear(aprcl_config_ptr conf)
 {
     fmpz_clear(conf->s);
     fmpz_factor_clear(conf->qs);

--- a/aprcl/config_jacobi.c
+++ b/aprcl/config_jacobi.c
@@ -83,17 +83,17 @@ _aprcl_config_jacobi_reduce_s2(aprcl_config_ptr conf, const fmpz_t n)
         conf->qs_used[i] = 1;
 
         q = fmpz_get_ui(conf->qs->p + i);
-        n_factor_init(&q_factors);
-        n_factor(&q_factors, q - 1, 1);
+        n_factor_init(q_factors);
+        n_factor(q_factors, q - 1, 1);
 
         w[i] = 0;
 
-        for (j = 0; j < q_factors.num; j++)
+        for (j = 0; j < q_factors->num; j++)
         {
             ulong p, euler_phi;
 
-            p = q_factors.p[j];
-            euler_phi = n_pow(p, q_factors.exp[j] - 1) * (p - 1);
+            p = q_factors->p[j];
+            euler_phi = n_pow(p, q_factors->exp[j] - 1) * (p - 1);
             euler_phi = euler_phi * euler_phi;
 
             w[i] += euler_phi;
@@ -183,8 +183,8 @@ aprcl_config_jacobi_init(aprcl_config_ptr conf, const fmpz_t n)
     conf->R = aprcl_R_value(n);
     _aprcl_config_jacobi_update(conf);
 
-    n_factor_init(&conf->rs);
-    n_factor(&conf->rs, conf->R, 1);
+    n_factor_init(conf->rs);
+    n_factor(conf->rs, conf->R, 1);
 
     conf->qs_used = (int *) flint_malloc(sizeof(int) * conf->qs->num);
     _aprcl_config_jacobi_reduce_s2(conf, n);

--- a/aprcl/is_prime_gauss.c
+++ b/aprcl/is_prime_gauss.c
@@ -114,7 +114,7 @@ _aprcl_is_gausspower_from_unity_p(ulong q, ulong r, const fmpz_t n)
 {
     slong result;
     ulong i;
-    unity_zpq temp, gauss, gausspow, gausssigma;
+    unity_zpq_t temp, gauss, gausspow, gausssigma;
 
     unity_zpq_init(gauss, q, r, n);
     unity_zpq_init(gausssigma, q, r, n);
@@ -149,7 +149,7 @@ _aprcl_is_gausspower_from_unity_p(ulong q, ulong r, const fmpz_t n)
 }
 
 primality_test_status
-_aprcl_is_prime_gauss(const fmpz_t n, const aprcl_config config)
+_aprcl_is_prime_gauss(const fmpz_t n, aprcl_config_srcptr config)
 {
     int *lambdas;
     ulong i, j, k, nmod4;
@@ -356,7 +356,7 @@ int
 aprcl_is_prime_gauss_min_R(const fmpz_t n, ulong R)
 {
     primality_test_status result;
-    aprcl_config config;
+    aprcl_config_t config;
 
     aprcl_config_gauss_init_min_R(config, n, R);
     result = _aprcl_is_prime_gauss(n, config);
@@ -373,7 +373,7 @@ aprcl_is_prime_gauss(const fmpz_t n)
 {
     ulong R;
     primality_test_status result;
-    aprcl_config config;
+    aprcl_config_t config;
 
     if (fmpz_cmp_ui(n, 2) < 0)
        return 0;

--- a/aprcl/is_prime_gauss.c
+++ b/aprcl/is_prime_gauss.c
@@ -163,8 +163,8 @@ _aprcl_is_prime_gauss(const fmpz_t n, aprcl_config_srcptr config)
 
         If (Lp), then lambdas_p = 3.
     */
-    lambdas = (int*) flint_malloc(sizeof(int) * config->rs.num);
-    for (i = 0; i < config->rs.num; i++)
+    lambdas = (int*) flint_malloc(sizeof(int) * config->rs->num);
+    for (i = 0; i < config->rs->num; i++)
         lambdas[i] = 0;
 
     result = PROBABPRIME;
@@ -189,17 +189,17 @@ _aprcl_is_prime_gauss(const fmpz_t n, aprcl_config_srcptr config)
         }
 
         /* find prime factors of q - 1 */
-        n_factor_init(&q_factors);
-        n_factor(&q_factors, q - 1, 1);
+        n_factor_init(q_factors);
+        n_factor(q_factors, q - 1, 1);
 
         /* for every prime p | q - 1 */
-        for (j = 0; j < q_factors.num; j++)
+        for (j = 0; j < q_factors->num; j++)
         {
             int state, pind;
             ulong p;
             if (result == COMPOSITE) break;
 
-            p = q_factors.p[j];
+            p = q_factors->p[j];
 
             pind = _aprcl_p_ind(config, p);
             state = lambdas[pind];
@@ -244,7 +244,7 @@ _aprcl_is_prime_gauss(const fmpz_t n, aprcl_config_srcptr config)
             }
 
             /* for every prime power p^k | q - 1 */
-            for (k = 1; k <= q_factors.exp[j]; k++)
+            for (k = 1; k <= q_factors->exp[j]; k++)
             {
                 int unity_power;
                 ulong r;
@@ -323,7 +323,7 @@ _aprcl_is_prime_gauss(const fmpz_t n, aprcl_config_srcptr config)
         then n can be as prime or composite
     */
     if (result == PROBABPRIME)
-        for (i = 0; i < config->rs.num; i++)
+        for (i = 0; i < config->rs->num; i++)
             if (lambdas[i] != 3)
                 result = UNKNOWN;
 

--- a/aprcl/is_prime_jacobi.c
+++ b/aprcl/is_prime_jacobi.c
@@ -83,11 +83,11 @@
     algorithm (9.1.28) step 4.a in [1].
 */
 slong
-_aprcl_is_prime_jacobi_check_pk(const unity_zp j, const fmpz_t u, ulong v)
+_aprcl_is_prime_jacobi_check_pk(unity_zp_srcptr j, const fmpz_t u, ulong v)
 {
     slong h;
     ulong i, r;
-    unity_zp j0, jv, temp, aut;
+    unity_zp_t j0, jv, temp, aut;
 
     /* initialization */
     r = n_pow(j->p, j->exp);            /* r = p^k */
@@ -212,10 +212,10 @@ _aprcl_is_prime_jacobi_check_21(ulong q, const fmpz_t n)
     For details see algorithm (9.1.28) step 4.c in [1].
 */
 slong
-_aprcl_is_prime_jacobi_check_22(const unity_zp j, const fmpz_t u, ulong v, ulong q)
+_aprcl_is_prime_jacobi_check_22(unity_zp_srcptr j, const fmpz_t u, ulong v, ulong q)
 {
     slong h;
-    unity_zp j0, jv, j_pow;
+    unity_zp_t j0, jv, j_pow;
 
     /* initialization */
     unity_zp_init(j_pow, 2, 2, fmpz_mod_ctx_modulus(j->ctx));
@@ -271,12 +271,12 @@ _aprcl_is_prime_jacobi_check_22(const unity_zp j, const fmpz_t u, ulong v, ulong
     For details see algorithm (9.1.28) step 4.b in [1].
 */
 slong
-_aprcl_is_prime_jacobi_check_2k(const unity_zp j, const unity_zp j2_1,
-        const unity_zp j2_2, const fmpz_t u, ulong v)
+_aprcl_is_prime_jacobi_check_2k(unity_zp_srcptr j, unity_zp_srcptr j2_1,
+        unity_zp_srcptr j2_2, const fmpz_t u, ulong v)
 {
     slong h;
     ulong i, r;
-    unity_zp j_j0, j0, jv, temp, aut;
+    unity_zp_t j_j0, j0, jv, temp, aut;
 
     /* initialization */
     r = n_pow(j->p, j->exp);
@@ -446,7 +446,7 @@ _aprcl_is_prime_jacobi_additional_test(const fmpz_t n, ulong p)
            ulong v, k;
            slong h;
            fmpz_t u;
-           unity_zp jacobi_sum;
+           unity_zp_t jacobi_sum;
 
            fmpz_init(u);
 
@@ -536,7 +536,7 @@ _aprcl_is_prime_jacobi_additional_test(const fmpz_t n, ulong p)
 }
 
 primality_test_status
-_aprcl_is_prime_jacobi(const fmpz_t n, const aprcl_config config)
+_aprcl_is_prime_jacobi(const fmpz_t n, aprcl_config_srcptr config)
 {
     int *lambdas;
     ulong i, j, nmod4;
@@ -632,7 +632,7 @@ _aprcl_is_prime_jacobi(const fmpz_t n, const aprcl_config config)
             int pind;
             slong h;
             ulong v, p, r, k;
-            unity_zp jacobi_sum, jacobi_sum2_1, jacobi_sum2_2;
+            unity_zp_t jacobi_sum, jacobi_sum2_1, jacobi_sum2_2;
 
             if (result == COMPOSITE)
                 break;
@@ -651,7 +651,7 @@ _aprcl_is_prime_jacobi(const fmpz_t n, const aprcl_config config)
             fmpz_tdiv_q_ui(u, n, r);
             v = fmpz_tdiv_ui(n, r);
 
-            /* init unity_zp for jacobi sums */
+            /* init unity_zp_t for jacobi sums */
             unity_zp_init(jacobi_sum, p, k, n);
             unity_zp_init(jacobi_sum2_1, p, k, n);
             unity_zp_init(jacobi_sum2_2, p, k, n);
@@ -736,7 +736,7 @@ _aprcl_is_prime_jacobi(const fmpz_t n, const aprcl_config config)
                     lambdas[pind] = 1;
             }
 
-            /* clear unity_zp for jacobi sums */
+            /* clear unity_zp_t for jacobi sums */
             unity_zp_clear(jacobi_sum);
             unity_zp_clear(jacobi_sum2_1);
             unity_zp_clear(jacobi_sum2_2);
@@ -813,7 +813,7 @@ int
 aprcl_is_prime_jacobi(const fmpz_t n)
 {
     primality_test_status result;
-    aprcl_config config;
+    aprcl_config_t config;
 
     /* 
         Choose R and s values for n and store its factorisation.

--- a/aprcl/is_prime_jacobi.c
+++ b/aprcl/is_prime_jacobi.c
@@ -570,7 +570,7 @@ _aprcl_is_prime_jacobi(const fmpz_t n, aprcl_config_srcptr config)
 
         If (Lp), then lambdas_p = 1.
     */
-    lambdas = (int*) flint_malloc(sizeof(int) * config->rs.num);
+    lambdas = (int*) flint_malloc(sizeof(int) * config->rs->num);
 
     /* nmod4 = n % 4 */
     nmod4 = fmpz_tdiv_ui(n, 4);
@@ -580,9 +580,9 @@ _aprcl_is_prime_jacobi(const fmpz_t n, aprcl_config_srcptr config)
             to 1 if p >= 3 and n^{p - 1} != 1 mod p^2;
             to 0 otherwise.
     */
-    for (i = 0; i < config->rs.num; i++)
+    for (i = 0; i < config->rs->num; i++)
     {
-        ulong p = config->rs.p[i];
+        ulong p = config->rs->p[i];
         if (p > 2)
         {
             fmpz_set_ui(p2, p * p);
@@ -623,11 +623,11 @@ _aprcl_is_prime_jacobi(const fmpz_t n, aprcl_config_srcptr config)
         }
 
         /* find prime factors of q - 1 */
-        n_factor_init(&q_factors);
-        n_factor(&q_factors, q - 1, 1);
+        n_factor_init(q_factors);
+        n_factor(q_factors, q - 1, 1);
 
         /* for every prime p | q - 1 */
-        for (j = 0; j < q_factors.num; j++)
+        for (j = 0; j < q_factors->num; j++)
         {
             int pind;
             slong h;
@@ -637,8 +637,8 @@ _aprcl_is_prime_jacobi(const fmpz_t n, aprcl_config_srcptr config)
             if (result == COMPOSITE)
                 break;
 
-            p = q_factors.p[j];     /* set p; p | q - 1 */
-            k = q_factors.exp[j];   /* set max k for which p^k | q - 1 */
+            p = q_factors->p[j];     /* set p; p | q - 1 */
+            k = q_factors->exp[j];   /* set max k for which p^k | q - 1 */
             r = n_pow(p, k);        /* set r = p^k */
             pind = _aprcl_p_ind(config, p);  /* find index of p in lambdas */
 
@@ -750,12 +750,12 @@ _aprcl_is_prime_jacobi(const fmpz_t n, aprcl_config_srcptr config)
     if (result == PROBABPRIME)
     {
         /* for every lambdas_p */
-        for (i = 0; i < config->rs.num; i++)
+        for (i = 0; i < config->rs->num; i++)
         {
             /* if lambdas_p == 0 need run additional test for p */
             if (lambdas[i] == 0)
             {
-                int r = _aprcl_is_prime_jacobi_additional_test(n, config->rs.p[i]);
+                int r = _aprcl_is_prime_jacobi_additional_test(n, config->rs->p[i]);
 
                 /* if r == 2 then we prove that n is composite */
                 if (r == 2)

--- a/aprcl/test/t-config_gauss.c
+++ b/aprcl/test/t-config_gauss.c
@@ -26,7 +26,7 @@ int main(void)
     for (i = 0; i < 10 * flint_test_multiplier(); i++)
     {
         fmpz_t n, s2;
-        aprcl_config conf;
+        aprcl_config_t conf;
 
         fmpz_init(s2);
         fmpz_init(n);

--- a/aprcl/test/t-config_jacobi.c
+++ b/aprcl/test/t-config_jacobi.c
@@ -26,7 +26,7 @@ int main(void)
     for (i = 0; i < 10 * flint_test_multiplier(); i++)
     {
         fmpz_t n, s2;
-        aprcl_config conf;
+        aprcl_config_t conf;
 
         fmpz_init(n);
         fmpz_init(s2);

--- a/aprcl/test/t-is_prime_jacobi.c
+++ b/aprcl/test/t-is_prime_jacobi.c
@@ -28,7 +28,7 @@ int main(void)
     /* Test _aprcl_is_prime_jacobi_check_pk() */
     {
         ulong p, q, v, k, p_pow;
-        unity_zp j;
+        unity_zp_t j;
         fmpz_t n, u;
 
         q = 19;
@@ -81,7 +81,7 @@ int main(void)
     /* Test _aprcl_is_prime_jacobi_check_22() */
     {
         ulong p, q, v, k, p_pow;
-        unity_zp j;
+        unity_zp_t j;
         fmpz_t n, u;
 
         q = 13;
@@ -115,7 +115,7 @@ int main(void)
     /* Test _aprcl_is_prime_jacobi_check_2k() */
     {
         ulong p, q, v, k, p_pow;
-        unity_zp j, j2_1, j2_2;
+        unity_zp_t j, j2_1, j2_2;
         fmpz_t n, u;
 
         q = 41;

--- a/aprcl/test/t-unity_zp_add.c
+++ b/aprcl/test/t-unity_zp_add.c
@@ -27,7 +27,7 @@ int main(void)
     {
         ulong p;
         fmpz_t n;
-        unity_zp f, g, h1, h2;
+        unity_zp_t f, g, h1, h2;
 
         p = n_randprime(state, 2 + n_randint(state, 6), 0);
 

--- a/aprcl/test/t-unity_zp_aut_inv.c
+++ b/aprcl/test/t-unity_zp_aut_inv.c
@@ -30,16 +30,16 @@ int main(void)
         unity_zp_t f, g, h;
         n_factor_t q_factors;
 
-        n_factor_init(&q_factors);
+        n_factor_init(q_factors);
 
         q = n_randprime(state, 2 + n_randint(state, 6), 0);
         while (q < 3)
             q = n_randprime(state, 2 + n_randint(state, 6), 0);
 
-        n_factor(&q_factors, q - 1, 1);
-        ind = n_randint(state, q_factors.num);
-        p = q_factors.p[ind];
-        k = q_factors.exp[ind];
+        n_factor(q_factors, q - 1, 1);
+        ind = n_randint(state, q_factors->num);
+        p = q_factors->p[ind];
+        k = q_factors->exp[ind];
         
         x = n_randint(state, n_pow(p, k));
         while (n_gcd(p, x) != 1 || x == 0)

--- a/aprcl/test/t-unity_zp_aut_inv.c
+++ b/aprcl/test/t-unity_zp_aut_inv.c
@@ -27,7 +27,7 @@ int main(void)
     {
         ulong ind, q, p, k, x;
         fmpz_t n;
-        unity_zp f, g, h;
+        unity_zp_t f, g, h;
         n_factor_t q_factors;
 
         n_factor_init(&q_factors);

--- a/aprcl/test/t-unity_zp_equal.c
+++ b/aprcl/test/t-unity_zp_equal.c
@@ -27,7 +27,7 @@ int main(void)
     {
         ulong p;
         fmpz_t n;
-        unity_zp f, g;
+        unity_zp_t f, g;
 
         p = n_randprime(state, 2 + n_randint(state, 6), 0);
 

--- a/aprcl/test/t-unity_zp_init.c
+++ b/aprcl/test/t-unity_zp_init.c
@@ -27,7 +27,7 @@ int main(void)
     {
         ulong p;
         fmpz_t n;
-        unity_zp f;
+        unity_zp_t f;
 
         p = n_randprime(state, 2 + n_randint(state, 6), 0);
 

--- a/aprcl/test/t-unity_zp_is_unity.c
+++ b/aprcl/test/t-unity_zp_is_unity.c
@@ -27,7 +27,7 @@ int main(void)
     {
         ulong p, exp;
         fmpz_t n;
-        unity_zp f;
+        unity_zp_t f;
         ulong ind;
 
         p = n_randprime(state, 2 + n_randint(state, 4), 0);

--- a/aprcl/test/t-unity_zp_jacobi_sum.c
+++ b/aprcl/test/t-unity_zp_jacobi_sum.c
@@ -31,7 +31,7 @@ int main(void)
     {
         ulong ind, q, p, k;
         fmpz_t n;
-        unity_zp f, g;
+        unity_zp_t f, g;
         n_factor_t q_factors;
         mp_ptr table;
 
@@ -85,7 +85,7 @@ int main(void)
     {
         ulong q, p, k;
         fmpz_t n;
-        unity_zp f, g;
+        unity_zp_t f, g;
         n_factor_t q_factors;
         mp_ptr table;
 
@@ -138,7 +138,7 @@ int main(void)
     {
         ulong a, b, q, p, k;
         fmpz_t n;
-        unity_zp f, g;
+        unity_zp_t f, g;
         n_factor_t q_factors;
         mp_ptr table;
 

--- a/aprcl/test/t-unity_zp_jacobi_sum.c
+++ b/aprcl/test/t-unity_zp_jacobi_sum.c
@@ -35,16 +35,16 @@ int main(void)
         n_factor_t q_factors;
         mp_ptr table;
 
-        n_factor_init(&q_factors);
+        n_factor_init(q_factors);
 
         q = n_randprime(state, 2 + n_randint(state, 4), 0);
         while (q < 3)
             q = n_randprime(state, 2 + n_randint(state, 4), 0);
 
-        n_factor(&q_factors, q - 1, 1);
-        ind = n_randint(state, q_factors.num);
-        p = q_factors.p[ind];
-        k = q_factors.exp[ind];
+        n_factor(q_factors, q - 1, 1);
+        ind = n_randint(state, q_factors->num);
+        p = q_factors->p[ind];
+        k = q_factors->exp[ind];
 
         fmpz_init(n);
         fmpz_randtest_unsigned(n, state, 200);
@@ -89,15 +89,15 @@ int main(void)
         n_factor_t q_factors;
         mp_ptr table;
 
-        n_factor_init(&q_factors);
+        n_factor_init(q_factors);
 
         q = n_randprime(state, 2 + n_randint(state, 4), 0);
         while (q < 3)
             q = n_randprime(state, 2 + n_randint(state, 4), 0);
 
-        n_factor(&q_factors, q - 1, 1);
+        n_factor(q_factors, q - 1, 1);
         p = 2;
-        k = q_factors.exp[0];
+        k = q_factors->exp[0];
 
         fmpz_init(n);
         fmpz_randtest_unsigned(n, state, 200);
@@ -142,15 +142,15 @@ int main(void)
         n_factor_t q_factors;
         mp_ptr table;
 
-        n_factor_init(&q_factors);
+        n_factor_init(q_factors);
 
         q = n_randprime(state, 2 + n_randint(state, 6), 0);
         while (q < 3)
             q = n_randprime(state, 2 + n_randint(state, 6), 0);
 
-        n_factor(&q_factors, q - 1, 1);
+        n_factor(q_factors, q - 1, 1);
         p = 2;
-        k = q_factors.exp[0];
+        k = q_factors->exp[0];
 
         if (k < 3) continue;
 

--- a/aprcl/test/t-unity_zp_mul.c
+++ b/aprcl/test/t-unity_zp_mul.c
@@ -28,7 +28,7 @@ int main(void)
     {
         ulong p, ind1, ind2;
         fmpz_t n;
-        unity_zp f, g, h1, h2;
+        unity_zp_t f, g, h1, h2;
 
         p = n_randprime(state, 2 + n_randint(state, 6), 0);
 
@@ -71,7 +71,7 @@ int main(void)
     {
         ulong p;
         fmpz_t n;
-        unity_zp f, g, h1, h2;
+        unity_zp_t f, g, h1, h2;
 
         p = n_randprime(state, 2 + n_randint(state, 6), 0);
 

--- a/aprcl/test/t-unity_zp_mul11.c
+++ b/aprcl/test/t-unity_zp_mul11.c
@@ -33,7 +33,7 @@ int main(void)
     {
         ulong p;
         fmpz_t n;
-        unity_zp f1, f2, g, h;
+        unity_zp_t f1, f2, g, h;
 
         p = 11;
 

--- a/aprcl/test/t-unity_zp_mul2.c
+++ b/aprcl/test/t-unity_zp_mul2.c
@@ -33,7 +33,7 @@ int main(void)
     {
         ulong p, k;
         fmpz_t n;
-        unity_zp f1, f2, g, h;
+        unity_zp_t f1, f2, g, h;
 
         p = 2;
         k = 2;
@@ -93,7 +93,7 @@ int main(void)
     {
         ulong p, k;
         fmpz_t n;
-        unity_zp f1, f2, g, h;
+        unity_zp_t f1, f2, g, h;
 
         p = 2;
         k = 3;
@@ -153,7 +153,7 @@ int main(void)
     {
         ulong p, k;
         fmpz_t n;
-        unity_zp f1, f2, g, h;
+        unity_zp_t f1, f2, g, h;
 
         p = 2;
         k = 4;

--- a/aprcl/test/t-unity_zp_mul3.c
+++ b/aprcl/test/t-unity_zp_mul3.c
@@ -33,7 +33,7 @@ int main(void)
     {
         ulong p;
         fmpz_t n;
-        unity_zp f1, f2, g, h;
+        unity_zp_t f1, f2, g, h;
 
         p = 3;
 
@@ -92,7 +92,7 @@ int main(void)
     {
         ulong p, k;
         fmpz_t n;
-        unity_zp f1, f2, g, h;
+        unity_zp_t f1, f2, g, h;
 
         p = 3;
         k = 2;

--- a/aprcl/test/t-unity_zp_mul5.c
+++ b/aprcl/test/t-unity_zp_mul5.c
@@ -33,7 +33,7 @@ int main(void)
     {
         ulong p;
         fmpz_t n;
-        unity_zp f1, f2, g, h;
+        unity_zp_t f1, f2, g, h;
 
         p = 5;
 

--- a/aprcl/test/t-unity_zp_mul7.c
+++ b/aprcl/test/t-unity_zp_mul7.c
@@ -33,7 +33,7 @@ int main(void)
     {
         ulong p;
         fmpz_t n;
-        unity_zp f1, f2, g, h;
+        unity_zp_t f1, f2, g, h;
 
         p = 7;
 

--- a/aprcl/test/t-unity_zp_pow.c
+++ b/aprcl/test/t-unity_zp_pow.c
@@ -27,7 +27,7 @@ int main(void)
     {
         ulong p, pow;
         fmpz_t n;
-        unity_zp f, g, h1, h2;
+        unity_zp_t f, g, h1, h2;
 
         p = n_randprime(state, 2 + n_randint(state, 6), 0);
 

--- a/aprcl/test/t-unity_zp_pow_2k.c
+++ b/aprcl/test/t-unity_zp_pow_2k.c
@@ -27,7 +27,7 @@ int main(void)
     {
         ulong p;
         fmpz_t n, pow;
-        unity_zp f, g, h;
+        unity_zp_t f, g, h;
 
         p = n_randprime(state, 2 + n_randint(state, 6), 0);
 

--- a/aprcl/test/t-unity_zp_pow_sliding.c
+++ b/aprcl/test/t-unity_zp_pow_sliding.c
@@ -27,7 +27,7 @@ int main(void)
     {
         ulong p;
         fmpz_t n, pow;
-        unity_zp f, g, h;
+        unity_zp_t f, g, h;
 
         p = n_randprime(state, 2 + n_randint(state, 6), 0);
 

--- a/aprcl/test/t-unity_zp_reduce_cyclotomic.c
+++ b/aprcl/test/t-unity_zp_reduce_cyclotomic.c
@@ -31,7 +31,7 @@ int main(void)
         fmpz_mod_poly_t cyclo_poly;
         ulong p, exp;
         fmpz_t n;
-        unity_zp f, g;
+        unity_zp_t f, g;
 
         p = n_randprime(state, 2 + n_randint(state, 2), 0);
         exp = n_randint(state, 4);

--- a/aprcl/test/t-unity_zp_sqr.c
+++ b/aprcl/test/t-unity_zp_sqr.c
@@ -27,7 +27,7 @@ int main(void)
     {
         ulong p;
         fmpz_t n;
-        unity_zp f, g, h;
+        unity_zp_t f, g, h;
 
         p = n_randprime(state, 2 + n_randint(state, 6), 0);
 

--- a/aprcl/test/t-unity_zp_sqr11.c
+++ b/aprcl/test/t-unity_zp_sqr11.c
@@ -33,7 +33,7 @@ int main(void)
     {
         ulong p;
         fmpz_t n;
-        unity_zp f, g, temp;
+        unity_zp_t f, g, temp;
 
         p = 11;
 

--- a/aprcl/test/t-unity_zp_sqr2.c
+++ b/aprcl/test/t-unity_zp_sqr2.c
@@ -33,7 +33,7 @@ int main(void)
     {
         ulong p, k;
         fmpz_t n;
-        unity_zp f, g, temp;
+        unity_zp_t f, g, temp;
 
         p = 2;
         k = 2;
@@ -85,7 +85,7 @@ int main(void)
     {
         ulong p, k;
         fmpz_t n;
-        unity_zp f, g, temp;
+        unity_zp_t f, g, temp;
 
         p = 2;
         k = 3;
@@ -137,7 +137,7 @@ int main(void)
     {
         ulong p, k;
         fmpz_t n;
-        unity_zp f, g, temp;
+        unity_zp_t f, g, temp;
 
         p = 2;
         k = 4;

--- a/aprcl/test/t-unity_zp_sqr3.c
+++ b/aprcl/test/t-unity_zp_sqr3.c
@@ -33,7 +33,7 @@ int main(void)
     {
         ulong p;
         fmpz_t n;
-        unity_zp f, g, temp;
+        unity_zp_t f, g, temp;
 
         p = 3;
 
@@ -84,7 +84,7 @@ int main(void)
     {
         ulong p, k;
         fmpz_t n;
-        unity_zp f, g, temp;
+        unity_zp_t f, g, temp;
 
         p = 3;
         k = 2;

--- a/aprcl/test/t-unity_zp_sqr5.c
+++ b/aprcl/test/t-unity_zp_sqr5.c
@@ -33,7 +33,7 @@ int main(void)
     {
         ulong p;
         fmpz_t n;
-        unity_zp f, g, temp;
+        unity_zp_t f, g, temp;
 
         p = 5;
 

--- a/aprcl/test/t-unity_zp_sqr7.c
+++ b/aprcl/test/t-unity_zp_sqr7.c
@@ -33,7 +33,7 @@ int main(void)
     {
         ulong p;
         fmpz_t n;
-        unity_zp f, g, temp;
+        unity_zp_t f, g, temp;
 
         p = 7;
 

--- a/aprcl/test/t-unity_zpq_add.c
+++ b/aprcl/test/t-unity_zpq_add.c
@@ -27,7 +27,7 @@ int main(void)
     {
         ulong p, q;
         fmpz_t n;
-        unity_zpq f, g, h1, h2;
+        unity_zpq_t f, g, h1, h2;
 
         fmpz_init(n);
 

--- a/aprcl/test/t-unity_zpq_equal.c
+++ b/aprcl/test/t-unity_zpq_equal.c
@@ -27,7 +27,7 @@ int main(void)
     {
         ulong p, q;
         fmpz_t n;
-        unity_zpq f, g;
+        unity_zpq_t f, g;
 
         p = n_randprime(state, 2 + n_randint(state, 6), 0);
         q = n_randprime(state, 2 + n_randint(state, 6), 0);

--- a/aprcl/test/t-unity_zpq_gauss_sum.c
+++ b/aprcl/test/t-unity_zpq_gauss_sum.c
@@ -28,7 +28,7 @@ int main(void)
         int result;
         ulong p, q, pnum, ppow;
         fmpz_t n;
-        unity_zpq gausssigma, gauss, gausspower;
+        unity_zpq_t gausssigma, gauss, gausspower;
         n_factor_t factors;
 
         n_factor_init(&factors);

--- a/aprcl/test/t-unity_zpq_gauss_sum.c
+++ b/aprcl/test/t-unity_zpq_gauss_sum.c
@@ -31,17 +31,17 @@ int main(void)
         unity_zpq_t gausssigma, gauss, gausspower;
         n_factor_t factors;
 
-        n_factor_init(&factors);
+        n_factor_init(factors);
 
         q = n_randprime(state, 6, 0);
         if (q == 2)
             q = 7;
 
-        n_factor(&factors, q - 1, 0);
+        n_factor(factors, q - 1, 0);
 
-        pnum = n_randint(state, factors.num);
-        p = factors.p[pnum];
-        ppow = n_randint(state, factors.exp[pnum]);
+        pnum = n_randint(state, factors->num);
+        p = factors->p[pnum];
+        ppow = n_randint(state, factors->exp[pnum]);
         if (ppow == 0)
             ppow = 1;
 

--- a/aprcl/test/t-unity_zpq_init.c
+++ b/aprcl/test/t-unity_zpq_init.c
@@ -27,7 +27,7 @@ int main(void)
     {
         ulong p, q;
         fmpz_t n;
-        unity_zpq f;
+        unity_zpq_t f;
 
         fmpz_init(n);
 

--- a/aprcl/test/t-unity_zpq_mul.c
+++ b/aprcl/test/t-unity_zpq_mul.c
@@ -27,7 +27,7 @@ int main(void)
     {
         ulong p, q;
         fmpz_t n;
-        unity_zpq f, g, h1, h2;
+        unity_zpq_t f, g, h1, h2;
 
         fmpz_init(n);
 

--- a/aprcl/test/t-unity_zpq_mul_unity_p.c
+++ b/aprcl/test/t-unity_zpq_mul_unity_p.c
@@ -27,7 +27,7 @@ int main(void)
     {
         ulong p, q;
         fmpz_t n;
-        unity_zpq f, g;
+        unity_zpq_t f, g;
 
         fmpz_init(n);
 
@@ -60,7 +60,7 @@ int main(void)
 
         for (j = 0; j < p; j++)
         {
-            unity_zpq h1, h2;
+            unity_zpq_t h1, h2;
             unity_zpq_init(h1, q, p, n);
             unity_zpq_init(h2, q, p, n);
             

--- a/aprcl/test/t-unity_zpq_pow.c
+++ b/aprcl/test/t-unity_zpq_pow.c
@@ -27,7 +27,7 @@ int main(void)
     {
         ulong p, q, pow;
         fmpz_t n;
-        unity_zpq f, g, h1, h2;
+        unity_zpq_t f, g, h1, h2;
 
         p = n_randprime(state, 2 + n_randint(state, 5), 0);
         q = n_randprime(state, 2 + n_randint(state, 5), 0);

--- a/aprcl/unity_zp_add.c
+++ b/aprcl/unity_zp_add.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-unity_zp_add(unity_zp f, const unity_zp g, const unity_zp h)
+unity_zp_add(unity_zp_ptr f, unity_zp_srcptr g, unity_zp_srcptr h)
 {
     FLINT_ASSERT(fmpz_equal(fmpz_mod_ctx_modulus(f->ctx),
                             fmpz_mod_ctx_modulus(g->ctx)));

--- a/aprcl/unity_zp_aut.c
+++ b/aprcl/unity_zp_aut.c
@@ -15,7 +15,7 @@
     Computes f such that \sigma_x(g) = f.
 */
 void
-unity_zp_aut(unity_zp f, const unity_zp g, ulong x)
+unity_zp_aut(unity_zp_ptr f, unity_zp_srcptr g, ulong x)
 {
     ulong i, p_pow, p_pow_preinv;
     fmpz_t coeff;

--- a/aprcl/unity_zp_aut_inv.c
+++ b/aprcl/unity_zp_aut_inv.c
@@ -15,7 +15,7 @@
     Computes f such that \sigma_x(f) = g.
 */
 void
-unity_zp_aut_inv(unity_zp f, const unity_zp g, ulong x)
+unity_zp_aut_inv(unity_zp_ptr f, unity_zp_srcptr g, ulong x)
 {
     ulong i, j, p_pow1, p_pow2, m, p_pow_preinv;
     fmpz_t f_coeff, g_coeff;

--- a/aprcl/unity_zp_coeff_add.c
+++ b/aprcl/unity_zp_coeff_add.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-unity_zp_coeff_add_fmpz(unity_zp f, ulong ind, const fmpz_t x)
+unity_zp_coeff_add_fmpz(unity_zp_ptr f, ulong ind, const fmpz_t x)
 {
     fmpz_t coeff;
     fmpz_init(coeff);
@@ -31,7 +31,7 @@ unity_zp_coeff_add_fmpz(unity_zp f, ulong ind, const fmpz_t x)
 }
 
 void
-unity_zp_coeff_add_ui(unity_zp f, ulong ind, ulong x)
+unity_zp_coeff_add_ui(unity_zp_ptr f, ulong ind, ulong x)
 {
     fmpz_t coeff;
     fmpz_init(coeff);

--- a/aprcl/unity_zp_coeff_inc.c
+++ b/aprcl/unity_zp_coeff_inc.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-unity_zp_coeff_inc(unity_zp f, ulong ind)
+unity_zp_coeff_inc(unity_zp_ptr f, ulong ind)
 {
     if (ind >= f->poly->length)
     {
@@ -26,7 +26,7 @@ unity_zp_coeff_inc(unity_zp f, ulong ind)
 }
 
 void
-unity_zp_coeff_dec(unity_zp f, ulong ind)
+unity_zp_coeff_dec(unity_zp_ptr f, ulong ind)
 {
     if (ind >= f->poly->length)
     {

--- a/aprcl/unity_zp_coeff_set.c
+++ b/aprcl/unity_zp_coeff_set.c
@@ -12,13 +12,13 @@
 #include "aprcl.h"
 
 void
-unity_zp_coeff_set_fmpz(unity_zp f, ulong ind, const fmpz_t x)
+unity_zp_coeff_set_fmpz(unity_zp_ptr f, ulong ind, const fmpz_t x)
 {
     fmpz_mod_poly_set_coeff_fmpz(f->poly, ind, x, f->ctx);
 }
 
 void
-unity_zp_coeff_set_ui(unity_zp f, ulong ind, ulong x)
+unity_zp_coeff_set_ui(unity_zp_ptr f, ulong ind, ulong x)
 {
     fmpz_mod_poly_set_coeff_ui(f->poly, ind, x, f->ctx);
 }

--- a/aprcl/unity_zp_copy.c
+++ b/aprcl/unity_zp_copy.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-unity_zp_copy(unity_zp f, const unity_zp g)
+unity_zp_copy(unity_zp_ptr f, unity_zp_srcptr g)
 {
     FLINT_ASSERT(fmpz_equal(fmpz_mod_ctx_modulus(f->ctx),
                             fmpz_mod_ctx_modulus(g->ctx)));

--- a/aprcl/unity_zp_equal.c
+++ b/aprcl/unity_zp_equal.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 int
-unity_zp_equal(unity_zp f, unity_zp g)
+unity_zp_equal(unity_zp_ptr f, unity_zp_ptr g)
 {
     /*
         f and g can be reduced only by modylo x^{p^k} - 1,

--- a/aprcl/unity_zp_init.c
+++ b/aprcl/unity_zp_init.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-unity_zp_init(unity_zp f, ulong p, ulong exp, const fmpz_t n)
+unity_zp_init(unity_zp_ptr f, ulong p, ulong exp, const fmpz_t n)
 {
     f->p = p;
     f->exp = exp;
@@ -21,7 +21,7 @@ unity_zp_init(unity_zp f, ulong p, ulong exp, const fmpz_t n)
 }
 
 void
-unity_zp_clear(unity_zp f)
+unity_zp_clear(unity_zp_ptr f)
 {
     fmpz_mod_poly_clear(f->poly, f->ctx);
     fmpz_mod_ctx_clear(f->ctx);

--- a/aprcl/unity_zp_is_unity.c
+++ b/aprcl/unity_zp_is_unity.c
@@ -12,11 +12,11 @@
 #include "aprcl.h"
 
 slong
-unity_zp_is_unity(unity_zp f)
+unity_zp_is_unity(unity_zp_ptr f)
 {
     ulong result;
     ulong i, p_pow;
-    unity_zp unity;
+    unity_zp_t unity;
 
     p_pow = n_pow(f->p, f->exp);
     unity_zp_init(unity, f->p, f->exp, fmpz_mod_ctx_modulus(f->ctx));

--- a/aprcl/unity_zp_jacobi_sum.c
+++ b/aprcl/unity_zp_jacobi_sum.c
@@ -16,7 +16,7 @@
     Computes sum \zeta_{p^k}^{a * x + b * f(x)} for x = 1, 2, ..., q - 2.
 */
 void 
-_unity_zp_jacobi_sum_pq_general(unity_zp f, const mp_ptr table,
+_unity_zp_jacobi_sum_pq_general(unity_zp_ptr f, const mp_ptr table,
         ulong p, ulong q, ulong k, ulong a, ulong b)
 {
     int i, j;
@@ -53,7 +53,7 @@ _unity_zp_jacobi_sum_pq_general(unity_zp f, const mp_ptr table,
     Computes sum \zeta_{p^k}^{x + f(x)} for x = 1, 2, ..., q - 2.
 */
 void
-unity_zp_jacobi_sum_pq(unity_zp f, ulong q, ulong p)
+unity_zp_jacobi_sum_pq(unity_zp_ptr f, ulong q, ulong p)
 {
     ulong k;
     mp_ptr table;
@@ -70,7 +70,7 @@ unity_zp_jacobi_sum_pq(unity_zp f, ulong q, ulong p)
     Computes sum \zeta_{p^k}^{2 * x + b * f(x)} for x = 1, 2, ..., q - 2.
 */
 void
-unity_zp_jacobi_sum_2q_one(unity_zp f, ulong q)
+unity_zp_jacobi_sum_2q_one(unity_zp_ptr f, ulong q)
 {
     ulong k;
     mp_ptr table;
@@ -88,7 +88,7 @@ unity_zp_jacobi_sum_2q_one(unity_zp f, ulong q)
     for x = 1, 2, ..., q - 2.
 */
 void
-unity_zp_jacobi_sum_2q_two(unity_zp f, ulong q)
+unity_zp_jacobi_sum_2q_two(unity_zp_ptr f, ulong q)
 {
     ulong a, b, k;
     mp_ptr table;

--- a/aprcl/unity_zp_mul.c
+++ b/aprcl/unity_zp_mul.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-unity_zp_mul(unity_zp f, const unity_zp g, const unity_zp h)
+unity_zp_mul(unity_zp_ptr f, unity_zp_srcptr g, unity_zp_srcptr h)
 {
     slong glen, hlen;
 
@@ -43,7 +43,7 @@ unity_zp_mul(unity_zp f, const unity_zp g, const unity_zp h)
 }
 
 void
-unity_zp_mul_inplace(unity_zp f, const unity_zp g, const unity_zp h, fmpz_t * t)
+unity_zp_mul_inplace(unity_zp_ptr f, unity_zp_srcptr g, unity_zp_srcptr h, fmpz_t * t)
 {
     /* multiplication for p^k = 4 */
     if (f->p == 2 && f->exp == 2)

--- a/aprcl/unity_zp_mul11.c
+++ b/aprcl/unity_zp_mul11.c
@@ -18,7 +18,7 @@
     Resulting f reduced by F_11 cyclotomic polynomial.
 */
 void
-unity_zp_mul11(unity_zp f, const unity_zp g, const unity_zp h, fmpz_t * t)
+unity_zp_mul11(unity_zp_ptr f, unity_zp_srcptr g, unity_zp_srcptr h, fmpz_t * t)
 {
     int i;
 

--- a/aprcl/unity_zp_mul2.c
+++ b/aprcl/unity_zp_mul2.c
@@ -18,7 +18,7 @@
     Resulting f reduced by F_4 cyclotomic polynomial.
 */
 void
-unity_zp_mul4(unity_zp f, const unity_zp g, const unity_zp h, fmpz_t * t)
+unity_zp_mul4(unity_zp_ptr f, unity_zp_srcptr g, unity_zp_srcptr h, fmpz_t * t)
 {
     /*
         g = (x0, x1);
@@ -60,7 +60,7 @@ unity_zp_mul4(unity_zp f, const unity_zp g, const unity_zp h, fmpz_t * t)
     Resulting f reduced by F_8 cyclotomic polynomial.
 */
 void
-unity_zp_mul8(unity_zp f, const unity_zp g, const unity_zp h, fmpz_t * t)
+unity_zp_mul8(unity_zp_ptr f, unity_zp_srcptr g, unity_zp_srcptr h, fmpz_t * t)
 {
     /*
         g = (x0, x1, x2, x3);
@@ -141,7 +141,7 @@ unity_zp_mul8(unity_zp f, const unity_zp g, const unity_zp h, fmpz_t * t)
     Resulting f reduced by F_16 cyclotomic polynomial.
 */
 void
-unity_zp_mul16(unity_zp f, const unity_zp g, const unity_zp h, fmpz_t * t)
+unity_zp_mul16(unity_zp_ptr f, unity_zp_srcptr g, unity_zp_srcptr h, fmpz_t * t)
 {
     int i;
 

--- a/aprcl/unity_zp_mul3.c
+++ b/aprcl/unity_zp_mul3.c
@@ -18,7 +18,7 @@
     Resulting f reduced by F_3 cyclotomic polynomial.
 */
 void
-unity_zp_mul3(unity_zp f, const unity_zp g, const unity_zp h, fmpz_t * t)
+unity_zp_mul3(unity_zp_ptr f, unity_zp_srcptr g, unity_zp_srcptr h, fmpz_t * t)
 {
     /*
         g = (x0, x1);
@@ -58,7 +58,7 @@ unity_zp_mul3(unity_zp f, const unity_zp g, const unity_zp h, fmpz_t * t)
     Resulting f reduced by F_9 cyclotomic polynomial.
 */
 void
-unity_zp_mul9(unity_zp f, const unity_zp g, const unity_zp h, fmpz_t * t)
+unity_zp_mul9(unity_zp_ptr f, unity_zp_srcptr g, unity_zp_srcptr h, fmpz_t * t)
 {
     /*
         g = (x0, ... , x5);

--- a/aprcl/unity_zp_mul5.c
+++ b/aprcl/unity_zp_mul5.c
@@ -18,7 +18,7 @@
     Resulting f reduced by F_5 cyclotomic polynomial.
 */
 void
-unity_zp_mul5(unity_zp f, const unity_zp g, const unity_zp h, fmpz_t * t)
+unity_zp_mul5(unity_zp_ptr f, unity_zp_srcptr g, unity_zp_srcptr h, fmpz_t * t)
 {
     /*
         g = (x0, x1, x2, x3);

--- a/aprcl/unity_zp_mul7.c
+++ b/aprcl/unity_zp_mul7.c
@@ -18,7 +18,7 @@
     Resulting f reduced by F_7 cyclotomic polynomial.
 */
 void
-unity_zp_mul7(unity_zp f, const unity_zp g, const unity_zp h, fmpz_t * t)
+unity_zp_mul7(unity_zp_ptr f, unity_zp_srcptr g, unity_zp_srcptr h, fmpz_t * t)
 {
     /*
         g = (x0, ... , x5);

--- a/aprcl/unity_zp_mul_scalar.c
+++ b/aprcl/unity_zp_mul_scalar.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-unity_zp_mul_scalar_fmpz(unity_zp f, const unity_zp g, const fmpz_t s)
+unity_zp_mul_scalar_fmpz(unity_zp_ptr f, unity_zp_srcptr g, const fmpz_t s)
 {
     FLINT_ASSERT(fmpz_equal(fmpz_mod_ctx_modulus(f->ctx),
                             fmpz_mod_ctx_modulus(g->ctx)));
@@ -21,7 +21,7 @@ unity_zp_mul_scalar_fmpz(unity_zp f, const unity_zp g, const fmpz_t s)
 }
 
 void
-unity_zp_mul_scalar_ui(unity_zp f, const unity_zp g, ulong s)
+unity_zp_mul_scalar_ui(unity_zp_ptr f, unity_zp_srcptr g, ulong s)
 {
     FLINT_ASSERT(fmpz_equal(fmpz_mod_ctx_modulus(f->ctx),
                             fmpz_mod_ctx_modulus(g->ctx)));

--- a/aprcl/unity_zp_pow.c
+++ b/aprcl/unity_zp_pow.c
@@ -12,10 +12,10 @@
 #include "aprcl.h"
 
 void
-unity_zp_pow_fmpz(unity_zp f, const unity_zp g, const fmpz_t pow)
+unity_zp_pow_fmpz(unity_zp_ptr f, unity_zp_srcptr g, const fmpz_t pow)
 {
     slong i;
-    unity_zp temp;
+    unity_zp_t temp;
 
     unity_zp_init(temp, f->p, f->exp, fmpz_mod_ctx_modulus(f->ctx));
 
@@ -42,7 +42,7 @@ unity_zp_pow_fmpz(unity_zp f, const unity_zp g, const fmpz_t pow)
 }
 
 void
-unity_zp_pow_ui(unity_zp f, const unity_zp g, ulong pow)
+unity_zp_pow_ui(unity_zp_ptr f, unity_zp_srcptr g, ulong pow)
 {
     fmpz_t p;
     fmpz_init_set_ui(p, pow);

--- a/aprcl/unity_zp_pow_2k.c
+++ b/aprcl/unity_zp_pow_2k.c
@@ -12,13 +12,13 @@
 #include "aprcl.h"
 
 void
-unity_zp_pow_2k_fmpz(unity_zp f, const unity_zp g, const fmpz_t pow)
+unity_zp_pow_2k_fmpz(unity_zp_ptr f, unity_zp_srcptr g, const fmpz_t pow)
 {
     ulong j, k, pow2k;
     slong i, e;
     fmpz_t digit;
-    unity_zp temp;
-    unity_zp *g_powers;
+    unity_zp_t temp;
+    unity_zp_t *g_powers;
 
     fmpz_init(digit);
     unity_zp_init(temp, f->p, f->exp, fmpz_mod_ctx_modulus(f->ctx));
@@ -36,7 +36,7 @@ unity_zp_pow_2k_fmpz(unity_zp f, const unity_zp g, const fmpz_t pow)
         g_powers[(i + 1) / 2] = g^i
     */
     pow2k = 1 << (k - 1);
-    g_powers = (unity_zp*) flint_malloc(sizeof(unity_zp) * (pow2k + 1));
+    g_powers = flint_malloc(sizeof(unity_zp_struct) * (pow2k + 1));
 
     /* sets g_powers[0] = 1 */
     unity_zp_init(g_powers[0], f->p, f->exp, fmpz_mod_ctx_modulus(f->ctx));
@@ -118,11 +118,10 @@ unity_zp_pow_2k_fmpz(unity_zp f, const unity_zp g, const fmpz_t pow)
 }
 
 void
-unity_zp_pow_2k_ui(unity_zp f, const unity_zp g, ulong pow)
+unity_zp_pow_2k_ui(unity_zp_ptr f, unity_zp_srcptr g, ulong pow)
 {
     fmpz_t p;
     fmpz_init_set_ui(p, pow);
     unity_zp_pow_2k_fmpz(f, g, p);
     fmpz_clear(p);
 }
-

--- a/aprcl/unity_zp_pow_sliding.c
+++ b/aprcl/unity_zp_pow_sliding.c
@@ -12,12 +12,12 @@
 #include "aprcl.h"
 
 void
-unity_zp_pow_sliding_fmpz(unity_zp f, unity_zp g, const fmpz_t pow)
+unity_zp_pow_sliding_fmpz(unity_zp_ptr f, unity_zp_ptr g, const fmpz_t pow)
 {
     ulong h, k, value;
     slong i, j;
-    unity_zp temp;
-    unity_zp *g_powers;
+    unity_zp_t temp;
+    unity_zp_t *g_powers;
 
     fmpz_t * t;
     t = (fmpz_t*) flint_malloc(sizeof(fmpz_t) * SQUARING_SPACE);
@@ -39,7 +39,7 @@ unity_zp_pow_sliding_fmpz(unity_zp f, unity_zp g, const fmpz_t pow)
         g_powers store odd powers of g up to 2^k - 1;
         g_powers[(i + 1) / 2] = g^i
     */
-    g_powers = (unity_zp*) flint_malloc(sizeof(unity_zp) * (n_pow(2, k - 1) + 1));
+    g_powers = flint_malloc(sizeof(unity_zp_struct) * (n_pow(2, k - 1) + 1));
 
     /* sets g_powers[0] = 1 */
     unity_zp_init(g_powers[0], f->p, f->exp, fmpz_mod_ctx_modulus(f->ctx));
@@ -112,4 +112,3 @@ unity_zp_pow_sliding_fmpz(unity_zp f, unity_zp g, const fmpz_t pow)
 
     unity_zp_clear(temp);
 }
-

--- a/aprcl/unity_zp_print.c
+++ b/aprcl/unity_zp_print.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-unity_zp_print(const unity_zp f)
+unity_zp_print(unity_zp_srcptr f)
 {
     flint_printf("p = %wu; exp = %wu\n", f->p, f->exp);
     fmpz_mod_poly_print(f->poly, f->ctx);

--- a/aprcl/unity_zp_reduce_cyclotomic.c
+++ b/aprcl/unity_zp_reduce_cyclotomic.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-_unity_zp_reduce_cyclotomic_divmod(unity_zp f)
+_unity_zp_reduce_cyclotomic_divmod(unity_zp_ptr f)
 {
     ulong i, j, ppow1, ppow2, cycl_pow;
 
@@ -50,7 +50,7 @@ _unity_zp_reduce_cyclotomic_divmod(unity_zp f)
 }
 
 void
-_unity_zp_reduce_cyclotomic(unity_zp f)
+_unity_zp_reduce_cyclotomic(unity_zp_ptr f)
 {
     ulong i, j, ppow, cycl_pow;
 
@@ -83,7 +83,7 @@ _unity_zp_reduce_cyclotomic(unity_zp f)
 }
 
 void
-unity_zp_reduce_cyclotomic(unity_zp f, const unity_zp g)
+unity_zp_reduce_cyclotomic(unity_zp_ptr f, unity_zp_srcptr g)
 {
     unity_zp_copy(f, g);
     _unity_zp_reduce_cyclotomic(f);

--- a/aprcl/unity_zp_set_zero.c
+++ b/aprcl/unity_zp_set_zero.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-unity_zp_set_zero(unity_zp f)
+unity_zp_set_zero(unity_zp_ptr f)
 {
     fmpz_mod_poly_zero(f->poly, f->ctx);
 }

--- a/aprcl/unity_zp_sqr.c
+++ b/aprcl/unity_zp_sqr.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-unity_zp_sqr(unity_zp f, const unity_zp g)
+unity_zp_sqr(unity_zp_ptr f, unity_zp_srcptr g)
 {
     if (g->poly->length == 0)
     {
@@ -29,7 +29,7 @@ unity_zp_sqr(unity_zp f, const unity_zp g)
 }
 
 void
-unity_zp_sqr_inplace(unity_zp f, const unity_zp g, fmpz_t * t)
+unity_zp_sqr_inplace(unity_zp_ptr f, unity_zp_srcptr g, fmpz_t * t)
 {
     /* squaring for p^k = 4 */
     if (f->p == 2 && f->exp == 2)

--- a/aprcl/unity_zp_sqr11.c
+++ b/aprcl/unity_zp_sqr11.c
@@ -18,7 +18,7 @@
     Resulting f reduced by F_11 cyclotomic polynomial.
 */
 void
-unity_zp_sqr11(unity_zp f, const unity_zp g, fmpz_t * t)
+unity_zp_sqr11(unity_zp_ptr f, unity_zp_srcptr g, fmpz_t * t)
 {
     int i;
 

--- a/aprcl/unity_zp_sqr2.c
+++ b/aprcl/unity_zp_sqr2.c
@@ -18,7 +18,7 @@
     Resulting f reduced by F_4 cyclotomic polynomial.
 */
 void
-unity_zp_sqr4(unity_zp f, const unity_zp g, fmpz_t * t)
+unity_zp_sqr4(unity_zp_ptr f, unity_zp_srcptr g, fmpz_t * t)
 {
     /*
         g = (x0, x1);
@@ -49,7 +49,7 @@ unity_zp_sqr4(unity_zp f, const unity_zp g, fmpz_t * t)
     Resulting f reduced by F_8 cyclotomic polynomial.
 */
 void
-unity_zp_sqr8(unity_zp f, const unity_zp g, fmpz_t * t)
+unity_zp_sqr8(unity_zp_ptr f, unity_zp_srcptr g, fmpz_t * t)
 {
     /*
         g = (x0, x1, x2, x3);
@@ -107,7 +107,7 @@ unity_zp_sqr8(unity_zp f, const unity_zp g, fmpz_t * t)
     Resulting f reduced by F_16 cyclotomic polynomial.
 */
 void
-unity_zp_sqr16(unity_zp f, const unity_zp g, fmpz_t * t)
+unity_zp_sqr16(unity_zp_ptr f, unity_zp_srcptr g, fmpz_t * t)
 {
     ulong i;
 

--- a/aprcl/unity_zp_sqr3.c
+++ b/aprcl/unity_zp_sqr3.c
@@ -18,7 +18,7 @@
     Resulting f reduced by F_3 cyclotomic polynomial.
 */
 void
-unity_zp_sqr3(unity_zp f, const unity_zp g, fmpz_t * t)
+unity_zp_sqr3(unity_zp_ptr f, unity_zp_srcptr g, fmpz_t * t)
 {
     /*
         g = (x0, x1);
@@ -47,7 +47,7 @@ unity_zp_sqr3(unity_zp f, const unity_zp g, fmpz_t * t)
     Resulting f reduced by F_3 cyclotomic polynomial.
 */
 void
-unity_zp_sqr9(unity_zp f, const unity_zp g, fmpz_t * t)
+unity_zp_sqr9(unity_zp_ptr f, unity_zp_srcptr g, fmpz_t * t)
 {
     /*
         g = (x0, x1, x2, x3, x4, x5);

--- a/aprcl/unity_zp_sqr5.c
+++ b/aprcl/unity_zp_sqr5.c
@@ -18,7 +18,7 @@
     Resulting f reduced by F_5 cyclotomic polynomial.
 */
 void
-unity_zp_sqr5(unity_zp f, const unity_zp g, fmpz_t * t)
+unity_zp_sqr5(unity_zp_ptr f, unity_zp_srcptr g, fmpz_t * t)
 {
     /*
         g = (x0, x1, x2, x3);

--- a/aprcl/unity_zp_sqr7.c
+++ b/aprcl/unity_zp_sqr7.c
@@ -18,7 +18,7 @@
     Resulting f reduced by F_7 cyclotomic polynomial.
 */
 void
-unity_zp_sqr7(unity_zp f, const unity_zp g, fmpz_t * t)
+unity_zp_sqr7(unity_zp_ptr f, unity_zp_srcptr g, fmpz_t * t)
 {
     /*
         g = (x0, ... , x5);

--- a/aprcl/unity_zp_swap.c
+++ b/aprcl/unity_zp_swap.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-unity_zp_swap(unity_zp f, unity_zp g)
+unity_zp_swap(unity_zp_ptr f, unity_zp_ptr g)
 {
     FLINT_ASSERT(fmpz_equal(fmpz_mod_ctx_modulus(f->ctx),
                             fmpz_mod_ctx_modulus(g->ctx)));

--- a/aprcl/unity_zpq_add.c
+++ b/aprcl/unity_zpq_add.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-unity_zpq_add(unity_zpq f, const unity_zpq g, const unity_zpq h)
+unity_zpq_add(unity_zpq_ptr f, unity_zpq_srcptr g, unity_zpq_srcptr h)
 {
     ulong i;
 

--- a/aprcl/unity_zpq_clear.c
+++ b/aprcl/unity_zpq_clear.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-unity_zpq_clear(unity_zpq f)
+unity_zpq_clear(unity_zpq_ptr f)
 {
     slong i;
 

--- a/aprcl/unity_zpq_coeff_add.c
+++ b/aprcl/unity_zpq_coeff_add.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-unity_zpq_coeff_add(unity_zpq f, slong i, slong j, const fmpz_t x)
+unity_zpq_coeff_add(unity_zpq_ptr f, slong i, slong j, const fmpz_t x)
 {
     if (i >= fmpz_mod_poly_length(f->polys[j], f->ctx))
     {
@@ -27,7 +27,7 @@ unity_zpq_coeff_add(unity_zpq f, slong i, slong j, const fmpz_t x)
 }
 
 void
-unity_zpq_coeff_add_ui(unity_zpq f, slong i, slong j, ulong x)
+unity_zpq_coeff_add_ui(unity_zpq_ptr f, slong i, slong j, ulong x)
 {
     if (i >= fmpz_mod_poly_length(f->polys[j], f->ctx))
     {

--- a/aprcl/unity_zpq_coeff_set.c
+++ b/aprcl/unity_zpq_coeff_set.c
@@ -12,13 +12,13 @@
 #include "aprcl.h"
 
 void
-unity_zpq_coeff_set_fmpz(unity_zpq f, slong i, slong j, const fmpz_t x)
+unity_zpq_coeff_set_fmpz(unity_zpq_ptr f, slong i, slong j, const fmpz_t x)
 {
     fmpz_mod_poly_set_coeff_fmpz(f->polys[j], i, x, f->ctx);
 }
 
 void
-unity_zpq_coeff_set_ui(unity_zpq f, slong i, slong j, ulong x)
+unity_zpq_coeff_set_ui(unity_zpq_ptr f, slong i, slong j, ulong x)
 {
     fmpz_mod_poly_set_coeff_ui(f->polys[j], i, x, f->ctx);
 }

--- a/aprcl/unity_zpq_copy.c
+++ b/aprcl/unity_zpq_copy.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-unity_zpq_copy(unity_zpq f, const unity_zpq g)
+unity_zpq_copy(unity_zpq_ptr f, unity_zpq_srcptr g)
 {
     slong i;
 

--- a/aprcl/unity_zpq_equal.c
+++ b/aprcl/unity_zpq_equal.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 int
-unity_zpq_equal(const unity_zpq f, const unity_zpq g)
+unity_zpq_equal(unity_zpq_srcptr f, unity_zpq_srcptr g)
 {
     slong i;
 

--- a/aprcl/unity_zpq_gauss_sum.c
+++ b/aprcl/unity_zpq_gauss_sum.c
@@ -15,7 +15,7 @@
     Computes gauss sum for character \chi corresponding (q, p).
 */
 void
-unity_zpq_gauss_sum(unity_zpq f, ulong q, ulong p)
+unity_zpq_gauss_sum(unity_zpq_ptr f, ulong q, ulong p)
 {
     slong i, qinv, qpow, ppow, g;
 

--- a/aprcl/unity_zpq_gauss_sum_character_pow.c
+++ b/aprcl/unity_zpq_gauss_sum_character_pow.c
@@ -15,7 +15,7 @@
     Computes gauss sum for character \chi^n corresponding (q, p).
 */
 void
-unity_zpq_gauss_sum_character_pow(unity_zpq f, ulong q, ulong p, ulong pow)
+unity_zpq_gauss_sum_character_pow(unity_zpq_ptr f, ulong q, ulong p, ulong pow)
 {
     slong i, qinv, pinv, qpow, ppow, g;
 
@@ -36,7 +36,7 @@ unity_zpq_gauss_sum_character_pow(unity_zpq f, ulong q, ulong p, ulong pow)
     Computes gauss sum for character \chi^n corresponding (q, p).
 */
 void
-unity_zpq_gauss_sum_sigma_pow(unity_zpq f, ulong q, ulong p)
+unity_zpq_gauss_sum_sigma_pow(unity_zpq_ptr f, ulong q, ulong p)
 {
     ulong n;
 

--- a/aprcl/unity_zpq_init.c
+++ b/aprcl/unity_zpq_init.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-unity_zpq_init(unity_zpq f, ulong q, ulong p, const fmpz_t n)
+unity_zpq_init(unity_zpq_ptr f, ulong q, ulong p, const fmpz_t n)
 {
     slong i;
 

--- a/aprcl/unity_zpq_is_p_unity.c
+++ b/aprcl/unity_zpq_is_p_unity.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 slong
-unity_zpq_p_unity(const unity_zpq f)
+unity_zpq_p_unity(unity_zpq_srcptr f)
 {
     slong i;
     ulong is_punity;
@@ -34,7 +34,7 @@ unity_zpq_p_unity(const unity_zpq f)
 }
 
 int
-unity_zpq_is_p_unity(const unity_zpq f)
+unity_zpq_is_p_unity(unity_zpq_srcptr f)
 {
     if (unity_zpq_p_unity(f) != f->p)
         return 1;
@@ -43,7 +43,7 @@ unity_zpq_is_p_unity(const unity_zpq f)
 }
 
 int
-unity_zpq_is_p_unity_generator(const unity_zpq f)
+unity_zpq_is_p_unity_generator(unity_zpq_srcptr f)
 {
     slong upow = unity_zpq_p_unity(f);
 

--- a/aprcl/unity_zpq_mul.c
+++ b/aprcl/unity_zpq_mul.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-unity_zpq_mul(unity_zpq f, const unity_zpq g, const unity_zpq h)
+unity_zpq_mul(unity_zpq_ptr f, unity_zpq_srcptr g, unity_zpq_srcptr h)
 {
     slong i, j, k;
     ulong p, q;

--- a/aprcl/unity_zpq_mul_unity_p.c
+++ b/aprcl/unity_zpq_mul_unity_p.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-_unity_zpq_mul_unity_p(unity_zpq f)
+_unity_zpq_mul_unity_p(unity_zpq_ptr f)
 {
     slong i;
 
@@ -24,7 +24,7 @@ _unity_zpq_mul_unity_p(unity_zpq f)
     Computes unity_zpq * \zeta_p by swapping poly coeffs.
 */
 void
-unity_zpq_mul_unity_p_pow(unity_zpq f, const unity_zpq g, slong k)
+unity_zpq_mul_unity_p_pow(unity_zpq_ptr f, unity_zpq_srcptr g, slong k)
 {
     slong i;
 

--- a/aprcl/unity_zpq_pow.c
+++ b/aprcl/unity_zpq_pow.c
@@ -12,9 +12,9 @@
 #include "aprcl.h"
 
 void
-unity_zpq_pow(unity_zpq f, const unity_zpq g, const fmpz_t pow)
+unity_zpq_pow(unity_zpq_ptr f, unity_zpq_srcptr g, const fmpz_t pow)
 {
-    unity_zpq value;
+    unity_zpq_t value;
     fmpz_t power, rem;
 
     unity_zpq_init(value, f->q, f->p, fmpz_mod_ctx_modulus(f->ctx));
@@ -27,12 +27,12 @@ unity_zpq_pow(unity_zpq f, const unity_zpq g, const fmpz_t pow)
 
     while (fmpz_is_zero(power) == 0)
     {
-        unity_zpq temp_pow;
+        unity_zpq_t temp_pow;
 
         fmpz_fdiv_r_2exp(rem, power, 1);
         if (fmpz_is_zero(rem) == 0)
         {
-            unity_zpq temp;
+            unity_zpq_t temp;
             unity_zpq_init(temp, f->q, f->p, fmpz_mod_ctx_modulus(f->ctx));
 
             unity_zpq_mul(temp, f, value);
@@ -56,7 +56,7 @@ unity_zpq_pow(unity_zpq f, const unity_zpq g, const fmpz_t pow)
 }
 
 void
-unity_zpq_pow_ui(unity_zpq f, const unity_zpq g, ulong pow)
+unity_zpq_pow_ui(unity_zpq_ptr f, unity_zpq_srcptr g, ulong pow)
 {
     fmpz_t p;
 

--- a/aprcl/unity_zpq_scalar_mul_fmpz.c
+++ b/aprcl/unity_zpq_scalar_mul_fmpz.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-unity_zpq_scalar_mul_fmpz(unity_zpq f, const unity_zpq g, const fmpz_t s)
+unity_zpq_scalar_mul_fmpz(unity_zpq_ptr f, unity_zpq_srcptr g, const fmpz_t s)
 {
     slong i;
 

--- a/aprcl/unity_zpq_scalar_mul_ui.c
+++ b/aprcl/unity_zpq_scalar_mul_ui.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-unity_zpq_scalar_mul_ui(unity_zpq f, const unity_zpq g, ulong s)
+unity_zpq_scalar_mul_ui(unity_zpq_ptr f, unity_zpq_srcptr g, ulong s)
 {
     slong i;
 

--- a/aprcl/unity_zpq_swap.c
+++ b/aprcl/unity_zpq_swap.c
@@ -12,7 +12,7 @@
 #include "aprcl.h"
 
 void
-unity_zpq_swap(unity_zpq f, unity_zpq g)
+unity_zpq_swap(unity_zpq_ptr f, unity_zpq_ptr g)
 {
     fmpz_mod_poly_t *temp = f->polys;
     f->polys = g->polys;

--- a/aprcl/utility.c
+++ b/aprcl/utility.c
@@ -18,8 +18,8 @@ int
 _aprcl_p_ind(aprcl_config_srcptr conf, ulong p)
 {
     int i;
-    for (i = 0; i < conf->rs.num; i++)
-        if (p == conf->rs.p[i])
+    for (i = 0; i < conf->rs->num; i++)
+        if (p == conf->rs->p[i])
             return i;
     return -1;
 }

--- a/aprcl/utility.c
+++ b/aprcl/utility.c
@@ -15,7 +15,7 @@
     Returns the index of divisor p on R factors list.
 */
 int
-_aprcl_p_ind(const aprcl_config conf, ulong p)
+_aprcl_p_ind(aprcl_config_srcptr conf, ulong p)
 {
     int i;
     for (i = 0; i < conf->rs.num; i++)

--- a/arith/dedekind_cosine_sum_factored.c
+++ b/arith/dedekind_cosine_sum_factored.c
@@ -225,18 +225,18 @@ arith_hrr_expsum_factored(trig_prod_t prod, mp_limb_t k, mp_limb_t n)
         return;
     }
 
-    n_factor_init(&fac);
-    n_factor(&fac, k, 0);
+    n_factor_init(fac);
+    n_factor(fac, k, 0);
 
     /* Repeatedly factor A_k(n) into A_k1(n1)*A_k2(n2) with k1, k2 coprime */
-    for (i = 0; i + 1 < fac.num && prod->prefactor != 0; i++)
+    for (i = 0; i + 1 < fac->num && prod->prefactor != 0; i++)
     {
         mp_limb_t p, k1, k2, inv, n1, n2;
 
-        p = fac.p[i];
+        p = fac->p[i];
 
         /* k = 2 * k1 with k1 odd */
-        if (p == UWORD(2) && fac.exp[i] == 1)
+        if (p == UWORD(2) && fac->exp[i] == 1)
         {
             k2 = k / 2;
             inv = n_preinvert_limb(k2);
@@ -251,7 +251,7 @@ arith_hrr_expsum_factored(trig_prod_t prod, mp_limb_t k, mp_limb_t n)
             n = n2;
         }
         /* k = 4 * k1 with k1 odd */
-        else if (p == UWORD(2) && fac.exp[i] == 2)
+        else if (p == UWORD(2) && fac->exp[i] == 2)
         {
             k2 = k / 4;
             inv = n_preinvert_limb(k2);
@@ -271,7 +271,7 @@ arith_hrr_expsum_factored(trig_prod_t prod, mp_limb_t k, mp_limb_t n)
         {
             mp_limb_t d1, d2, e;
 
-            k1 = n_pow(fac.p[i], fac.exp[i]);
+            k1 = n_pow(fac->p[i], fac->exp[i]);
             k2 = k / k1;
 
             d1 = gcd24_tab[k1 % 24];
@@ -281,14 +281,14 @@ arith_hrr_expsum_factored(trig_prod_t prod, mp_limb_t k, mp_limb_t n)
             n1 = solve_n1(n, k1, k2, d1, d2, e);
             n2 = solve_n1(n, k2, k1, d2, d1, e);
             
-            trigprod_mul_prime_power(prod, k1, n1, fac.p[i], fac.exp[i]);
+            trigprod_mul_prime_power(prod, k1, n1, fac->p[i], fac->exp[i]);
             k = k2;
             n = n2;
         }
     }
 
-    if (fac.num != 0 && prod->prefactor != 0)
+    if (fac->num != 0 && prod->prefactor != 0)
         trigprod_mul_prime_power(prod, k, n,
-            fac.p[fac.num - 1], fac.exp[fac.num - 1]);
+            fac->p[fac->num - 1], fac->exp[fac->num - 1]);
 
 }

--- a/d_mat.h
+++ b/d_mat.h
@@ -43,41 +43,43 @@ typedef struct
 } d_mat_struct;
 
 typedef d_mat_struct d_mat_t[1];
+typedef d_mat_struct * d_mat_ptr;
+typedef const d_mat_struct * d_mat_srcptr;
 
 #define d_mat_entry(mat,i,j) (*((mat)->rows[i] + (j)))
 
 D_MAT_INLINE
-double * d_mat_entry_ptr(const d_mat_t mat, slong i, slong j)
+double * d_mat_entry_ptr(d_mat_srcptr mat, slong i, slong j)
 {
    return mat->rows[i] + j;
 }
 
 D_MAT_INLINE
-double d_mat_get_entry(const d_mat_t mat, slong i, slong j)
+double d_mat_get_entry(d_mat_srcptr mat, slong i, slong j)
 {
    return mat->rows[i][j];
 }
 
 D_MAT_INLINE
-slong d_mat_nrows(const d_mat_t mat)
+slong d_mat_nrows(d_mat_srcptr mat)
 {
     return mat->r;
 }
 
 D_MAT_INLINE
-slong d_mat_ncols(const d_mat_t mat)
+slong d_mat_ncols(d_mat_srcptr mat)
 {
     return mat->c;
 }
 
 /* Memory management  ********************************************************/
 
-FLINT_DLL void d_mat_init(d_mat_t mat, slong rows, slong cols);
+FLINT_DLL void d_mat_init(d_mat_ptr mat, slong rows, slong cols);
 
-FLINT_DLL void d_mat_swap(d_mat_t mat1, d_mat_t mat2);
+FLINT_DLL void d_mat_swap(d_mat_ptr mat1, d_mat_ptr mat2);
 
 D_MAT_INLINE void
-d_mat_swap_entrywise(d_mat_t mat1, d_mat_t mat2)
+d_mat_swap_entrywise(d_mat_ptr mat1, d_mat_ptr mat2)
 {
     slong i, j;
     for (i = 0; i < d_mat_nrows(mat1); i++)
@@ -89,56 +91,56 @@ d_mat_swap_entrywise(d_mat_t mat1, d_mat_t mat2)
     }
 }
 
-FLINT_DLL void d_mat_set(d_mat_t mat1, const d_mat_t mat2);
+FLINT_DLL void d_mat_set(d_mat_ptr mat1, d_mat_srcptr mat2);
 
-FLINT_DLL void d_mat_clear(d_mat_t mat);
+FLINT_DLL void d_mat_clear(d_mat_ptr mat);
 
-FLINT_DLL int d_mat_equal(const d_mat_t mat1, const d_mat_t mat2);
+FLINT_DLL int d_mat_equal(d_mat_srcptr mat1, d_mat_srcptr mat2);
 
-FLINT_DLL int d_mat_approx_equal(const d_mat_t mat1, const d_mat_t mat2, double eps);
+FLINT_DLL int d_mat_approx_equal(d_mat_srcptr mat1, d_mat_srcptr mat2, double eps);
 
-FLINT_DLL int d_mat_is_zero(const d_mat_t mat);
+FLINT_DLL int d_mat_is_zero(d_mat_srcptr mat);
 
-FLINT_DLL int d_mat_is_approx_zero(const d_mat_t mat, double eps);
+FLINT_DLL int d_mat_is_approx_zero(d_mat_srcptr mat, double eps);
 
 D_MAT_INLINE
-int d_mat_is_empty(const d_mat_t mat)
+int d_mat_is_empty(d_mat_srcptr mat)
 {
     return (mat->r == 0) || (mat->c == 0);
 }
 
 D_MAT_INLINE
-int d_mat_is_square(const d_mat_t mat)
+int d_mat_is_square(d_mat_srcptr mat)
 {
     return (mat->r == mat->c);
 }
 
-FLINT_DLL void d_mat_zero(d_mat_t mat);
+FLINT_DLL void d_mat_zero(d_mat_ptr mat);
 
-FLINT_DLL void d_mat_one(d_mat_t mat);
+FLINT_DLL void d_mat_one(d_mat_ptr mat);
 
 
 /* Input and output  *********************************************************/
 
-FLINT_DLL void d_mat_print(const d_mat_t mat);
+FLINT_DLL void d_mat_print(d_mat_srcptr mat);
 
 /* Random matrix generation  *************************************************/
 
-FLINT_DLL void d_mat_randtest(d_mat_t mat, flint_rand_t state, slong minexp,
+FLINT_DLL void d_mat_randtest(d_mat_ptr mat, flint_rand_t state, slong minexp,
                     slong maxexp);
 
 /* Transpose */
 
-FLINT_DLL void d_mat_transpose(d_mat_t B, const d_mat_t A);
+FLINT_DLL void d_mat_transpose(d_mat_ptr B, d_mat_srcptr A);
 
 /* Multiplication */
 
-FLINT_DLL void d_mat_mul_classical(d_mat_t C, const d_mat_t A, const d_mat_t B);
+FLINT_DLL void d_mat_mul_classical(d_mat_ptr C, d_mat_srcptr A, d_mat_srcptr B);
 
 /* Permutations */
 
 D_MAT_INLINE
-void d_mat_swap_rows(d_mat_t mat, slong r, slong s)
+void d_mat_swap_rows(d_mat_ptr mat, slong r, slong s)
 {
     if (r != s)
     {
@@ -152,9 +154,9 @@ void d_mat_swap_rows(d_mat_t mat, slong r, slong s)
 
 /* Gram-Schmidt Orthogonalisation and QR Decomposition  ********************************************************/
 
-FLINT_DLL void d_mat_gso(d_mat_t B, const d_mat_t A);
+FLINT_DLL void d_mat_gso(d_mat_ptr B, d_mat_srcptr A);
 
-FLINT_DLL void d_mat_qr(d_mat_t Q, d_mat_t R, const d_mat_t A);
+FLINT_DLL void d_mat_qr(d_mat_ptr Q, d_mat_ptr R, d_mat_srcptr A);
 
 #ifdef __cplusplus
 }

--- a/d_mat.h
+++ b/d_mat.h
@@ -126,7 +126,7 @@ FLINT_DLL void d_mat_print(d_mat_srcptr mat);
 
 /* Random matrix generation  *************************************************/
 
-FLINT_DLL void d_mat_randtest(d_mat_ptr mat, flint_rand_t state, slong minexp,
+FLINT_DLL void d_mat_randtest(d_mat_ptr mat, flint_rand_ptr state, slong minexp,
                     slong maxexp);
 
 /* Transpose */

--- a/d_mat/approx_equal.c
+++ b/d_mat/approx_equal.c
@@ -13,7 +13,7 @@
 #include "d_mat.h"
 
 int
-d_mat_approx_equal(const d_mat_t mat1, const d_mat_t mat2, double eps)
+d_mat_approx_equal(d_mat_srcptr mat1, d_mat_srcptr mat2, double eps)
 {
     slong j;
 

--- a/d_mat/clear.c
+++ b/d_mat/clear.c
@@ -13,7 +13,7 @@
 #include "d_mat.h"
 
 void
-d_mat_clear(d_mat_t mat)
+d_mat_clear(d_mat_ptr mat)
 {
     if (mat->entries)
     {

--- a/d_mat/equal.c
+++ b/d_mat/equal.c
@@ -13,7 +13,7 @@
 #include "d_mat.h"
 
 int
-d_mat_equal(const d_mat_t mat1, const d_mat_t mat2)
+d_mat_equal(d_mat_srcptr mat1, d_mat_srcptr mat2)
 {
     slong j;
 

--- a/d_mat/gso.c
+++ b/d_mat/gso.c
@@ -12,7 +12,7 @@
 #include "d_mat.h"
 
 void
-d_mat_gso(d_mat_t B, const d_mat_t A)
+d_mat_gso(d_mat_ptr B, d_mat_srcptr A)
 {
     slong i, j, k;
     int flag;

--- a/d_mat/init.c
+++ b/d_mat/init.c
@@ -13,7 +13,7 @@
 #include "d_mat.h"
 
 void
-d_mat_init(d_mat_t mat, slong rows, slong cols)
+d_mat_init(d_mat_ptr mat, slong rows, slong cols)
 {
     slong i;
     

--- a/d_mat/is_approx_zero.c
+++ b/d_mat/is_approx_zero.c
@@ -13,7 +13,7 @@
 #include "d_mat.h"
 
 int
-d_mat_is_approx_zero(const d_mat_t mat, double eps)
+d_mat_is_approx_zero(d_mat_srcptr mat, double eps)
 {
     slong j;
 

--- a/d_mat/is_zero.c
+++ b/d_mat/is_zero.c
@@ -13,7 +13,7 @@
 #include "d_mat.h"
 
 int
-d_mat_is_zero(const d_mat_t mat)
+d_mat_is_zero(d_mat_srcptr mat)
 {
     slong j;
 

--- a/d_mat/mul_classical.c
+++ b/d_mat/mul_classical.c
@@ -13,7 +13,7 @@
 #include "d_mat.h"
 
 void
-d_mat_mul_classical(d_mat_t C, const d_mat_t A, const d_mat_t B)
+d_mat_mul_classical(d_mat_ptr C, d_mat_srcptr A, d_mat_srcptr B)
 {
     slong ar, bc, br;
     slong jj, kk, i, j, k, blocksize;

--- a/d_mat/one.c
+++ b/d_mat/one.c
@@ -13,7 +13,7 @@
 #include "d_mat.h"
 
 void
-d_mat_one(d_mat_t mat)
+d_mat_one(d_mat_ptr mat)
 {
     slong i, n;
 

--- a/d_mat/print.c
+++ b/d_mat/print.c
@@ -13,7 +13,7 @@
 #include "d_mat.h"
 
 void
-d_mat_print(const d_mat_t mat)
+d_mat_print(d_mat_srcptr mat)
 {
     slong i, j;
 

--- a/d_mat/qr.c
+++ b/d_mat/qr.c
@@ -12,7 +12,7 @@
 #include "d_mat.h"
 
 void
-d_mat_qr(d_mat_t Q, d_mat_t R, const d_mat_t A)
+d_mat_qr(d_mat_ptr Q, d_mat_ptr R, d_mat_srcptr A)
 {
     slong i, j, k;
     int flag, orig;

--- a/d_mat/randtest.c
+++ b/d_mat/randtest.c
@@ -13,7 +13,7 @@
 #include "d_mat.h"
 
 void
-d_mat_randtest(d_mat_ptr mat, flint_rand_t state, slong minexp, slong maxexp)
+d_mat_randtest(d_mat_ptr mat, flint_rand_ptr state, slong minexp, slong maxexp)
 {
     slong r, c, i, j;
 

--- a/d_mat/randtest.c
+++ b/d_mat/randtest.c
@@ -13,7 +13,7 @@
 #include "d_mat.h"
 
 void
-d_mat_randtest(d_mat_t mat, flint_rand_t state, slong minexp, slong maxexp)
+d_mat_randtest(d_mat_ptr mat, flint_rand_t state, slong minexp, slong maxexp)
 {
     slong r, c, i, j;
 

--- a/d_mat/set.c
+++ b/d_mat/set.c
@@ -14,7 +14,7 @@
 #include "d_mat.h"
 
 void
-d_mat_set(d_mat_t mat1, const d_mat_t mat2)
+d_mat_set(d_mat_ptr mat1, d_mat_srcptr mat2)
 {
     if (mat1 != mat2)
     {

--- a/d_mat/swap.c
+++ b/d_mat/swap.c
@@ -13,7 +13,7 @@
 #include "d_mat.h"
 
 void
-d_mat_swap(d_mat_t mat1, d_mat_t mat2)
+d_mat_swap(d_mat_ptr mat1, d_mat_ptr mat2)
 {
     if (mat1 != mat2)
     {

--- a/d_mat/transpose.c
+++ b/d_mat/transpose.c
@@ -13,7 +13,7 @@
 #include "d_mat.h"
 
 void
-d_mat_transpose(d_mat_t B, const d_mat_t A)
+d_mat_transpose(d_mat_ptr B, d_mat_srcptr A)
 {
     slong ii, jj, i, j, blocksize;
     blocksize = 64 / sizeof(double);

--- a/d_mat/zero.c
+++ b/d_mat/zero.c
@@ -13,7 +13,7 @@
 #include "d_mat.h"
 
 void
-d_mat_zero(d_mat_t mat)
+d_mat_zero(d_mat_ptr mat)
 {
     slong i;
 

--- a/d_vec.h
+++ b/d_vec.h
@@ -34,7 +34,7 @@ FLINT_DLL void _d_vec_clear(double * vec);
 
 /*  Randomisation  ***********************************************************/
 
-FLINT_DLL void _d_vec_randtest(double * f, flint_rand_t state, 
+FLINT_DLL void _d_vec_randtest(double * f, flint_rand_ptr state,
                         slong len, slong minexp, slong maxexp);
 
 /*  Assignment and basic manipulation  ***************************************/

--- a/d_vec/randtest.c
+++ b/d_vec/randtest.c
@@ -12,7 +12,7 @@
 #include "d_vec.h"
 
 void
-_d_vec_randtest(double *f, flint_rand_t state, slong len, slong minexp,
+_d_vec_randtest(double *f, flint_rand_ptr state, slong len, slong minexp,
                 slong maxexp)
 {
     slong i;

--- a/doc/source/aprcl.rst
+++ b/doc/source/aprcl.rst
@@ -1,7 +1,7 @@
 .. _aprcl:
 
 **aprcl.h** -- APRCL primality testing
-========================================================================================
+================================================================================
 
 This module implements the rigorous APRCL primality test, suitable for integers
 up to a few thousand digits.
@@ -9,6 +9,43 @@ up to a few thousand digits.
 Authors:
 
 * Vladimir Glazachev (Google Summer of Code, 2015)
+
+
+Types
+--------------------------------------------------------------------------------
+
+.. type:: aprcl_config_t
+
+    A one-element array holding an element of type ``aprcl_config_struct``,
+    containing precomputed parameters for primality testing.
+
+.. type:: unity_zp_t
+
+    A one-element array holding an element of type ``unity_zp_struct``, which
+    represents an element in `\mathbb{Z}[\zeta_{p^{exp}}]/(n)` as an
+    :type:`fmpz_mod_poly_t` reduced modulo a cyclotomic polynomial.
+
+.. type:: unity_zpq
+
+    A one-element array holding an element of type ``unity_zpq_struct``, which
+    represents an element in `\mathbb{Z}[\zeta_q, \zeta_p]/(n)` as an
+    :type:`fmpz_mod_poly_t`.
+
+
+.. type:: aprcl_config_ptr
+.. type:: unity_zp_ptr
+.. type:: unity_zpq_ptr
+
+    Pointer to the corresponding struct.
+
+
+.. type:: aprcl_config_srcptr
+.. type:: unity_zp_srcptr
+.. type:: unity_zpq_srcptr
+
+    Pointer to a constant object of corresponding struct.
+
+
 
 Primality test functions
 --------------------------------------------------------------------------------
@@ -42,13 +79,13 @@ Primality test functions
     To handle this condition, the :func:`_aprcl_is_prime_jacobi` function
     can be used.
 
-.. function:: primality_test_status _aprcl_is_prime_jacobi(const fmpz_t n, const aprcl_config config)
+.. function:: primality_test_status _aprcl_is_prime_jacobi(const fmpz_t n, const aprcl_config_t config)
 
     Jacobi sum test for `n`. Possible return values:
     ``PRIME``, ``COMPOSITE`` and ``UNKNOWN`` (if we cannot
     prove primality).
 
-.. function:: primality_test_status _aprcl_is_prime_gauss(const fmpz_t n, const aprcl_config config)
+.. function:: primality_test_status _aprcl_is_prime_gauss(const fmpz_t n, const aprcl_config_t config)
 
     Tests `n` for primality with fixed ``config``. Possible return values:
     ``PRIME``, ``COMPOSITE`` and ``PROBABPRIME``
@@ -66,24 +103,18 @@ Primality test functions
 Configuration functions
 --------------------------------------------------------------------------------
 
-.. type:: _aprcl_config
-
-.. type:: aprcl_config
-
-    Holds precomputed parameters.
-
-.. function:: void aprcl_config_gauss_init(aprcl_config conf, const fmpz_t n)
+.. function:: void aprcl_config_gauss_init(aprcl_config_t conf, const fmpz_t n)
 
     Computes the `s` and `R` values used in the cyclotomic primality test,
     `s^2 > n` and `s=\prod\limits_{\substack{q-1|R \\ q \text{ prime}}}q`.
     Also stores factors of `R` and `s`.
 
-.. function:: void aprcl_config_gauss_init_min_R(aprcl_config conf, const fmpz_t n, ulong R)
+.. function:: void aprcl_config_gauss_init_min_R(aprcl_config_t conf, const fmpz_t n, ulong R)
 
     Computes the `s` with fixed minimum `R` such that `a^R \equiv 1 \mod{s}`
     for all integer `a` coprime to `s`. 
 
-.. function:: void aprcl_config_gauss_clear(aprcl_config conf)
+.. function:: void aprcl_config_gauss_clear(aprcl_config_t conf)
 
     Clears the given ``aprcl_config`` element. It must be reinitialised in
     order to be used again.
@@ -94,13 +125,13 @@ Configuration functions
     corresponding `s` value is greater than `\sqrt{n}`. The maximum
     stored value `6983776800` allows to test numbers up to `6000` digits.
 
-.. function:: void aprcl_config_jacobi_init(aprcl_config conf, const fmpz_t n)
+.. function:: void aprcl_config_jacobi_init(aprcl_config_t conf, const fmpz_t n)
 
     Computes the `s` and `R` values used in the cyclotomic primality test,
     `s^2 > n` and `a^R \equiv 1 \mod{s}` for all `a` coprime to `s`.
     Also stores factors of `R` and `s`.
 
-.. function:: void aprcl_config_jacobi_clear(aprcl_config conf)
+.. function:: void aprcl_config_jacobi_clear(aprcl_config_t conf)
 
     Clears the given ``aprcl_config`` element. It must be reinitialised in
     order to be used again.
@@ -110,55 +141,39 @@ Cyclotomic arithmetic
 
 This code implements arithmetic in cyclotomic rings.
 
-Types
-................................................................................
-
-.. type:: _unity_zp
-
-.. type:: unity_zp
-
-    Represents an element of `\mathbb{Z}[\zeta_{p^{exp}}]/(n)` as an
-    :type:`fmpz_mod_poly_t` reduced modulo a cyclotomic polynomial.
-
-.. type:: _unity_zpq
-
-.. type:: unity_zpq
-
-    Represents an element of `\mathbb{Z}[\zeta_q, \zeta_p]/(n)`
-    as an array of :type:`fmpz_mod_poly_t`.
 
 Memory management
 ................................................................................
 
-.. function:: void unity_zp_init(unity_zp f, ulong p, ulong exp, const fmpz_t n)
+.. function:: void unity_zp_init(unity_zp_t f, ulong p, ulong exp, const fmpz_t n)
 
     Initializes `f` as an element of `\mathbb{Z}[\zeta_{p^{exp}}]/(n)`.
 
-.. function:: void unity_zp_clear(unity_zp f)
+.. function:: void unity_zp_clear(unity_zp_t f)
 
     Clears the given element. It must be reinitialised in
     order to be used again.
 
-.. function:: void unity_zp_copy(unity_zp f, const unity_zp g)
+.. function:: void unity_zp_copy(unity_zp_t f, const unity_zp_t g)
 
     Sets `f` to `g`. `f` and `g` must be initialized with same `p` and `n`.
 
-.. function:: void unity_zp_swap(unity_zp f, unity_zp q)
+.. function:: void unity_zp_swap(unity_zp_t f, unity_zp_t q)
 
     Swaps `f` and `g`. `f` and `g` must be initialized with same `p` and `n`.
 
-.. function:: void unity_zp_set_zero(unity_zp f)
+.. function:: void unity_zp_set_zero(unity_zp_t f)
 
     Sets `f` to zero.
 
 Comparison
 ................................................................................
 
-.. function:: slong unity_zp_is_unity(const unity_zp f)
+.. function:: slong unity_zp_is_unity(const unity_zp_t f)
 
     If `f = \zeta^h` returns h; otherwise returns -1.
 
-.. function:: int unity_zp_equal(const unity_zp f, const unity_zp g)
+.. function:: int unity_zp_equal(const unity_zp_t f, const unity_zp_t g)
 
     Returns nonzero if `f = g` reduced by the `p^{exp}`-th cyclotomic
     polynomial.
@@ -166,32 +181,32 @@ Comparison
 Output
 ................................................................................
 
-.. function:: void unity_zp_print(const unity_zp f)
+.. function:: void unity_zp_print(const unity_zp_t f)
 
     Prints the contents of the `f`.
 
 Coefficient management
 ................................................................................
 
-.. function:: void unity_zp_coeff_set_fmpz(unity_zp f, ulong ind, const fmpz_t x)
-              void unity_zp_coeff_set_ui(unity_zp f, ulong ind, ulong x)
+.. function:: void unity_zp_coeff_set_fmpz(unity_zp_t f, ulong ind, const fmpz_t x)
+              void unity_zp_coeff_set_ui(unity_zp_t f, ulong ind, ulong x)
 
     Sets the coefficient of `\zeta^{ind}` to `x`.
     `ind` must be less than `p^{exp}`.
 
-.. function:: void unity_zp_coeff_add_fmpz(unity_zp f, ulong ind, const fmpz_t x)
-              void unity_zp_coeff_add_ui(unity_zp f, ulong ind, ulong x)
+.. function:: void unity_zp_coeff_add_fmpz(unity_zp_t f, ulong ind, const fmpz_t x)
+              void unity_zp_coeff_add_ui(unity_zp_t f, ulong ind, ulong x)
 
     Adds `x` to the coefficient of `\zeta^{ind}`.
     `x` must be less than `n`.
     `ind` must be less than `p^{exp}`.
 
-.. function:: void unity_zp_coeff_inc(unity_zp f, ulong ind)
+.. function:: void unity_zp_coeff_inc(unity_zp_t f, ulong ind)
 
     Increments the coefficient of `\zeta^{ind}`.
     `ind` must be less than `p^{exp}`.
 
-.. function:: void unity_zp_coeff_dec(unity_zp f, ulong ind)
+.. function:: void unity_zp_coeff_dec(unity_zp_t f, ulong ind)
 
     Decrements the coefficient of `\zeta^{ind}`.
     `ind` must be less than `p^{exp}`.
@@ -199,12 +214,12 @@ Coefficient management
 Scalar multiplication
 ................................................................................
 
-.. function:: void unity_zp_mul_scalar_fmpz(unity_zp f, const unity_zp g, const fmpz_t s)
+.. function:: void unity_zp_mul_scalar_fmpz(unity_zp_t f, const unity_zp_t g, const fmpz_t s)
 
     Sets `f` to `s \cdot g`. `f` and `g` must be initialized with
     same `p`, `exp` and `n`.
 
-.. function:: void unity_zp_mul_scalar_ui(unity_zp f, const unity_zp g, ulong s)
+.. function:: void unity_zp_mul_scalar_ui(unity_zp_t f, const unity_zp_t g, ulong s)
 
     Sets `f` to `s \cdot g`. `f` and `g` must be initialized with
     same `p`, `exp` and `n`.
@@ -212,29 +227,29 @@ Scalar multiplication
 Addition and multiplication
 ................................................................................
 
-.. function:: void unity_zp_add(unity_zp f, const unity_zp g, const unity_zp h)
+.. function:: void unity_zp_add(unity_zp_t f, const unity_zp_t g, const unity_zp_t h)
 
     Sets `f` to `g + h`.
     `f`, `g` and `h` must be initialized with same `p`, `exp` and `n`.
 
-.. function:: void unity_zp_mul(unity_zp f, const unity_zp g, const unity_zp h)
+.. function:: void unity_zp_mul(unity_zp_t f, const unity_zp_t g, const unity_zp_t h)
 
     Sets `f` to `g \cdot h`.
     `f`, `g` and `h` must be initialized with same `p`, `exp` and `n`.
 
-.. function:: void unity_zp_sqr(unity_zp f, const unity_zp g)
+.. function:: void unity_zp_sqr(unity_zp_t f, const unity_zp_t g)
 
     Sets `f` to `g \cdot g`.
     `f`, `g` and `h` must be initialized with same `p`, `exp` and `n`.
 
-.. function:: void unity_zp_mul_inplace(unity_zp f, const unity_zp g, const untiy_zp h, fmpz_t * t)
+.. function:: void unity_zp_mul_inplace(unity_zp_t f, const unity_zp_t g, const untiy_zp h, fmpz_t * t)
 
     Sets `f` to `g \cdot h`. If `p^{exp} = 3, 4, 5, 7, 8, 9, 11, 16` special
     multiplication functions are used. The preallocated array `t` of ``fmpz_t`` is
     used for all computations in this case.
     `f`, `g` and `h` must be initialized with same `p`, `exp` and `n`.
 
-.. function:: void unity_zp_sqr_inplace(unity_zp f, const unity_zp g, fmpz_t * t)
+.. function:: void unity_zp_sqr_inplace(unity_zp_t f, const unity_zp_t g, fmpz_t * t)
 
     Sets `f` to `g \cdot g`. If `p^{exp} = 3, 4, 5, 7, 8, 9, 11, 16` special
     multiplication functions are used. The preallocated array `t` of ``fmpz_t`` is
@@ -244,12 +259,12 @@ Addition and multiplication
 Powering functions
 ................................................................................
 
-.. function:: void unity_zp_pow_fmpz(unity_zp f, unity_zp g, const fmpz_t pow)
+.. function:: void unity_zp_pow_fmpz(unity_zp_t f, unity_zp_t g, const fmpz_t pow)
 
     Sets `f` to `g^{pow}`. `f` and `g` must be initialized with
     same `p`, `exp` and `n`.
 
-.. function:: void unity_zp_pow_ui(unity_zp f, unity_zp g, ulong pow)
+.. function:: void unity_zp_pow_ui(unity_zp_t f, unity_zp_t g, ulong pow)
 
     Sets `f` to `g^{pow}`. `f` and `g` must be initialized with
     same `p`, `exp` and `n`.
@@ -259,17 +274,17 @@ Powering functions
     Returns the smallest integer `k` satisfying
     `\log (n) < (k(k + 1)2^{2k}) / (2^{k + 1} - k - 2) + 1`
 
-.. function:: void unity_zp_pow_2k_fmpz(unity_zp f, unity_zp g, const fmpz_t pow)
+.. function:: void unity_zp_pow_2k_fmpz(unity_zp_t f, unity_zp_t g, const fmpz_t pow)
 
     Sets `f` to `g^{pow}` using the `2^k`-ary exponentiation method.
     `f` and `g` must be initialized with same `p`, `exp` and `n`.
 
-.. function:: void unity_zp_pow_2k_ui(unity_zp f, const unity_zp g, ulong pow)
+.. function:: void unity_zp_pow_2k_ui(unity_zp_t f, const unity_zp_t g, ulong pow)
 
     Sets `f` to `g^{pow}` using the `2^k`-ary exponentiation method.
     `f` and `g` must be initialized with same `p`, `exp` and `n`.
 
-.. function:: void unity_zp_pow_sliding_fmpz(unity_zp f, unity_zp g, const fmpz_t pow)
+.. function:: void unity_zp_pow_sliding_fmpz(unity_zp_t f, unity_zp_t g, const fmpz_t pow)
 
     Sets `f` to `g^{pow}` using the sliding window exponentiation method.
     `f` and `g` must be initialized with same `p`, `exp` and `n`.
@@ -278,14 +293,14 @@ Powering functions
 Cyclotomic reduction
 ................................................................................
 
-.. function:: void _unity_zp_reduce_cyclotomic_divmod(unity_zp f)
-              void _unity_zp_reduce_cyclotomic(unity_zp f)
+.. function:: void _unity_zp_reduce_cyclotomic_divmod(unity_zp_t f)
+              void _unity_zp_reduce_cyclotomic(unity_zp_t f)
 
     Sets `f = f \bmod \Phi_{p^{exp}}`. `\Phi_{p^{exp}}` is the `p^{exp}`-th
     cyclotomic polynomial. `g` must be reduced by `x^{p^{exp}}-1` poly.
     `f` and `g` must be initialized with same `p`, `exp` and `n`.
 
-.. function:: void unity_zp_reduce_cyclotomic(unity_zp f, const unity_zp g)
+.. function:: void unity_zp_reduce_cyclotomic(unity_zp_t f, const unity_zp_t g)
 
     Sets `f = g \bmod \Phi_{p^{exp}}`. `\Phi_{p^{exp}}` is the `p^{exp}`-th
     cyclotomic polynomial.
@@ -293,12 +308,12 @@ Cyclotomic reduction
 Automorphism and inverse
 ................................................................................
 
-.. function:: void unity_zp_aut(unity_zp f, const unity_zp g, ulong x)
+.. function:: void unity_zp_aut(unity_zp_t f, const unity_zp_t g, ulong x)
 
     Sets `f = \sigma_x(g)`, the automorphism `\sigma_x(\zeta)=\zeta^x`.
     `f` and `g` must be initialized with the same `p`, `exp` and `n`.
 
-.. function:: void unity_zp_aut_inv(unity_zp f, const unity_zp g, ulong x)
+.. function:: void unity_zp_aut_inv(unity_zp_t f, const unity_zp_t g, ulong x)
 
     Sets `f = \sigma_x^{-1}(g)`, so `\sigma_x(f) = g`.
     `g` must be reduced by `\Phi_{p^{exp}}`.
@@ -311,16 +326,16 @@ Here `\chi_{p, q}` is the character defined by
 `\chi_{p, q}(g^x) = \zeta_{p^k}^x`, where `g` is
 a primitive root modulo `q`.
 
-.. function:: void unity_zp_jacobi_sum_pq(unity_zp f, ulong q, ulong p)
+.. function:: void unity_zp_jacobi_sum_pq(unity_zp_t f, ulong q, ulong p)
 
     Sets `f` to the Jacobi sum `J(p, q) = j(\chi_{p, q}, \chi_{p, q})`.
 
-.. function:: void unity_zp_jacobi_sum_2q_one(unity_zp f, ulong q)
+.. function:: void unity_zp_jacobi_sum_2q_one(unity_zp_t f, ulong q)
 
     Sets `f` to the Jacobi sum
     `J_2(q) = j(\chi_{2, q}^{2^{k - 3}}, \chi_{2, q}^{3 \cdot 2^{k - 3}}))^2`.
 
-.. function:: void unity_zp_jacobi_sum_2q_two(unity_zp f, ulong q)
+.. function:: void unity_zp_jacobi_sum_2q_two(unity_zp_t f, ulong q)
 
     Sets `f` to the Jacobi sum
     `J_3(1) = j(\chi_{2, q}, \chi_{2, q}, \chi_{2, q}) =
@@ -329,87 +344,87 @@ a primitive root modulo `q`.
 Extended rings
 ................................................................................
 
-.. function:: void unity_zpq_init(unity_zpq f, ulong q, ulong p, const fmpz_t n)
+.. function:: void unity_zpq_init(unity_zpq_t f, ulong q, ulong p, const fmpz_t n)
 
     Initializes `f` as an element of `\mathbb{Z}[\zeta_q, \zeta_p]/(n)`.
 
-.. function:: void unity_zpq_clear(unity_zpq f)
+.. function:: void unity_zpq_clear(unity_zpq_t f)
 
     Clears the given element. It must be reinitialized in
     order to be used again.
 
-.. function:: void unity_zpq_copy(unity_zpq f, const unity_zpq g)
+.. function:: void unity_zpq_copy(unity_zpq_t f, const unity_zpq_t g)
 
     Sets `f` to `g`. `f` and `g` must be initialized with
     same `p`, `q` and `n`.
 
-.. function:: void unity_zpq_swap(unity_zpq f, unity_zpq q)
+.. function:: void unity_zpq_swap(unity_zpq_t f, unity_zpq_t q)
 
     Swaps `f` and `g`. `f` and `g` must be initialized with
     same `p`, `q` and `n`.
 
-.. function:: int unity_zpq_equal(const unity_zpq f, const unity_zpq g)
+.. function:: int unity_zpq_equal(const unity_zpq_t f, const unity_zpq_t g)
 
     Returns nonzero if `f = g`.
 
-.. function:: ulong unity_zpq_p_unity(const unity_zpq f)
+.. function:: ulong unity_zpq_p_unity(const unity_zpq_t f)
 
     If `f = \zeta_p^x` returns `x in [0, p - 1]`; otherwise returns `p`.
 
-.. function:: int unity_zpq_is_p_unity(const unity_zpq f)
+.. function:: int unity_zpq_is_p_unity(const unity_zpq_t f)
 
     Returns nonzero if `f = \zeta_p^x`.
 
-.. function:: int unity_zpq_is_p_unity_generator(const unity_zpq f)
+.. function:: int unity_zpq_is_p_unity_generator(const unity_zpq_t f)
 
     Returns nonzero if `f` is a generator of the cyclic group `<\zeta_p>`.
 
-.. function:: void unity_zpq_coeff_set_fmpz(unity_zpq f, ulong i, ulong j, const fmpz_t x)
+.. function:: void unity_zpq_coeff_set_fmpz(unity_zpq_t f, ulong i, ulong j, const fmpz_t x)
 
     Sets the coefficient of `\zeta_q^i \zeta_p^j` to `x`.
     `i` must be less than `q` and `j` must be less than `p`.
 
-.. function:: void unity_zpq_coeff_set_ui(unity_zpq f, ulong i, ulong j, ulong x)
+.. function:: void unity_zpq_coeff_set_ui(unity_zpq_t f, ulong i, ulong j, ulong x)
 
     Sets the coefficient of `\zeta_q^i \zeta_p^j` to `x`.
     `i` must be less than `q` and `j` must be less then `p`.
 
-.. function:: void unity_zpq_coeff_add(unity_zpq f, ulong i, ulong j, const fmpz_t x)
+.. function:: void unity_zpq_coeff_add(unity_zpq_t f, ulong i, ulong j, const fmpz_t x)
 
     Adds `x` to the coefficient of `\zeta_p^i \zeta_q^j`. `x` must be less than `n`.
 
-.. function:: void unity_zpq_add(unity_zpq f, const unity_zpq g, const unity_zpq h)
+.. function:: void unity_zpq_add(unity_zpq_t f, const unity_zpq_t g, const unity_zpq_t h)
 
     Sets `f` to `g + h`.
     `f`, `g` and `h` must be initialized with same
     `q`, `p` and `n`.
 
-.. function:: void unity_zpq_mul(unity_zpq f, const unity_zpq g, const unity_zpq h)
+.. function:: void unity_zpq_mul(unity_zpq_t f, const unity_zpq_t g, const unity_zpq_t h)
 
     Sets the `f` to `g \cdot h`.
     `f`, `g` and `h` must be initialized with same
     `q`, `p` and `n`.
 
-.. function:: void _unity_zpq_mul_unity_p(unity_zpq f)
+.. function:: void _unity_zpq_mul_unity_p(unity_zpq_t f)
 
     Sets `f = f \cdot \zeta_p`.
 
-.. function:: void unity_zpq_mul_unity_p_pow(unity_zpq f, const unity_zpq g, ulong k)
+.. function:: void unity_zpq_mul_unity_p_pow(unity_zpq_t f, const unity_zpq_t g, ulong k)
 
     Sets `f` to `g \cdot \zeta_p^k`.
 
-.. function:: void unity_zpq_pow(unity_zpq f, unity_zpq g, const fmpz_t p)
+.. function:: void unity_zpq_pow(unity_zpq_t f, unity_zpq_t g, const fmpz_t p)
 
     Sets `f` to `g^p`. `f` and `g` must be initialized with same `p`, `q` and `n`.
 
-.. function:: void unity_zpq_pow_ui(unity_zpq f, unity_zpq g, ulong p)
+.. function:: void unity_zpq_pow_ui(unity_zpq_t f, unity_zpq_t g, ulong p)
 
     Sets `f` to `g^p`. `f` and `g` must be initialized with same `p`, `q` and `n`.
 
-.. function:: void unity_zpq_gauss_sum(unity_zpq f, ulong q, ulong p)
+.. function:: void unity_zpq_gauss_sum(unity_zpq_t f, ulong q, ulong p)
 
     Sets `f = \tau(\chi_{p, q})`.
 
-.. function:: void unity_zpq_gauss_sum_sigma_pow(unity_zpq f, ulong q, ulong p)
+.. function:: void unity_zpq_gauss_sum_sigma_pow(unity_zpq_t f, ulong q, ulong p)
 
     Sets `f = \tau^{\sigma_n}(\chi_{p, q})`.

--- a/doc/source/d_mat.rst
+++ b/doc/source/d_mat.rst
@@ -4,6 +4,22 @@
 ===============================================================================
 
 
+Types
+--------------------------------------------------------------------------------
+
+.. type:: d_mat_t
+
+    A one-element array holding an element of type ``d_mat_struct``.
+
+.. type:: d_mat_ptr
+
+    Pointer to a ``d_mat_struct``.
+
+.. type:: d_mat_srcptr
+
+    Pointer to a constant ``d_mat_struct``.
+
+
 
 Memory management
 --------------------------------------------------------------------------------

--- a/doc/source/flint.rst
+++ b/doc/source/flint.rst
@@ -28,21 +28,25 @@ Allocation Functions
 Random Numbers
 ------------------
 
-.. type:: flint_rand_s
+.. type:: flint_rand_struct
 
     A structure holding the state of a flint pseudo random number generator.
 
 .. type:: flint_rand_t
 
-    An array of length 1 of :type:`flint_rand_s`.
+    An array of length 1 of :type:`flint_rand_struct`.
 
-.. function:: flint_rand_s * flint_rand_alloc()
+.. type:: flint_rand_ptr
+
+    Pointer to a :type:`flint_rand_struct`.
+
+.. function:: flint_rand_ptr flint_rand_alloc()
 
     Allocates a ``flint_rand_t`` object to be used like a heap-allocated
     ``flint_rand_t`` in external libraries.
     The random state is not initialised.
 
-.. function:: void flint_rand_free(flint_rand_s * state)
+.. function:: void flint_rand_free(flint_rand_ptr state)
    
     Frees a random state object as allocated using :func:`flint_rand_alloc`.
 

--- a/doc/source/flintxx_functions.txt
+++ b/doc/source/flintxx_functions.txt
@@ -25,8 +25,8 @@ Rand.. cpp:functions
 
     Initialize random state.
 
-.. cpp:function:: flint_rand_t& frandxx::_data()
-.. cpp:function:: const flint_rand_t& frandxx::_data() const
+.. cpp:function:: flint_rand_ptr& frandxx::_data()
+.. cpp:function:: flint_rand_srcptr& frandxx::_data() const
 
     Obtain a reference to the underlying C random state.
 

--- a/doc/source/ulong_extras.rst
+++ b/doc/source/ulong_extras.rst
@@ -1,7 +1,27 @@
 .. _ulong-extras:
 
 **ulong_extras.h** -- arithmetic and number-theoretic functions for single-word integers
-========================================================================================
+================================================================================
+
+Types
+--------------------------------------------------------------------------------
+
+.. type:: n_factor_struct
+
+    FILL ME IN
+
+.. type:: n_factor_t
+
+    One-element array of ``n_factor_struct``.
+
+.. type:: n_factor_ptr
+
+    Pointer to ``n_factor_struct``.
+
+.. type:: n_factor_srcptr
+
+    Pointer to constant ``n_factor_struct``.
+
 
 
 Random functions 
@@ -508,7 +528,7 @@ Modular Arithmetic
     returned by the function and the location ``sqrt`` points to is set to 
     NULL. 
 
-.. function:: slong n_sqrtmodn(ulong ** sqrt, ulong a, n_factor_t * fac)
+.. function:: slong n_sqrtmodn(ulong ** sqrt, ulong a, n_factor_t fac)
 
     Computes all the square roots of ``a`` modulo ``m`` given the 
     factorisation of ``m`` in ``fac``. The roots are stored in an array 
@@ -1019,11 +1039,10 @@ Factorisation
     `p` we make repeated use of :func:`n_divrem2_precomp` until division
     by `p` is no longer possible.
 
-.. function:: void n_factor_insert(n_factor_t * factors, ulong p, ulong exp)
+.. function:: void n_factor_insert(n_factor_t factors, ulong p, ulong exp)
 
     Inserts the given prime power factor ``p^exp`` into 
-    the ``n_factor_t`` ``factors``. See the documentation for 
-    :func:`n_factor_trial` for a description of the ``n_factor_t`` type. 
+    the ``n_factor_t`` ``factors``.
 
     The algorithm performs a simple search to see if `p` already 
     exists as a prime factor in the structure. If so the exponent
@@ -1033,7 +1052,7 @@ Factorisation
     There is no test code for this function other than its use by
     the various factoring functions, which have test code.
 
-.. function:: ulong n_factor_trial_range(n_factor_t * factors, ulong n, ulong start, ulong num_primes)
+.. function:: ulong n_factor_trial_range(n_factor_t factors, ulong n, ulong start, ulong num_primes)
 
     Trial factor `n` with the first ``num_primes`` primes, but
     starting at the prime with index start (counting from zero).
@@ -1062,7 +1081,7 @@ Factorisation
     :func:`n_compute_primes` are utilised with the :func:`n_remove2_precomp`
     function.
 
-.. function:: ulong n_factor_trial(n_factor_t * factors, ulong n, ulong num_primes)
+.. function:: ulong n_factor_trial(n_factor_t factors, ulong n, ulong num_primes)
 
     This function calls :func:`n_factor_trial_range`, with the value of 
     `0` for ``start``. By default this adds factors to an already existing
@@ -1119,7 +1138,7 @@ Factorisation
     If SQUFOF fails to factor `n` we return `0`, however with 
     ``iters`` large enough this should never happen.
 
-.. function:: void n_factor(n_factor_t * factors, ulong n, int proved)
+.. function:: void n_factor(n_factor_t factors, ulong n, int proved)
 
     Factors `n` with no restrictions on `n`. If the prime factors are 
     required to be checked with a primality test, one may set 
@@ -1130,9 +1149,6 @@ Factorisation
     However, in future, this flag may produce and separately check
     a primality certificate. This may be quite slow (and probably no
     less reliable in practice).
-
-    For details on the ``n_factor_t`` structure, see 
-    :func:`n_factor_trial`.
 
     This function first tries trial factoring with a number of primes
     specified by the constant ``FLINT_FACTOR_TRIAL_PRIMES``. If the 
@@ -1151,7 +1167,7 @@ Factorisation
     ``FLINT_FACTOR_SQUFOF_ITERS``. If that fails an error results and
     the program aborts. However this should not happen in practice.
 
-.. function:: ulong n_factor_trial_partial(n_factor_t * factors, ulong n, ulong * prod, ulong num_primes, ulong limit)
+.. function:: ulong n_factor_trial_partial(n_factor_t factors, ulong n, ulong * prod, ulong num_primes, ulong limit)
 
     Attempts trial factoring of `n` with the first ``num_primes primes``, 
     but stops when the product of prime factors so far exceeds ``limit``.
@@ -1181,7 +1197,7 @@ Factorisation
     :func:`n_compute_primes` are utilised with the :func:`n_remove2_precomp`
     function.
 
-.. function:: ulong n_factor_partial(n_factor_t * factors, ulong n, ulong limit, int proved)
+.. function:: ulong n_factor_partial(n_factor_t factors, ulong n, ulong limit, int proved)
 
     Factors `n`, but stops when the product of prime factors so far 
     exceeds ``limit``.
@@ -1320,7 +1336,7 @@ Primitive Roots and Discrete Logarithms
 --------------------------------------------------------------------------------
 
 
-.. function:: ulong n_primitive_root_prime_prefactor(ulong p, n_factor_t * factors)
+.. function:: ulong n_primitive_root_prime_prefactor(ulong p, n_factor_t factors)
 
     Returns a primitive root for the multiplicative subgroup of `\mathbb{Z}/p\mathbb{Z}`
     where `p` is prime given the factorisation (``factors``) of `p - 1`.

--- a/double_extras.h
+++ b/double_extras.h
@@ -37,11 +37,11 @@
 #define D_INF HUGE_VAL
 #define D_NAN (HUGE_VAL - HUGE_VAL)
 
-FLINT_DLL double d_randtest(flint_rand_t state);
+FLINT_DLL double d_randtest(flint_rand_ptr state);
 
-FLINT_DLL double d_randtest_signed(flint_rand_t state, slong minexp, slong maxexp);
+FLINT_DLL double d_randtest_signed(flint_rand_ptr state, slong minexp, slong maxexp);
 
-FLINT_DLL double d_randtest_special(flint_rand_t state, slong minexp, slong maxexp);
+FLINT_DLL double d_randtest_special(flint_rand_ptr state, slong minexp, slong maxexp);
 
 DOUBLE_EXTRAS_INLINE
 double d_polyval(const double * poly, int len, double x)

--- a/double_extras/randtest.c
+++ b/double_extras/randtest.c
@@ -16,7 +16,7 @@
 #define EXP_MINUS_64 5.42101086242752217e-20
 
 double
-d_randtest(flint_rand_t state)
+d_randtest(flint_rand_ptr state)
 {
     mp_limb_t m1, m2;
     double t;

--- a/double_extras/randtest_signed.c
+++ b/double_extras/randtest_signed.c
@@ -14,7 +14,7 @@
 #include "ulong_extras.h"
 
 double
-d_randtest_signed(flint_rand_t state, slong minexp, slong maxexp)
+d_randtest_signed(flint_rand_ptr state, slong minexp, slong maxexp)
 {
     double d, t;
     slong exp, kind;

--- a/double_extras/randtest_special.c
+++ b/double_extras/randtest_special.c
@@ -14,7 +14,7 @@
 #include "ulong_extras.h"
 
 double
-d_randtest_special(flint_rand_t state, slong minexp, slong maxexp)
+d_randtest_special(flint_rand_ptr state, slong minexp, slong maxexp)
 {
     double d, t;
     slong exp, kind;

--- a/flint.h
+++ b/flint.h
@@ -189,12 +189,14 @@ typedef struct
     int gmp_init;
     mp_limb_t __randval;
     mp_limb_t __randval2;
-} flint_rand_s;
+} flint_rand_struct;
 
-typedef flint_rand_s flint_rand_t[1];
+typedef flint_rand_struct flint_rand_t[1];
+typedef flint_rand_struct * flint_rand_ptr;
+typedef const flint_rand_struct * flint_rand_srcptr;
 
 FLINT_INLINE
-void flint_randinit(flint_rand_t state)
+void flint_randinit(flint_rand_ptr state)
 {
    state->gmp_init = 0;
 #if FLINT64
@@ -207,14 +209,14 @@ void flint_randinit(flint_rand_t state)
 }
 
 FLINT_INLINE
-void flint_randseed(flint_rand_t state, ulong seed1, ulong seed2)
+void flint_randseed(flint_rand_ptr state, ulong seed1, ulong seed2)
 {
    state->__randval = seed1;
    state->__randval2 = seed2;
 }
 
 FLINT_INLINE
-void flint_get_randseed(ulong * seed1, ulong * seed2, flint_rand_t state)
+void flint_get_randseed(ulong * seed1, ulong * seed2, flint_rand_ptr state)
 {
    *seed1 = state->__randval;
    *seed2 = state->__randval2;
@@ -222,7 +224,7 @@ void flint_get_randseed(ulong * seed1, ulong * seed2, flint_rand_t state)
 
 
 FLINT_INLINE
-void _flint_rand_init_gmp(flint_rand_t state)
+void _flint_rand_init_gmp(flint_rand_ptr state)
 {
     if (!state->gmp_init)
     {
@@ -232,20 +234,20 @@ void _flint_rand_init_gmp(flint_rand_t state)
 }
 
 FLINT_INLINE
-void flint_randclear(flint_rand_t state)
+void flint_randclear(flint_rand_ptr state)
 {
     if (state->gmp_init)
         gmp_randclear(state->gmp_state);
 }
 
 FLINT_INLINE
-flint_rand_s * flint_rand_alloc(void)
+flint_rand_ptr flint_rand_alloc(void)
 {
-    return (flint_rand_s *) flint_malloc(sizeof(flint_rand_s));
+    return flint_malloc(sizeof(flint_rand_struct));
 }
 
 FLINT_INLINE
-void flint_rand_free(flint_rand_s * state)
+void flint_rand_free(flint_rand_ptr state)
 {
     flint_free(state);
 }

--- a/flintxx/doc/flintxx.txt
+++ b/flintxx/doc/flintxx.txt
@@ -33,8 +33,8 @@ frandxx::frandxx()
 
     Initialize random state.
 
-flint_rand_t& frandxx::_data()
-const flint_rand_t& frandxx::_data() const
+flint_rand_ptr& frandxx::_data()
+flint_rand_srcptr& frandxx::_data() const
 
     Obtain a reference to the underlying C random state.
 

--- a/flintxx/frandxx.h
+++ b/flintxx/frandxx.h
@@ -30,8 +30,8 @@ public:
     frandxx() {flint_randinit(inner);}
     ~frandxx() {flint_randclear(inner);}
 
-    flint_rand_t& _data() {return inner;}
-    const flint_rand_t& _data() const {return inner;}
+    flint_rand_ptr& _data() {return inner;}
+    flint_rand_srcptr& _data() const {return inner;}
 };
 } // flint
 

--- a/fmpq.h
+++ b/fmpq.h
@@ -214,15 +214,15 @@ FMPQ_INLINE int fmpq_print(const fmpq_t x)
     return fmpq_fprint(stdout, x);
 }
 
-FLINT_DLL void _fmpq_randtest(fmpz_t num, fmpz_t den, flint_rand_t state, flint_bitcnt_t bits);
+FLINT_DLL void _fmpq_randtest(fmpz_t num, fmpz_t den, flint_rand_ptr state, flint_bitcnt_t bits);
 
-FLINT_DLL void fmpq_randtest(fmpq_t res, flint_rand_t state, flint_bitcnt_t bits);
+FLINT_DLL void fmpq_randtest(fmpq_t res, flint_rand_ptr state, flint_bitcnt_t bits);
 
-FLINT_DLL void fmpq_randtest_not_zero(fmpq_t res, flint_rand_t state, flint_bitcnt_t bits);
+FLINT_DLL void fmpq_randtest_not_zero(fmpq_t res, flint_rand_ptr state, flint_bitcnt_t bits);
 
-FLINT_DLL void _fmpq_randbits(fmpz_t num, fmpz_t den, flint_rand_t state, flint_bitcnt_t bits);
+FLINT_DLL void _fmpq_randbits(fmpz_t num, fmpz_t den, flint_rand_ptr state, flint_bitcnt_t bits);
 
-FLINT_DLL void fmpq_randbits(fmpq_t res, flint_rand_t state, flint_bitcnt_t bits);
+FLINT_DLL void fmpq_randbits(fmpq_t res, flint_rand_ptr state, flint_bitcnt_t bits);
 
 FLINT_DLL void _fmpq_add_small(fmpz_t rnum, fmpz_t rden, slong p1, ulong q1, slong p2, ulong q2);
 

--- a/fmpq/profile/p-reconstruct_fmpz_2.c
+++ b/fmpq/profile/p-reconstruct_fmpz_2.c
@@ -15,7 +15,7 @@
 
 
 double profile_it(
-    flint_rand_t state,
+    flint_rand_ptr state,
     slong reps,
     flint_bitcnt_t Nbits,
     flint_bitcnt_t Dbits,

--- a/fmpq/randbits.c
+++ b/fmpq/randbits.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 
 void
-_fmpq_randbits(fmpz_t num, fmpz_t den, flint_rand_t state, flint_bitcnt_t bits)
+_fmpq_randbits(fmpz_t num, fmpz_t den, flint_rand_ptr state, flint_bitcnt_t bits)
 {
     fmpz_randbits(num, state, bits);
 
@@ -23,7 +23,7 @@ _fmpq_randbits(fmpz_t num, fmpz_t den, flint_rand_t state, flint_bitcnt_t bits)
     _fmpq_canonicalise(num, den);
 }
 
-void fmpq_randbits(fmpq_t res, flint_rand_t state, flint_bitcnt_t bits)
+void fmpq_randbits(fmpq_t res, flint_rand_ptr state, flint_bitcnt_t bits)
 {
     _fmpq_randbits(fmpq_numref(res), fmpq_denref(res), state, bits);
 }

--- a/fmpq/randtest.c
+++ b/fmpq/randtest.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 
 void
-_fmpq_randtest(fmpz_t num, fmpz_t den, flint_rand_t state, flint_bitcnt_t bits)
+_fmpq_randtest(fmpz_t num, fmpz_t den, flint_rand_ptr state, flint_bitcnt_t bits)
 {
     mp_limb_t x = n_randlimb(state);
 
@@ -55,12 +55,12 @@ _fmpq_randtest(fmpz_t num, fmpz_t den, flint_rand_t state, flint_bitcnt_t bits)
     _fmpq_canonicalise(num, den);
 }
 
-void fmpq_randtest(fmpq_t res, flint_rand_t state, flint_bitcnt_t bits)
+void fmpq_randtest(fmpq_t res, flint_rand_ptr state, flint_bitcnt_t bits)
 {
     _fmpq_randtest(fmpq_numref(res), fmpq_denref(res), state, bits);
 }
 
-void fmpq_randtest_not_zero(fmpq_t f, flint_rand_t state, flint_bitcnt_t bits)
+void fmpq_randtest_not_zero(fmpq_t f, flint_rand_ptr state, flint_bitcnt_t bits)
 {
     if (bits == 0)
     {

--- a/fmpq_mat.h
+++ b/fmpq_mat.h
@@ -106,9 +106,9 @@ FLINT_DLL void fmpq_mat_print(const fmpq_mat_t mat);
 
 /* Random matrix generation **************************************************/
 
-FLINT_DLL void fmpq_mat_randbits(fmpq_mat_t mat, flint_rand_t state, flint_bitcnt_t bits);
+FLINT_DLL void fmpq_mat_randbits(fmpq_mat_t mat, flint_rand_ptr state, flint_bitcnt_t bits);
 
-FLINT_DLL void fmpq_mat_randtest(fmpq_mat_t mat, flint_rand_t state, flint_bitcnt_t bits);
+FLINT_DLL void fmpq_mat_randtest(fmpq_mat_t mat, flint_rand_ptr state, flint_bitcnt_t bits);
 
 /* Special matrices **********************************************************/
 

--- a/fmpq_mat/randbits.c
+++ b/fmpq_mat/randbits.c
@@ -11,7 +11,7 @@
 
 #include "fmpq_mat.h"
 
-void fmpq_mat_randbits(fmpq_mat_t mat, flint_rand_t state, flint_bitcnt_t bits)
+void fmpq_mat_randbits(fmpq_mat_t mat, flint_rand_ptr state, flint_bitcnt_t bits)
 {
     slong i, j;
 

--- a/fmpq_mat/randtest.c
+++ b/fmpq_mat/randtest.c
@@ -11,7 +11,7 @@
 
 #include "fmpq_mat.h"
 
-void fmpq_mat_randtest(fmpq_mat_t mat, flint_rand_t state, flint_bitcnt_t bits)
+void fmpq_mat_randtest(fmpq_mat_t mat, flint_rand_ptr state, flint_bitcnt_t bits)
 {
     slong i, j;
 

--- a/fmpq_mpoly.h
+++ b/fmpq_mpoly.h
@@ -51,7 +51,7 @@ void fmpq_mpoly_ctx_init(fmpq_mpoly_ctx_t ctx,
 
 FMPQ_MPOLY_INLINE
 void fmpq_mpoly_ctx_init_rand(fmpq_mpoly_ctx_t ctx,
-                                           flint_rand_t state, slong max_nvars)
+                                           flint_rand_ptr state, slong max_nvars)
 {
     fmpz_mpoly_ctx_init_rand(ctx->zctx, state, max_nvars);
 }
@@ -575,7 +575,7 @@ FLINT_DLL void _fmpq_mpoly_push_rescale(fmpq_mpoly_t A,
 /* Random generation *********************************************************/
 
 FMPQ_MPOLY_INLINE
-void fmpq_mpoly_randtest_bounds(fmpq_mpoly_t A, flint_rand_t state,
+void fmpq_mpoly_randtest_bounds(fmpq_mpoly_t A, flint_rand_ptr state,
                    slong length, flint_bitcnt_t coeff_bits, ulong * exp_bounds,
                                                     const fmpq_mpoly_ctx_t ctx)
 {
@@ -586,7 +586,7 @@ void fmpq_mpoly_randtest_bounds(fmpq_mpoly_t A, flint_rand_t state,
 }
 
 FMPQ_MPOLY_INLINE
-void fmpq_mpoly_randtest_bound(fmpq_mpoly_t A, flint_rand_t state,
+void fmpq_mpoly_randtest_bound(fmpq_mpoly_t A, flint_rand_ptr state,
                    slong length, flint_bitcnt_t coeff_bits, ulong exp_bound,
                                                     const fmpq_mpoly_ctx_t ctx)
 {
@@ -597,7 +597,7 @@ void fmpq_mpoly_randtest_bound(fmpq_mpoly_t A, flint_rand_t state,
 }
 
 FMPQ_MPOLY_INLINE
-void fmpq_mpoly_randtest_bits(fmpq_mpoly_t A, flint_rand_t state,
+void fmpq_mpoly_randtest_bits(fmpq_mpoly_t A, flint_rand_ptr state,
                    slong length, flint_bitcnt_t coeff_bits, flint_bitcnt_t exp_bits,
                                                     const fmpq_mpoly_ctx_t ctx)
 {

--- a/fmpq_poly.h
+++ b/fmpq_poly.h
@@ -115,13 +115,13 @@ slong fmpq_poly_length(const fmpq_poly_t poly)
 
 /*  Randomisation  ***********************************************************/
 
-FLINT_DLL void fmpq_poly_randtest(fmpq_poly_t f, flint_rand_t state, 
+FLINT_DLL void fmpq_poly_randtest(fmpq_poly_t f, flint_rand_ptr state, 
                                                 slong len, flint_bitcnt_t bits_in);
 
-FLINT_DLL void fmpq_poly_randtest_unsigned(fmpq_poly_t f, flint_rand_t state, 
+FLINT_DLL void fmpq_poly_randtest_unsigned(fmpq_poly_t f, flint_rand_ptr state, 
                                                 slong len, flint_bitcnt_t bits_in);
 
-FLINT_DLL void fmpq_poly_randtest_not_zero(fmpq_poly_t f, flint_rand_t state,
+FLINT_DLL void fmpq_poly_randtest_not_zero(fmpq_poly_t f, flint_rand_ptr state,
                                                 slong len, flint_bitcnt_t bits_in);
 
 /*  Assignment and basic manipulation  ***************************************/

--- a/fmpq_poly/randtest.c
+++ b/fmpq_poly/randtest.c
@@ -20,7 +20,7 @@
 #include "fmpq_poly.h"
 #include "ulong_extras.h"
 
-void fmpq_poly_randtest(fmpq_poly_t poly, flint_rand_t state, 
+void fmpq_poly_randtest(fmpq_poly_t poly, flint_rand_ptr state, 
                         slong len, flint_bitcnt_t bits)
 {
     ulong m;
@@ -58,7 +58,7 @@ void fmpq_poly_randtest(fmpq_poly_t poly, flint_rand_t state,
     }
 }
 
-void fmpq_poly_randtest_unsigned(fmpq_poly_t poly, flint_rand_t state,
+void fmpq_poly_randtest_unsigned(fmpq_poly_t poly, flint_rand_ptr state,
                                  slong len, flint_bitcnt_t bits)
 {
     ulong m;
@@ -96,7 +96,7 @@ void fmpq_poly_randtest_unsigned(fmpq_poly_t poly, flint_rand_t state,
     }
 }
 
-void fmpq_poly_randtest_not_zero(fmpq_poly_t f, flint_rand_t state, 
+void fmpq_poly_randtest_not_zero(fmpq_poly_t f, flint_rand_ptr state, 
                                  slong len, flint_bitcnt_t bits)
 {
     if ((bits == 0) | (len == 0))

--- a/fmpq_vec.h
+++ b/fmpq_vec.h
@@ -33,11 +33,11 @@
 
 /*  Randomisation  ***********************************************************/
 
-FLINT_DLL void _fmpq_vec_randtest(fmpq * f, flint_rand_t state, 
+FLINT_DLL void _fmpq_vec_randtest(fmpq * f, flint_rand_ptr state, 
                         slong len, flint_bitcnt_t bits);
 
 FLINT_DLL void _fmpq_vec_randtest_uniq_sorted(fmpq * vec,
-                        flint_rand_t state, slong len, flint_bitcnt_t bits);
+                        flint_rand_ptr state, slong len, flint_bitcnt_t bits);
 
 /* Sorting  ******************************************************************/
 

--- a/fmpq_vec/randtest.c
+++ b/fmpq_vec/randtest.c
@@ -17,7 +17,7 @@
 #include "fmpq_vec.h"
 
 void
-_fmpq_vec_randtest(fmpq * f, flint_rand_t state, 
+_fmpq_vec_randtest(fmpq * f, flint_rand_ptr state, 
                    slong len, flint_bitcnt_t bits)
 {
     slong i, sparseness;

--- a/fmpq_vec/randtest_uniq_sorted.c
+++ b/fmpq_vec/randtest_uniq_sorted.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "fmpq_vec.h"
 
-void _fmpq_vec_randtest_uniq_sorted(fmpq * vec, flint_rand_t state, slong len, flint_bitcnt_t bits)
+void _fmpq_vec_randtest_uniq_sorted(fmpq * vec, flint_rand_ptr state, slong len, flint_bitcnt_t bits)
 {
     slong i;
     int do_again;

--- a/fmpz.h
+++ b/fmpz.h
@@ -174,21 +174,21 @@ void fmpz_clear(fmpz_t f)
         _fmpz_clear_mpz(*f);
 }
 
-FLINT_DLL void fmpz_randbits(fmpz_t f, flint_rand_t state, flint_bitcnt_t bits);
+FLINT_DLL void fmpz_randbits(fmpz_t f, flint_rand_ptr state, flint_bitcnt_t bits);
 
-FLINT_DLL void fmpz_randm(fmpz_t f, flint_rand_t state, const fmpz_t m);
+FLINT_DLL void fmpz_randm(fmpz_t f, flint_rand_ptr state, const fmpz_t m);
 
-FLINT_DLL void fmpz_randtest(fmpz_t f, flint_rand_t state, flint_bitcnt_t bits);
+FLINT_DLL void fmpz_randtest(fmpz_t f, flint_rand_ptr state, flint_bitcnt_t bits);
 
-FLINT_DLL void fmpz_randtest_unsigned(fmpz_t f, flint_rand_t state, flint_bitcnt_t bits);
+FLINT_DLL void fmpz_randtest_unsigned(fmpz_t f, flint_rand_ptr state, flint_bitcnt_t bits);
 
-FLINT_DLL void fmpz_randtest_not_zero(fmpz_t f, flint_rand_t state, flint_bitcnt_t bits);
+FLINT_DLL void fmpz_randtest_not_zero(fmpz_t f, flint_rand_ptr state, flint_bitcnt_t bits);
 
-FLINT_DLL void fmpz_randtest_mod(fmpz_t f, flint_rand_t state, const fmpz_t m);
+FLINT_DLL void fmpz_randtest_mod(fmpz_t f, flint_rand_ptr state, const fmpz_t m);
 
-FLINT_DLL void fmpz_randtest_mod_signed(fmpz_t f, flint_rand_t state, const fmpz_t m);
+FLINT_DLL void fmpz_randtest_mod_signed(fmpz_t f, flint_rand_ptr state, const fmpz_t m);
 
-FLINT_DLL void fmpz_randprime(fmpz_t f, flint_rand_t state, 
+FLINT_DLL void fmpz_randprime(fmpz_t f, flint_rand_ptr state, 
                               flint_bitcnt_t bits, int proved);
 
 FLINT_DLL slong fmpz_get_si(const fmpz_t f);

--- a/fmpz/randbits.c
+++ b/fmpz/randbits.c
@@ -18,7 +18,7 @@
 #include "fmpz.h"
 
 void
-fmpz_randbits(fmpz_t f, flint_rand_t state, flint_bitcnt_t bits)
+fmpz_randbits(fmpz_t f, flint_rand_ptr state, flint_bitcnt_t bits)
 {
     if (bits <= SMALL_FMPZ_BITCOUNT_MAX)
     {

--- a/fmpz/randm.c
+++ b/fmpz/randm.c
@@ -18,7 +18,7 @@
 #include "fmpz.h"
 
 void
-fmpz_randm(fmpz_t f, flint_rand_t state, const fmpz_t m)
+fmpz_randm(fmpz_t f, flint_rand_ptr state, const fmpz_t m)
 {
     flint_bitcnt_t bits = fmpz_bits(m);
     int sgn = fmpz_sgn(m);

--- a/fmpz/randprime.c
+++ b/fmpz/randprime.c
@@ -13,7 +13,7 @@
 #include "flint.h"
 #include "fmpz.h"
 
-void fmpz_randprime(fmpz_t f, flint_rand_t state, flint_bitcnt_t bits, int proved)
+void fmpz_randprime(fmpz_t f, flint_rand_ptr state, flint_bitcnt_t bits, int proved)
 {
     if (bits <= SMALL_FMPZ_BITCOUNT_MAX)
     {

--- a/fmpz/randtest.c
+++ b/fmpz/randtest.c
@@ -19,7 +19,7 @@
 #include "ulong_extras.h"
 
 void
-fmpz_randtest(fmpz_t f, flint_rand_t state, flint_bitcnt_t bits)
+fmpz_randtest(fmpz_t f, flint_rand_ptr state, flint_bitcnt_t bits)
 {
     ulong m;
 
@@ -31,7 +31,7 @@ fmpz_randtest(fmpz_t f, flint_rand_t state, flint_bitcnt_t bits)
 }
 
 void
-fmpz_randtest_unsigned(fmpz_t f, flint_rand_t state, flint_bitcnt_t bits)
+fmpz_randtest_unsigned(fmpz_t f, flint_rand_ptr state, flint_bitcnt_t bits)
 {
     ulong m;
 
@@ -65,7 +65,7 @@ fmpz_randtest_unsigned(fmpz_t f, flint_rand_t state, flint_bitcnt_t bits)
 }
 
 void
-fmpz_randtest_not_zero(fmpz_t f, flint_rand_t state, flint_bitcnt_t bits)
+fmpz_randtest_not_zero(fmpz_t f, flint_rand_ptr state, flint_bitcnt_t bits)
 {
     if (bits == 0)
     {

--- a/fmpz/randtest_mod.c
+++ b/fmpz/randtest_mod.c
@@ -17,7 +17,7 @@
 #include "ulong_extras.h"
 
 void
-fmpz_randtest_mod(fmpz_t f, flint_rand_t state, const fmpz_t m)
+fmpz_randtest_mod(fmpz_t f, flint_rand_ptr state, const fmpz_t m)
 {
     fmpz_t t;
 
@@ -36,7 +36,7 @@ fmpz_randtest_mod(fmpz_t f, flint_rand_t state, const fmpz_t m)
 }
 
 void
-fmpz_randtest_mod_signed(fmpz_t f, flint_rand_t state, const fmpz_t m)
+fmpz_randtest_mod_signed(fmpz_t f, flint_rand_ptr state, const fmpz_t m)
 {
     /* Randomly generate m/2 when included in the range */
     if ((n_randlimb(state) % 32 == 1) && (fmpz_fdiv_ui(m, 2) == 0))

--- a/fmpz_factor.h
+++ b/fmpz_factor.h
@@ -93,7 +93,7 @@ FLINT_DLL int fmpz_factor_pollard_brent_single(fmpz_t p_factor, fmpz_t n_in,
                                                          fmpz_t yi, fmpz_t ai, 
                                                           mp_limb_t max_iters);
 
-FLINT_DLL int fmpz_factor_pollard_brent(fmpz_t factor, flint_rand_t state,
+FLINT_DLL int fmpz_factor_pollard_brent(fmpz_t factor, flint_rand_ptr state,
                                         fmpz_t n, mp_limb_t max_tries, 
                                         mp_limb_t max_iters);
 /* Expansion *****************************************************************/
@@ -167,7 +167,7 @@ FLINT_DLL int fmpz_factor_ecm_stage_II(mp_ptr f, mp_limb_t B1, mp_limb_t B2,
                                        mp_limb_t P, mp_ptr n, ecm_t ecm_inf);
 
 FLINT_DLL int fmpz_factor_ecm(fmpz_t f, mp_limb_t curves, mp_limb_t B1,
-                        mp_limb_t B2, flint_rand_t state, const fmpz_t n_in);
+                        mp_limb_t B2, flint_rand_ptr state, const fmpz_t n_in);
 
 /* Inlines *******************************************************************/
 

--- a/fmpz_factor/ecm.c
+++ b/fmpz_factor/ecm.c
@@ -45,7 +45,7 @@ ulong n_ecm_primorial[] =
 
 int
 fmpz_factor_ecm(fmpz_t f, mp_limb_t curves, mp_limb_t B1, mp_limb_t B2,
-                flint_rand_t state, const fmpz_t n_in)
+                flint_rand_ptr state, const fmpz_t n_in)
 {
     fmpz_t sig, nm8;
     mp_limb_t P, num, maxP, mmin, mmax, mdiff, prod, maxj, n_size, cy;

--- a/fmpz_factor/extend_factor_ui.c
+++ b/fmpz_factor/extend_factor_ui.c
@@ -29,17 +29,17 @@ _fmpz_factor_extend_factor_ui(fmpz_factor_t factor, mp_limb_t n)
         return;
     }
 
-    n_factor_init(&nfac);
-    n_factor(&nfac, n, 0);
+    n_factor_init(nfac);
+    n_factor(nfac, n, 0);
 
     len = factor->num;
 
-    _fmpz_factor_fit_length(factor, len + nfac.num);
-    _fmpz_factor_set_length(factor, len + nfac.num);
+    _fmpz_factor_fit_length(factor, len + nfac->num);
+    _fmpz_factor_set_length(factor, len + nfac->num);
 
-    for (i = 0; i < nfac.num; i++)
+    for (i = 0; i < nfac->num; i++)
     {
-        fmpz_set_ui(factor->p + len + i, nfac.p[i]);
-        factor->exp[len + i] = nfac.exp[i];
+        fmpz_set_ui(factor->p + len + i, nfac->p[i]);
+        factor->exp[len + i] = nfac->exp[i];
     }
 }

--- a/fmpz_factor/pollard_brent.c
+++ b/fmpz_factor/pollard_brent.c
@@ -21,7 +21,7 @@
 #include "mpn_extras.h"
 
 int
-fmpz_factor_pollard_brent(fmpz_t p_factor, flint_rand_t state, fmpz_t n_in, 
+fmpz_factor_pollard_brent(fmpz_t p_factor, flint_rand_ptr state, fmpz_t n_in, 
                           mp_limb_t max_tries, mp_limb_t max_iters)
 {
     fmpz_t fa, fy, maxa, maxy;

--- a/fmpz_factor/test/t-factor.c
+++ b/fmpz_factor/test/t-factor.c
@@ -92,7 +92,7 @@ void check(fmpz_t n)
     fmpz_factor_clear(factor);
 }
 
-void randprime(fmpz_t p, flint_rand_t state, slong bits)
+void randprime(fmpz_t p, flint_rand_ptr state, slong bits)
 {
     fmpz_randbits(p, state, bits);
  

--- a/fmpz_factor/test/t-factor_smooth.c
+++ b/fmpz_factor/test/t-factor_smooth.c
@@ -72,7 +72,7 @@ void checkb(fmpz_t n, slong bits)
     fmpz_factor_clear(factor);
 }
 
-void randprime(fmpz_t p, flint_rand_t state, slong bits)
+void randprime(fmpz_t p, flint_rand_ptr state, slong bits)
 {
     fmpz_randbits(p, state, bits);
  

--- a/fmpz_factor/test/t-refine.c
+++ b/fmpz_factor/test/t-refine.c
@@ -13,13 +13,13 @@
 #include "fmpz.h"
 #include "fmpz_vec.h"
 
-void _fmpz_factor_randtest(fmpz_factor_t f, flint_rand_t state,
+void _fmpz_factor_randtest(fmpz_factor_t f, flint_rand_ptr state,
         slong num, flint_bitcnt_t bits);
 void _fmpz_factor_set(fmpz_factor_t z, const fmpz_factor_t x);
 int _fmpz_factor_equal(const fmpz_factor_t x, const fmpz_factor_t y);
 
 void
-_fmpz_factor_randtest(fmpz_factor_t f, flint_rand_t state,
+_fmpz_factor_randtest(fmpz_factor_t f, flint_rand_ptr state,
         slong num, flint_bitcnt_t bits)
 {
     slong i;

--- a/fmpz_lll.h
+++ b/fmpz_lll.h
@@ -81,7 +81,7 @@ FLINT_DLL void fmpz_lll_context_init(fmpz_lll_t fl, double delta, double eta,
 
 /* Random parameter generation  **********************************************/
 
-FLINT_DLL void fmpz_lll_randtest(fmpz_lll_t fl, flint_rand_t state);
+FLINT_DLL void fmpz_lll_randtest(fmpz_lll_t fl, flint_rand_ptr state);
 
 /* The various Babai's  ******************************************************/
 

--- a/fmpz_lll.h
+++ b/fmpz_lll.h
@@ -88,12 +88,12 @@ FLINT_DLL void fmpz_lll_randtest(fmpz_lll_t fl, flint_rand_t state);
 FLINT_DLL double fmpz_lll_heuristic_dot(const double * vec1, const double * vec2, slong len2,
        const fmpz_mat_t B, slong k, slong j, slong exp_adj);
 
-FLINT_DLL int fmpz_lll_check_babai(int kappa, fmpz_mat_t B, fmpz_mat_t U, d_mat_t mu, d_mat_t r, double *s,
-       d_mat_t appB, int *expo, fmpz_gram_t A,
+FLINT_DLL int fmpz_lll_check_babai(int kappa, fmpz_mat_t B, fmpz_mat_t U, d_mat_ptr mu, d_mat_ptr r, double *s,
+       d_mat_ptr appB, int *expo, fmpz_gram_t A,
        int a, int zeros, int kappamax, int n, const fmpz_lll_t fl);
 
-FLINT_DLL int fmpz_lll_check_babai_heuristic_d(int kappa, fmpz_mat_t B, fmpz_mat_t U, d_mat_t mu, d_mat_t r, double *s,
-       d_mat_t appB, int *expo, fmpz_gram_t A,
+FLINT_DLL int fmpz_lll_check_babai_heuristic_d(int kappa, fmpz_mat_t B, fmpz_mat_t U, d_mat_ptr mu, d_mat_ptr r, double *s,
+       d_mat_ptr appB, int *expo, fmpz_gram_t A,
        int a, int zeros, int kappamax, int n, const fmpz_lll_t fl);
 
 FLINT_DLL int fmpz_lll_shift(const fmpz_mat_t B);
@@ -112,12 +112,12 @@ FLINT_DLL int fmpz_lll_mpf(fmpz_mat_t B, fmpz_mat_t U, const fmpz_lll_t fl);
 
 FLINT_DLL int fmpz_lll_wrapper(fmpz_mat_t B, fmpz_mat_t U, const fmpz_lll_t fl);
 
-FLINT_DLL int fmpz_lll_advance_check_babai(int cur_kappa, int kappa, fmpz_mat_t B, fmpz_mat_t U, d_mat_t mu, d_mat_t r, double *s,
-       d_mat_t appB, int *expo, fmpz_gram_t A,
+FLINT_DLL int fmpz_lll_advance_check_babai(int cur_kappa, int kappa, fmpz_mat_t B, fmpz_mat_t U, d_mat_ptr mu, d_mat_ptr r, double *s,
+       d_mat_ptr appB, int *expo, fmpz_gram_t A,
        int a, int zeros, int kappamax, int n, const fmpz_lll_t fl);
 
-FLINT_DLL int fmpz_lll_advance_check_babai_heuristic_d(int cur_kappa, int kappa, fmpz_mat_t B, fmpz_mat_t U, d_mat_t mu, d_mat_t r, double *s,
-       d_mat_t appB, int *expo, fmpz_gram_t A,
+FLINT_DLL int fmpz_lll_advance_check_babai_heuristic_d(int cur_kappa, int kappa, fmpz_mat_t B, fmpz_mat_t U, d_mat_ptr mu, d_mat_ptr r, double *s,
+       d_mat_ptr appB, int *expo, fmpz_gram_t A,
        int a, int zeros, int kappamax, int n, const fmpz_lll_t fl);
 
 /* LLL with removals  ********************************************************/

--- a/fmpz_lll/advance_check_babai.c
+++ b/fmpz_lll/advance_check_babai.c
@@ -29,8 +29,8 @@
 #undef TYPE
 #endif
 
-#define FUNC_HEAD int fmpz_lll_advance_check_babai(int cur_kappa, int kappa, fmpz_mat_t B, fmpz_mat_t U, d_mat_t mu, d_mat_t r, double *s, \
-       d_mat_t appB, int *expo, fmpz_gram_t A, \
+#define FUNC_HEAD int fmpz_lll_advance_check_babai(int cur_kappa, int kappa, fmpz_mat_t B, fmpz_mat_t U, d_mat_ptr mu, d_mat_ptr r, double *s, \
+       d_mat_ptr appB, int *expo, fmpz_gram_t A, \
        int a, int zeros, int kappamax, int n, const fmpz_lll_t fl)
 #define LIMIT cur_kappa
 #define COMPUTE(G, I, J, C)                                 \

--- a/fmpz_lll/advance_check_babai_heuristic_d.c
+++ b/fmpz_lll/advance_check_babai_heuristic_d.c
@@ -29,8 +29,8 @@
 #undef TYPE
 #endif
 
-#define FUNC_HEAD int fmpz_lll_advance_check_babai_heuristic_d(int cur_kappa, int kappa, fmpz_mat_t B, fmpz_mat_t U, d_mat_t mu, d_mat_t r, double *s, \
-       d_mat_t appB, int *expo, fmpz_gram_t A, \
+#define FUNC_HEAD int fmpz_lll_advance_check_babai_heuristic_d(int cur_kappa, int kappa, fmpz_mat_t B, fmpz_mat_t U, d_mat_ptr mu, d_mat_ptr r, double *s, \
+       d_mat_ptr appB, int *expo, fmpz_gram_t A, \
        int a, int zeros, int kappamax, int n, const fmpz_lll_t fl)
 #define LIMIT cur_kappa
 #define COMPUTE(G, I, J, C)                                         \

--- a/fmpz_lll/check_babai.c
+++ b/fmpz_lll/check_babai.c
@@ -29,8 +29,8 @@
 #undef TYPE
 #endif
 
-#define FUNC_HEAD int fmpz_lll_check_babai(int kappa, fmpz_mat_t B, fmpz_mat_t U, d_mat_t mu, d_mat_t r, double *s, \
-       d_mat_t appB, int *expo, fmpz_gram_t A, \
+#define FUNC_HEAD int fmpz_lll_check_babai(int kappa, fmpz_mat_t B, fmpz_mat_t U, d_mat_ptr mu, d_mat_ptr r, double *s, \
+       d_mat_ptr appB, int *expo, fmpz_gram_t A, \
        int a, int zeros, int kappamax, int n, const fmpz_lll_t fl)
 #define LIMIT kappa
 #define COMPUTE(G, I, J, C)                                         \

--- a/fmpz_lll/check_babai_heuristic_d.c
+++ b/fmpz_lll/check_babai_heuristic_d.c
@@ -29,8 +29,8 @@
 #undef TYPE
 #endif
 
-#define FUNC_HEAD int fmpz_lll_check_babai_heuristic_d(int kappa, fmpz_mat_t B, fmpz_mat_t U, d_mat_t mu, d_mat_t r, double *s, \
-       d_mat_t appB, int *expo, fmpz_gram_t A, \
+#define FUNC_HEAD int fmpz_lll_check_babai_heuristic_d(int kappa, fmpz_mat_t B, fmpz_mat_t U, d_mat_ptr mu, d_mat_ptr r, double *s, \
+       d_mat_ptr appB, int *expo, fmpz_gram_t A, \
        int a, int zeros, int kappamax, int n, const fmpz_lll_t fl)
 #define LIMIT kappa
 #define COMPUTE(G, I, J, C)                                         \

--- a/fmpz_lll/profile/p-lll.c
+++ b/fmpz_lll/profile/p-lll.c
@@ -35,7 +35,7 @@ sample(void *arg, ulong count)
     fmpq_t delta, eta;
     fmpz_lll_t fl;
 
-    flint_rand_t rnd;
+    flint_rand_ptr rnd;
     fmpz_mat_t A, B, C, D;
     FLINT_TEST_INIT(state);
 

--- a/fmpz_lll/randtest.c
+++ b/fmpz_lll/randtest.c
@@ -14,7 +14,7 @@
 #include "fmpz_lll.h"
 
 void
-fmpz_lll_randtest(fmpz_lll_t fl, flint_rand_t state)
+fmpz_lll_randtest(fmpz_lll_t fl, flint_rand_ptr state)
 {
     double randd, delta, eta;
     rep_type rt;

--- a/fmpz_mat.h
+++ b/fmpz_mat.h
@@ -189,18 +189,18 @@ int fmpz_mat_read(fmpz_mat_t mat)
 
 /* Random matrix generation  *************************************************/
 
-FLINT_DLL void fmpz_mat_randbits(fmpz_mat_t mat, flint_rand_t state, flint_bitcnt_t bits);
-FLINT_DLL void fmpz_mat_randtest(fmpz_mat_t mat, flint_rand_t state, flint_bitcnt_t bits);
-FLINT_DLL void fmpz_mat_randtest_unsigned(fmpz_mat_t mat, flint_rand_t state, flint_bitcnt_t bits);
-FLINT_DLL void fmpz_mat_randintrel(fmpz_mat_t mat, flint_rand_t state, flint_bitcnt_t bits);
-FLINT_DLL void fmpz_mat_randsimdioph(fmpz_mat_t mat, flint_rand_t state, flint_bitcnt_t bits, flint_bitcnt_t bits2);
-FLINT_DLL void fmpz_mat_randntrulike(fmpz_mat_t mat, flint_rand_t state, flint_bitcnt_t bits, ulong q);
-FLINT_DLL void fmpz_mat_randntrulike2(fmpz_mat_t mat, flint_rand_t state, flint_bitcnt_t bits, ulong q);
-FLINT_DLL void fmpz_mat_randajtai(fmpz_mat_t mat, flint_rand_t state, double alpha);
-FLINT_DLL void fmpz_mat_randrank(fmpz_mat_t mat, flint_rand_t state, slong rank, flint_bitcnt_t bits);
-FLINT_DLL void fmpz_mat_randdet(fmpz_mat_t mat, flint_rand_t state, const fmpz_t det);
-FLINT_DLL void fmpz_mat_randops(fmpz_mat_t mat, flint_rand_t state, slong count);
-FLINT_DLL int fmpz_mat_randpermdiag(fmpz_mat_t mat, flint_rand_t state, const fmpz * diag, slong n);
+FLINT_DLL void fmpz_mat_randbits(fmpz_mat_t mat, flint_rand_ptr state, flint_bitcnt_t bits);
+FLINT_DLL void fmpz_mat_randtest(fmpz_mat_t mat, flint_rand_ptr state, flint_bitcnt_t bits);
+FLINT_DLL void fmpz_mat_randtest_unsigned(fmpz_mat_t mat, flint_rand_ptr state, flint_bitcnt_t bits);
+FLINT_DLL void fmpz_mat_randintrel(fmpz_mat_t mat, flint_rand_ptr state, flint_bitcnt_t bits);
+FLINT_DLL void fmpz_mat_randsimdioph(fmpz_mat_t mat, flint_rand_ptr state, flint_bitcnt_t bits, flint_bitcnt_t bits2);
+FLINT_DLL void fmpz_mat_randntrulike(fmpz_mat_t mat, flint_rand_ptr state, flint_bitcnt_t bits, ulong q);
+FLINT_DLL void fmpz_mat_randntrulike2(fmpz_mat_t mat, flint_rand_ptr state, flint_bitcnt_t bits, ulong q);
+FLINT_DLL void fmpz_mat_randajtai(fmpz_mat_t mat, flint_rand_ptr state, double alpha);
+FLINT_DLL void fmpz_mat_randrank(fmpz_mat_t mat, flint_rand_ptr state, slong rank, flint_bitcnt_t bits);
+FLINT_DLL void fmpz_mat_randdet(fmpz_mat_t mat, flint_rand_ptr state, const fmpz_t det);
+FLINT_DLL void fmpz_mat_randops(fmpz_mat_t mat, flint_rand_ptr state, slong count);
+FLINT_DLL int fmpz_mat_randpermdiag(fmpz_mat_t mat, flint_rand_ptr state, const fmpz * diag, slong n);
 
 /* Norms */
 
@@ -616,7 +616,7 @@ FLINT_DLL void fmpz_mat_hnf_minors(fmpz_mat_t H, const fmpz_mat_t A);
 FLINT_DLL void fmpz_mat_hnf_minors_transform(fmpz_mat_t H, fmpz_mat_t U, const fmpz_mat_t A);
 FLINT_DLL void fmpz_mat_hnf_modular(fmpz_mat_t H, const fmpz_mat_t A, const fmpz_t D);
 FLINT_DLL void fmpz_mat_hnf_modular_eldiv(fmpz_mat_t A, const fmpz_t D);
-FLINT_DLL void fmpz_mat_hnf_pernet_stein(fmpz_mat_t H, const fmpz_mat_t A, flint_rand_t state);
+FLINT_DLL void fmpz_mat_hnf_pernet_stein(fmpz_mat_t H, const fmpz_mat_t A, flint_rand_ptr state);
 FLINT_DLL int fmpz_mat_is_in_hnf(const fmpz_mat_t A);
 
 FLINT_DLL void fmpz_mat_snf(fmpz_mat_t S, const fmpz_mat_t A);

--- a/fmpz_mat.h
+++ b/fmpz_mat.h
@@ -638,15 +638,15 @@ FLINT_DLL void fmpz_mat_gram(fmpz_mat_t B, const fmpz_mat_t A);
 
 /* Conversions **************************************************************/
 
-FLINT_DLL int fmpz_mat_get_d_mat(d_mat_t B, const fmpz_mat_t A);
+FLINT_DLL int fmpz_mat_get_d_mat(d_mat_ptr B, const fmpz_mat_t A);
 
-FLINT_DLL int fmpz_mat_get_d_mat_transpose(d_mat_t B, const fmpz_mat_t A);
+FLINT_DLL int fmpz_mat_get_d_mat_transpose(d_mat_ptr B, const fmpz_mat_t A);
 
 FLINT_DLL void fmpz_mat_get_mpf_mat(mpf_mat_t B, const fmpz_mat_t A);
 
 /* Cholesky Decomposition ****************************************************/
 
-FLINT_DLL void fmpz_mat_chol_d(d_mat_t R, const fmpz_mat_t A);
+FLINT_DLL void fmpz_mat_chol_d(d_mat_ptr R, const fmpz_mat_t A);
 
 /* LLL ***********************************************************************/
 

--- a/fmpz_mat/chol_d.c
+++ b/fmpz_mat/chol_d.c
@@ -12,7 +12,7 @@
 #include "fmpz_mat.h"
 
 void
-fmpz_mat_chol_d(d_mat_t R, const fmpz_mat_t A)
+fmpz_mat_chol_d(d_mat_ptr R, const fmpz_mat_t A)
 {
     slong i, k, j, r = A->r;
 

--- a/fmpz_mat/get_d_mat.c
+++ b/fmpz_mat/get_d_mat.c
@@ -13,7 +13,7 @@
 #include "fmpz_mat.h"
 
 int
-fmpz_mat_get_d_mat(d_mat_t B, const fmpz_mat_t A)
+fmpz_mat_get_d_mat(d_mat_ptr B, const fmpz_mat_t A)
 {
     slong i, j;
     fmpz_t dmax;

--- a/fmpz_mat/get_d_mat_transpose.c
+++ b/fmpz_mat/get_d_mat_transpose.c
@@ -13,7 +13,7 @@
 #include "fmpz_mat.h"
 
 int
-fmpz_mat_get_d_mat_transpose(d_mat_t B, const fmpz_mat_t A)
+fmpz_mat_get_d_mat_transpose(d_mat_ptr B, const fmpz_mat_t A)
 {
     slong i, j;
     fmpz_t dmax;

--- a/fmpz_mat/hadamard.c
+++ b/fmpz_mat/hadamard.c
@@ -48,14 +48,14 @@ n_is_prime_power(mp_limb_t * p, mp_limb_t n)
     if (n < 2)
         return 0;
 
-    n_factor_init(&fac);
-    n_factor(&fac, n, 1);
+    n_factor_init(fac);
+    n_factor(fac, n, 1);
 
-    if (fac.num == 1)
+    if (fac->num == 1)
     {
         if (p != NULL)
-            *p = fac.p[0];
-        return fac.exp[0];
+            *p = fac->p[0];
+        return fac->exp[0];
     }
 
     return 0;

--- a/fmpz_mat/hnf_pernet_stein.c
+++ b/fmpz_mat/hnf_pernet_stein.c
@@ -14,7 +14,7 @@
 #include "perm.h"
 
 static void
-add_columns(fmpz_mat_t H, const fmpz_mat_t B, const fmpz_mat_t H1, flint_rand_t state)
+add_columns(fmpz_mat_t H, const fmpz_mat_t B, const fmpz_mat_t H1, flint_rand_ptr state)
 {
     int neg;
     slong i, j, n, bits;
@@ -430,7 +430,7 @@ double_det(fmpz_t d1, fmpz_t d2, const fmpz_mat_t B, const fmpz_mat_t c,
 }
 
 void
-fmpz_mat_hnf_pernet_stein(fmpz_mat_t H, const fmpz_mat_t A, flint_rand_t state)
+fmpz_mat_hnf_pernet_stein(fmpz_mat_t H, const fmpz_mat_t A, flint_rand_ptr state)
 {
     slong i, j, m, n, p, r, *P, *pivots, finished;
     fmpz_t d1, d2, g, s, t;

--- a/fmpz_mat/randajtai.c
+++ b/fmpz_mat/randajtai.c
@@ -15,7 +15,7 @@
 #include "fmpz_mat.h"
 
 void
-fmpz_mat_randajtai(fmpz_mat_t mat, flint_rand_t state, double alpha)
+fmpz_mat_randajtai(fmpz_mat_t mat, flint_rand_ptr state, double alpha)
 {
     const slong c = mat->c, r = mat->r, d = r;
 

--- a/fmpz_mat/randbits.c
+++ b/fmpz_mat/randbits.c
@@ -12,7 +12,7 @@
 #include "fmpz_mat.h"
 
 void
-fmpz_mat_randbits(fmpz_mat_t mat, flint_rand_t state, flint_bitcnt_t bits)
+fmpz_mat_randbits(fmpz_mat_t mat, flint_rand_ptr state, flint_bitcnt_t bits)
 {
     slong r, c, i, j;
 

--- a/fmpz_mat/randdet.c
+++ b/fmpz_mat/randdet.c
@@ -13,7 +13,7 @@
 #include "fmpz.h"
 
 void
-fmpz_mat_randdet(fmpz_mat_t mat, flint_rand_t state, const fmpz_t det)
+fmpz_mat_randdet(fmpz_mat_t mat, flint_rand_ptr state, const fmpz_t det)
 {
     slong i, j, k, n;
     int parity;

--- a/fmpz_mat/randintrel.c
+++ b/fmpz_mat/randintrel.c
@@ -14,7 +14,7 @@
 #include "fmpz_mat.h"
 
 void
-fmpz_mat_randintrel(fmpz_mat_t mat, flint_rand_t state, flint_bitcnt_t bits)
+fmpz_mat_randintrel(fmpz_mat_t mat, flint_rand_ptr state, flint_bitcnt_t bits)
 {
     const slong c = mat->c, r = mat->r;
 

--- a/fmpz_mat/randntrulike.c
+++ b/fmpz_mat/randntrulike.c
@@ -14,7 +14,7 @@
 #include "fmpz_mat.h"
 
 void
-fmpz_mat_randntrulike(fmpz_mat_t mat, flint_rand_t state, flint_bitcnt_t bits, ulong q)
+fmpz_mat_randntrulike(fmpz_mat_t mat, flint_rand_ptr state, flint_bitcnt_t bits, ulong q)
 {
     const slong c = mat->c, r = mat->r, d = r / 2;
 

--- a/fmpz_mat/randntrulike2.c
+++ b/fmpz_mat/randntrulike2.c
@@ -14,7 +14,7 @@
 #include "fmpz_mat.h"
 
 void
-fmpz_mat_randntrulike2(fmpz_mat_t mat, flint_rand_t state, flint_bitcnt_t bits, ulong q)
+fmpz_mat_randntrulike2(fmpz_mat_t mat, flint_rand_ptr state, flint_bitcnt_t bits, ulong q)
 {
     const slong c = mat->c, r = mat->r, d = r / 2;
 

--- a/fmpz_mat/randops.c
+++ b/fmpz_mat/randops.c
@@ -12,7 +12,7 @@
 #include "fmpz_mat.h"
 
 void
-fmpz_mat_randops(fmpz_mat_t mat, flint_rand_t state, slong count)
+fmpz_mat_randops(fmpz_mat_t mat, flint_rand_ptr state, slong count)
 {
     slong c, i, j, k;
     slong m = mat->r;

--- a/fmpz_mat/randpermdiag.c
+++ b/fmpz_mat/randpermdiag.c
@@ -13,7 +13,7 @@
 #include "perm.h"
 
 int
-fmpz_mat_randpermdiag(fmpz_mat_t mat, flint_rand_t state,
+fmpz_mat_randpermdiag(fmpz_mat_t mat, flint_rand_ptr state,
                       const fmpz * diag, slong n)
 {
     int parity;

--- a/fmpz_mat/randrank.c
+++ b/fmpz_mat/randrank.c
@@ -12,7 +12,7 @@
 #include "fmpz_mat.h"
 
 void
-fmpz_mat_randrank(fmpz_mat_t mat, flint_rand_t state, slong rank,
+fmpz_mat_randrank(fmpz_mat_t mat, flint_rand_ptr state, slong rank,
                   flint_bitcnt_t bits)
 {
     slong i;

--- a/fmpz_mat/randsimdioph.c
+++ b/fmpz_mat/randsimdioph.c
@@ -14,7 +14,7 @@
 #include "fmpz_mat.h"
 
 void
-fmpz_mat_randsimdioph(fmpz_mat_t mat, flint_rand_t state, flint_bitcnt_t bits, flint_bitcnt_t bits2)
+fmpz_mat_randsimdioph(fmpz_mat_t mat, flint_rand_ptr state, flint_bitcnt_t bits, flint_bitcnt_t bits2)
 {
     const slong c = mat->c, r = mat->r;
 

--- a/fmpz_mat/randtest.c
+++ b/fmpz_mat/randtest.c
@@ -12,7 +12,7 @@
 #include "fmpz_mat.h"
 
 void
-fmpz_mat_randtest(fmpz_mat_t mat, flint_rand_t state, flint_bitcnt_t bits)
+fmpz_mat_randtest(fmpz_mat_t mat, flint_rand_ptr state, flint_bitcnt_t bits)
 {
     slong r, c, i, j;
 

--- a/fmpz_mat/randtest_unsigned.c
+++ b/fmpz_mat/randtest_unsigned.c
@@ -12,7 +12,7 @@
 #include "fmpz_mat.h"
 
 void
-fmpz_mat_randtest_unsigned(fmpz_mat_t mat, flint_rand_t state, flint_bitcnt_t bits)
+fmpz_mat_randtest_unsigned(fmpz_mat_t mat, flint_rand_ptr state, flint_bitcnt_t bits)
 {
     slong r, c, i, j;
 

--- a/fmpz_mod.h
+++ b/fmpz_mod.h
@@ -65,10 +65,10 @@ FLINT_DLL void fmpz_mod_ctx_init(fmpz_mod_ctx_t ctx, const fmpz_t n);
 FLINT_DLL void fmpz_mod_ctx_init_ui(fmpz_mod_ctx_t ctx, ulong n);
 
 FLINT_DLL void fmpz_mod_ctx_init_rand_bits(fmpz_mod_ctx_t ctx,
-                                  flint_rand_t state, flint_bitcnt_t max_bits);
+                                  flint_rand_ptr state, flint_bitcnt_t max_bits);
 
 FLINT_DLL void fmpz_mod_ctx_init_rand_bits_prime(fmpz_mod_ctx_t ctx,
-                                  flint_rand_t state, flint_bitcnt_t max_bits);
+                                  flint_rand_ptr state, flint_bitcnt_t max_bits);
 
 FLINT_DLL void fmpz_mod_ctx_clear(fmpz_mod_ctx_t ctx);
 
@@ -230,10 +230,10 @@ FLINT_DLL void fmpz_mod_pow_ui(fmpz_t a, const fmpz_t b, ulong pow,
 FLINT_DLL int fmpz_mod_pow_fmpz(fmpz_t a, const fmpz_t b, const fmpz_t pow,
                                                      const fmpz_mod_ctx_t ctx);
 
-FLINT_DLL void fmpz_mod_rand(fmpz_t a, flint_rand_t state,
+FLINT_DLL void fmpz_mod_rand(fmpz_t a, flint_rand_ptr state,
                                                      const fmpz_mod_ctx_t ctx);
 
-FLINT_DLL void fmpz_mod_rand_not_zero(fmpz_t a, flint_rand_t state,
+FLINT_DLL void fmpz_mod_rand_not_zero(fmpz_t a, flint_rand_ptr state,
                                                      const fmpz_mod_ctx_t ctx);
 
 /* discrete logs a la Pohlig - Hellman ***************************************/

--- a/fmpz_mod/ctx_init_rand.c
+++ b/fmpz_mod/ctx_init_rand.c
@@ -12,7 +12,7 @@
 #include "fmpz_mod.h"
 
 void fmpz_mod_ctx_init_rand_bits(fmpz_mod_ctx_t ctx,
-                                   flint_rand_t state, flint_bitcnt_t max_bits)
+                                   flint_rand_ptr state, flint_bitcnt_t max_bits)
 {
     fmpz_t m;
     fmpz_init(m);
@@ -23,7 +23,7 @@ void fmpz_mod_ctx_init_rand_bits(fmpz_mod_ctx_t ctx,
 }
 
 void fmpz_mod_ctx_init_rand_bits_prime(fmpz_mod_ctx_t ctx,
-                                   flint_rand_t state, flint_bitcnt_t max_bits)
+                                   flint_rand_ptr state, flint_bitcnt_t max_bits)
 {
     fmpz_t m;
     fmpz_init(m);

--- a/fmpz_mod/rand.c
+++ b/fmpz_mod/rand.c
@@ -11,12 +11,12 @@
 
 #include "fmpz_mod.h"
 
-void fmpz_mod_rand(fmpz_t a, flint_rand_t state, const fmpz_mod_ctx_t ctx)
+void fmpz_mod_rand(fmpz_t a, flint_rand_ptr state, const fmpz_mod_ctx_t ctx)
 {
     fmpz_randm(a, state, fmpz_mod_ctx_modulus(ctx));
 }
 
-void fmpz_mod_rand_not_zero(fmpz_t a, flint_rand_t state, const fmpz_mod_ctx_t ctx)
+void fmpz_mod_rand_not_zero(fmpz_t a, flint_rand_ptr state, const fmpz_mod_ctx_t ctx)
 {
     slong i = 3;
     for (i = 0; i < 3; i++)

--- a/fmpz_mod_mat.h
+++ b/fmpz_mod_mat.h
@@ -134,19 +134,19 @@ fmpz_mod_mat_swap_entrywise(fmpz_mod_mat_t mat1, fmpz_mod_mat_t mat2)
 FLINT_DLL void _fmpz_mod_mat_reduce(fmpz_mod_mat_t mat);
 
 /* Random matrix generation */
-FLINT_DLL void fmpz_mod_mat_randtest(fmpz_mod_mat_t mat, flint_rand_t state);
+FLINT_DLL void fmpz_mod_mat_randtest(fmpz_mod_mat_t mat, flint_rand_ptr state);
 
-FLINT_DLL void fmpz_mod_mat_randrank(fmpz_mod_mat_t mat, flint_rand_t state,
+FLINT_DLL void fmpz_mod_mat_randrank(fmpz_mod_mat_t mat, flint_rand_ptr state,
                                                                    slong rank);
 
-FLINT_DLL void fmpz_mod_mat_randtril(fmpz_mod_mat_t mat, flint_rand_t state,
+FLINT_DLL void fmpz_mod_mat_randtril(fmpz_mod_mat_t mat, flint_rand_ptr state,
                                                                      int unit);
 
-FLINT_DLL void fmpz_mod_mat_randtriu(fmpz_mod_mat_t mat, flint_rand_t state,
+FLINT_DLL void fmpz_mod_mat_randtriu(fmpz_mod_mat_t mat, flint_rand_ptr state,
                                                                      int unit);
 
 FMPZ_MOD_MAT_INLINE
-void fmpz_mod_mat_randops(fmpz_mod_mat_t mat, slong count, flint_rand_t state)
+void fmpz_mod_mat_randops(fmpz_mod_mat_t mat, slong count, flint_rand_ptr state)
 {
     fmpz_mat_randops(mat->mat, state, count);
     _fmpz_mod_mat_reduce(mat);

--- a/fmpz_mod_mat/randrank.c
+++ b/fmpz_mod_mat/randrank.c
@@ -13,7 +13,7 @@
 
 #include "fmpz_mod_mat.h"
 
-void fmpz_mod_mat_randrank(fmpz_mod_mat_t mat, flint_rand_t state, slong rank)
+void fmpz_mod_mat_randrank(fmpz_mod_mat_t mat, flint_rand_ptr state, slong rank)
 {
     slong i;
     fmpz * diag;

--- a/fmpz_mod_mat/randtest.c
+++ b/fmpz_mod_mat/randtest.c
@@ -11,7 +11,7 @@
 
 #include "fmpz_mod_mat.h"
 
-void fmpz_mod_mat_randtest(fmpz_mod_mat_t mat, flint_rand_t state)
+void fmpz_mod_mat_randtest(fmpz_mod_mat_t mat, flint_rand_ptr state)
 {
     fmpz_mat_randtest(mat->mat, state, fmpz_bits(mat->mod));
     _fmpz_mod_mat_reduce(mat);

--- a/fmpz_mod_mat/randtril.c
+++ b/fmpz_mod_mat/randtril.c
@@ -13,7 +13,7 @@
 
 #include "fmpz_mod_mat.h"
 
-void fmpz_mod_mat_randtril(fmpz_mod_mat_t mat, flint_rand_t state, int unit)
+void fmpz_mod_mat_randtril(fmpz_mod_mat_t mat, flint_rand_ptr state, int unit)
 {
     fmpz* e;
     slong i, j;

--- a/fmpz_mod_mat/randtriu.c
+++ b/fmpz_mod_mat/randtriu.c
@@ -13,7 +13,7 @@
 
 #include "fmpz_mod_mat.h"
 
-void fmpz_mod_mat_randtriu(fmpz_mod_mat_t mat, flint_rand_t state, int unit)
+void fmpz_mod_mat_randtriu(fmpz_mod_mat_t mat, flint_rand_ptr state, int unit)
 {
     fmpz* e;
     slong i, j;

--- a/fmpz_mod_mat/test/t-rref.c
+++ b/fmpz_mod_mat/test/t-rref.c
@@ -21,7 +21,7 @@
 #include "ulong_extras.h"
 
 void
-fmpz_mod_mat_randrank(fmpz_mod_mat_t mat, flint_rand_t state, slong rank)
+fmpz_mod_mat_randrank(fmpz_mod_mat_t mat, flint_rand_ptr state, slong rank)
 {
     slong i;
     fmpz * diag;

--- a/fmpz_mod_mpoly.h
+++ b/fmpz_mod_mpoly.h
@@ -83,13 +83,13 @@ FLINT_DLL void fmpz_mod_mpoly_ctx_init(fmpz_mod_mpoly_ctx_t ctx,
                       slong nvars, const ordering_t ord, const fmpz_t modulus);
 
 FLINT_DLL void fmpz_mod_mpoly_ctx_init_rand(fmpz_mod_mpoly_ctx_t ctx,
-                    flint_rand_t state, slong max_nvars, const fmpz_t modulus);
+                    flint_rand_ptr state, slong max_nvars, const fmpz_t modulus);
 
 FLINT_DLL void fmpz_mod_mpoly_ctx_init_rand_bits_prime(fmpz_mod_mpoly_ctx_t ctx,
-                 flint_rand_t state, slong max_nvars, flint_bitcnt_t max_bits);
+                 flint_rand_ptr state, slong max_nvars, flint_bitcnt_t max_bits);
 
 FLINT_DLL void fmpz_mod_mpoly_ctx_init_rand_bits(fmpz_mod_mpoly_ctx_t ctx,
-                 flint_rand_t state, slong max_nvars, flint_bitcnt_t max_bits);
+                 flint_rand_ptr state, slong max_nvars, flint_bitcnt_t max_bits);
 
 FLINT_DLL void fmpz_mod_mpoly_ctx_clear(fmpz_mod_mpoly_ctx_t ctx);
 
@@ -563,15 +563,15 @@ FLINT_DLL void _fmpz_mod_mpoly_push_exp_ui(fmpz_mod_mpoly_t A,
 /* Random generation *********************************************************/
 
 FLINT_DLL void fmpz_mod_mpoly_randtest_bounds(fmpz_mod_mpoly_t A,
-                        flint_rand_t state, slong length, ulong * exp_bounds,
+                        flint_rand_ptr state, slong length, ulong * exp_bounds,
                                                const fmpz_mod_mpoly_ctx_t ctx);
 
 FLINT_DLL void fmpz_mod_mpoly_randtest_bound(fmpz_mod_mpoly_t A,
-                            flint_rand_t state, slong length, ulong exp_bound,
+                            flint_rand_ptr state, slong length, ulong exp_bound,
                                                const fmpz_mod_mpoly_ctx_t ctx);
 
 FLINT_DLL void fmpz_mod_mpoly_randtest_bits(fmpz_mod_mpoly_t A,
-                    flint_rand_t state, slong length, flint_bitcnt_t exp_bits,
+                    flint_rand_ptr state, slong length, flint_bitcnt_t exp_bits,
                                                const fmpz_mod_mpoly_ctx_t ctx);
 
 

--- a/fmpz_mod_mpoly/ctx_init_rand.c
+++ b/fmpz_mod_mpoly/ctx_init_rand.c
@@ -12,21 +12,21 @@
 #include "fmpz_mod_mpoly.h"
 
 void fmpz_mod_mpoly_ctx_init_rand(fmpz_mod_mpoly_ctx_t ctx,
-                    flint_rand_t state, slong max_nvars, const fmpz_t modulus)
+                    flint_rand_ptr state, slong max_nvars, const fmpz_t modulus)
 {
     mpoly_ctx_init_rand(ctx->minfo, state, max_nvars);
     fmpz_mod_ctx_init(ctx->ffinfo, modulus);
 }
 
 void fmpz_mod_mpoly_ctx_init_rand_bits(fmpz_mod_mpoly_ctx_t ctx,
-                  flint_rand_t state, slong max_nvars, flint_bitcnt_t max_bits)
+                  flint_rand_ptr state, slong max_nvars, flint_bitcnt_t max_bits)
 {
     mpoly_ctx_init_rand(ctx->minfo, state, max_nvars);
     fmpz_mod_ctx_init_rand_bits(ctx->ffinfo, state, max_bits);
 }
 
 void fmpz_mod_mpoly_ctx_init_rand_bits_prime(fmpz_mod_mpoly_ctx_t ctx,
-                  flint_rand_t state, slong max_nvars, flint_bitcnt_t max_bits)
+                  flint_rand_ptr state, slong max_nvars, flint_bitcnt_t max_bits)
 {
     mpoly_ctx_init_rand(ctx->minfo, state, max_nvars);
     fmpz_mod_ctx_init_rand_bits_prime(ctx->ffinfo, state, max_bits);

--- a/fmpz_mod_mpoly/randtest_bits.c
+++ b/fmpz_mod_mpoly/randtest_bits.c
@@ -11,7 +11,7 @@
 
 #include "fmpz_mod_mpoly.h"
 
-void fmpz_mod_mpoly_randtest_bits(fmpz_mod_mpoly_t A, flint_rand_t state,
+void fmpz_mod_mpoly_randtest_bits(fmpz_mod_mpoly_t A, flint_rand_ptr state,
                                   slong length, flint_bitcnt_t exp_bits,
                                                 const fmpz_mod_mpoly_ctx_t ctx)
 {

--- a/fmpz_mod_mpoly/randtest_bound.c
+++ b/fmpz_mod_mpoly/randtest_bound.c
@@ -11,7 +11,7 @@
 
 #include "fmpz_mod_mpoly.h"
 
-void fmpz_mod_mpoly_randtest_bound(fmpz_mod_mpoly_t A, flint_rand_t state,
+void fmpz_mod_mpoly_randtest_bound(fmpz_mod_mpoly_t A, flint_rand_ptr state,
                  slong length, ulong exp_bound, const fmpz_mod_mpoly_ctx_t ctx)
 {
     slong i, j, nvars = ctx->minfo->nvars;

--- a/fmpz_mod_mpoly/randtest_bounds.c
+++ b/fmpz_mod_mpoly/randtest_bounds.c
@@ -11,7 +11,7 @@
 
 #include "fmpz_mod_mpoly.h"
 
-void fmpz_mod_mpoly_randtest_bounds(fmpz_mod_mpoly_t A, flint_rand_t state,
+void fmpz_mod_mpoly_randtest_bounds(fmpz_mod_mpoly_t A, flint_rand_ptr state,
              slong length, ulong * exp_bounds, const fmpz_mod_mpoly_ctx_t ctx)
 {
     slong i, j, nvars = ctx->minfo->nvars;

--- a/fmpz_mod_mpoly_factor.h
+++ b/fmpz_mod_mpoly_factor.h
@@ -1172,17 +1172,17 @@ FLINT_DLL int fmpz_mod_mpoly_factor_lcc_wang(fmpz_mod_mpoly_struct * lc_divs,
 
 FLINT_DLL int fmpz_mod_mpoly_factor_irred_smprime_zassenhaus(
                             fmpz_mod_mpolyv_t fac, const fmpz_mod_mpoly_t A,
-                           const fmpz_mod_mpoly_ctx_t ctx, flint_rand_t state);
+                           const fmpz_mod_mpoly_ctx_t ctx, flint_rand_ptr state);
 
 FLINT_DLL int fmpz_mod_mpoly_factor_irred_smprime_wang(fmpz_mod_mpolyv_t fac,
                 const fmpz_mod_mpoly_t A, const fmpz_mod_mpoly_factor_t lcAfac,
                 const fmpz_mod_mpoly_t lcA, const fmpz_mod_mpoly_ctx_t ctx,
-                                                           flint_rand_t state);
+                                                           flint_rand_ptr state);
 
 FLINT_DLL int fmpz_mod_mpoly_factor_irred_smprime_zippel(fmpz_mod_mpolyv_t fac,
                 const fmpz_mod_mpoly_t A, const fmpz_mod_mpoly_factor_t lcAfac,
                 const fmpz_mod_mpoly_t lcA, const fmpz_mod_mpoly_ctx_t ctx,
-                                                           flint_rand_t state);
+                                                           flint_rand_ptr state);
 
 /*****************************************************************************/
 
@@ -1254,7 +1254,7 @@ FLINT_DLL int fmpz_mod_polyu3_hlift(slong r, fmpz_mod_polyun_struct * BB,
 
 FLINT_DLL int fmpz_mod_mpoly_hlift_zippel(slong m, fmpz_mod_mpoly_struct * B,
      slong r, const fmpz * alpha, const fmpz_mod_mpoly_t A, const slong * degs,
-                           const fmpz_mod_mpoly_ctx_t ctx, flint_rand_t state);
+                           const fmpz_mod_mpoly_ctx_t ctx, flint_rand_ptr state);
 
 FLINT_DLL int fmpz_mod_mpoly_factor_algo(fmpz_mod_mpoly_factor_t f,
                     const fmpz_mod_mpoly_t A, const fmpz_mod_mpoly_ctx_t ctx,
@@ -1320,7 +1320,7 @@ FLINT_DLL int fmpz_mod_mpolyl_gcdp_zippel(
     fmpz_mod_mpoly_t B,
     slong var,
     const fmpz_mod_mpoly_ctx_t ctx,
-    flint_rand_t state);
+    flint_rand_ptr state);
 
 FLINT_DLL int fmpz_mod_mpolyl_gcd_zippel2_smprime(
     fmpz_mod_mpoly_t rG, const slong * rGdegs,

--- a/fmpz_mod_mpoly_factor/gcd_zippel.c
+++ b/fmpz_mod_mpoly_factor/gcd_zippel.c
@@ -127,7 +127,7 @@ int fmpz_mod_mpolyl_gcds_zippel(
     slong l,
     slong var,
     const fmpz_mod_mpoly_ctx_t ctx,
-    flint_rand_t state,
+    flint_rand_ptr state,
     slong * Gdegbound,
     n_poly_t Amarks,
     n_poly_t Bmarks)
@@ -447,7 +447,7 @@ static int _do_bivar_or_univar(
     fmpz_mod_mpoly_t B,
     slong var,
     const fmpz_mod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     if (var == 1)
     {
@@ -545,7 +545,7 @@ int fmpz_mod_mpolyl_gcdp_zippel(
     fmpz_mod_mpoly_t B,
     slong var,
     const fmpz_mod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     flint_bitcnt_t bits = A->bits;
     slong i, j, N = mpoly_words_per_exp_sp(bits, ctx->minfo);

--- a/fmpz_mod_mpoly_factor/irred_smprime_wang.c
+++ b/fmpz_mod_mpoly_factor/irred_smprime_wang.c
@@ -22,7 +22,7 @@ int fmpz_mod_mpoly_factor_irred_smprime_wang(
     const fmpz_mod_mpoly_factor_t lcAfac,
     const fmpz_mod_mpoly_t lcA,
     const fmpz_mod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int success;
     int alphas_tries_remaining, alphabetas_tries_remaining, alphabetas_length;

--- a/fmpz_mod_mpoly_factor/irred_smprime_zassenhaus.c
+++ b/fmpz_mod_mpoly_factor/irred_smprime_zassenhaus.c
@@ -125,7 +125,7 @@ int fmpz_mod_mpoly_factor_irred_smprime_zassenhaus(
     fmpz_mod_mpolyv_t fac,
     const fmpz_mod_mpoly_t A,
     const fmpz_mod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int success;
     int tries_remaining = 10;

--- a/fmpz_mod_mpoly_factor/irred_smprime_zippel.c
+++ b/fmpz_mod_mpoly_factor/irred_smprime_zippel.c
@@ -22,7 +22,7 @@ int fmpz_mod_mpoly_factor_irred_smprime_zippel(
     const fmpz_mod_mpoly_factor_t lcAfac,
     const fmpz_mod_mpoly_t lcA,
     const fmpz_mod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int success;
     int alphas_tries_remaining, alphabetas_tries_remaining, alphabetas_length;

--- a/fmpz_mod_mpoly_factor/mpoly_hlift_zippel.c
+++ b/fmpz_mod_mpoly_factor/mpoly_hlift_zippel.c
@@ -851,7 +851,7 @@ int fmpz_mod_mpoly_hlift_zippel(
     const fmpz_mod_mpoly_t A,
     const slong * degs,
     const fmpz_mod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     flint_bitcnt_t bits = A->bits;
     int success;

--- a/fmpz_mod_poly.h
+++ b/fmpz_mod_poly.h
@@ -179,38 +179,38 @@ FLINT_DLL int fmpz_mod_poly_is_canonical(const fmpz_mod_poly_t A,
 
 /*  Randomisation ************************************************************/
 
-FLINT_DLL void fmpz_mod_poly_randtest(fmpz_mod_poly_t f, flint_rand_t state,
+FLINT_DLL void fmpz_mod_poly_randtest(fmpz_mod_poly_t f, flint_rand_ptr state,
                                           slong len, const fmpz_mod_ctx_t ctx);
 
 FLINT_DLL void fmpz_mod_poly_randtest_irreducible(fmpz_mod_poly_t f,
-                      flint_rand_t state, slong len, const fmpz_mod_ctx_t ctx);
+                      flint_rand_ptr state, slong len, const fmpz_mod_ctx_t ctx);
 
 FLINT_DLL void fmpz_mod_poly_randtest_not_zero(fmpz_mod_poly_t f, 
-                      flint_rand_t state, slong len, const fmpz_mod_ctx_t ctx);
+                      flint_rand_ptr state, slong len, const fmpz_mod_ctx_t ctx);
 
 FLINT_DLL void fmpz_mod_poly_randtest_monic(fmpz_mod_poly_t f,
-                      flint_rand_t state, slong len, const fmpz_mod_ctx_t ctx);
+                      flint_rand_ptr state, slong len, const fmpz_mod_ctx_t ctx);
 
 FLINT_DLL void fmpz_mod_poly_randtest_monic_irreducible(fmpz_mod_poly_t f,
-                      flint_rand_t state, slong len, const fmpz_mod_ctx_t ctx);
+                      flint_rand_ptr state, slong len, const fmpz_mod_ctx_t ctx);
 
 FLINT_DLL void fmpz_mod_poly_randtest_monic_primitive(fmpz_mod_poly_t f,
-                      flint_rand_t state, slong len, const fmpz_mod_ctx_t ctx);
+                      flint_rand_ptr state, slong len, const fmpz_mod_ctx_t ctx);
 
-FLINT_DLL void fmpz_mod_poly_randtest_trinomial(fmpz_mod_poly_t f, flint_rand_t state, slong len, const fmpz_mod_ctx_t ctx);
+FLINT_DLL void fmpz_mod_poly_randtest_trinomial(fmpz_mod_poly_t f, flint_rand_ptr state, slong len, const fmpz_mod_ctx_t ctx);
 
 FLINT_DLL int fmpz_mod_poly_randtest_trinomial_irreducible(fmpz_mod_poly_t f,
-                            flint_rand_t state, slong len, slong max_attempts,
+                            flint_rand_ptr state, slong len, slong max_attempts,
                                                      const fmpz_mod_ctx_t ctx);
 
-FLINT_DLL void fmpz_mod_poly_randtest_pentomial(fmpz_mod_poly_t f, flint_rand_t state, slong len, const fmpz_mod_ctx_t ctx);
+FLINT_DLL void fmpz_mod_poly_randtest_pentomial(fmpz_mod_poly_t f, flint_rand_ptr state, slong len, const fmpz_mod_ctx_t ctx);
 
 FLINT_DLL int fmpz_mod_poly_randtest_pentomial_irreducible(fmpz_mod_poly_t f,
-                            flint_rand_t state, slong len, slong max_attempts,
+                            flint_rand_ptr state, slong len, slong max_attempts,
                                                      const fmpz_mod_ctx_t ctx);
 
 FLINT_DLL void fmpz_mod_poly_randtest_sparse_irreducible(fmpz_mod_poly_t poly,
-                      flint_rand_t state, slong len, const fmpz_mod_ctx_t ctx);
+                      flint_rand_ptr state, slong len, const fmpz_mod_ctx_t ctx);
 
 /*  Attributes ***************************************************************/
 
@@ -1399,7 +1399,7 @@ FLINT_DLL int fmpz_mod_poly_find_distinct_nonzero_roots(fmpz * roots,
 
 FLINT_DLL void _fmpz_mod_poly_split_rabin(fmpz_mod_poly_t a, fmpz_mod_poly_t b,
                const fmpz_mod_poly_t f, const fmpz_t halfp, fmpz_mod_poly_t t,
-         fmpz_mod_poly_t t2, flint_rand_t randstate, const fmpz_mod_ctx_t ctx);
+         fmpz_mod_poly_t t2, flint_rand_ptr randstate, const fmpz_mod_ctx_t ctx);
 
 /* Characteristic polynomial and minimal polynomial */
 

--- a/fmpz_mod_poly/div_basecase.c
+++ b/fmpz_mod_poly/div_basecase.c
@@ -25,7 +25,9 @@ void _fmpz_mod_poly_div_basecase(fmpz *Q, fmpz *R,
 	TMP_START;
 	
     if (alloc)
+    {
         FMPZ_VEC_TMP_INIT(R, alloc);
+    }
 
 	if (R != A)
         _fmpz_vec_set(R + lenR, A + lenR, lenA - lenR);
@@ -56,7 +58,9 @@ void _fmpz_mod_poly_div_basecase(fmpz *Q, fmpz *R,
     }
 
     if (alloc)
+    {
         FMPZ_VEC_TMP_CLEAR(R, alloc);
+    }
 	
 	TMP_END;
 }

--- a/fmpz_mod_poly/find_distinct_nonzero_roots.c
+++ b/fmpz_mod_poly/find_distinct_nonzero_roots.c
@@ -20,7 +20,7 @@ void _fmpz_mod_poly_split_rabin(
     const fmpz_t halfp, /* floor((p-1)/2) */
     fmpz_mod_poly_t t,
     fmpz_mod_poly_t t2,
-    flint_rand_t randstate,
+    flint_rand_ptr randstate,
     const fmpz_mod_ctx_t ctx)
 {
     FLINT_ASSERT(fmpz_mod_poly_degree(f, ctx) > 1);

--- a/fmpz_mod_poly/profile/p-minpoly.c
+++ b/fmpz_mod_poly/profile/p-minpoly.c
@@ -56,7 +56,7 @@
     (TIMEVAR) = ((double)timer->cpu) / (NUMEX * loops); \
 } while(0)
 
-void time_algs(double* times, flint_rand_t state,
+void time_algs(double* times, flint_rand_ptr state,
                                  const fmpz_mod_ctx_struct * primes, slong len)
 {
     fmpz_mod_poly_struct polys[NUMEX];

--- a/fmpz_mod_poly/randtest.c
+++ b/fmpz_mod_poly/randtest.c
@@ -18,7 +18,7 @@
 #include "fmpz.h"
 #include "fmpz_mod_poly.h"
 
-void fmpz_mod_poly_randtest(fmpz_mod_poly_t f, flint_rand_t state, slong len,
+void fmpz_mod_poly_randtest(fmpz_mod_poly_t f, flint_rand_ptr state, slong len,
                                                       const fmpz_mod_ctx_t ctx)
 {
     slong i;
@@ -32,7 +32,7 @@ void fmpz_mod_poly_randtest(fmpz_mod_poly_t f, flint_rand_t state, slong len,
     _fmpz_mod_poly_normalise(f);
 }
 
-void fmpz_mod_poly_randtest_monic(fmpz_mod_poly_t f, flint_rand_t state,
+void fmpz_mod_poly_randtest_monic(fmpz_mod_poly_t f, flint_rand_ptr state,
                                            slong len, const fmpz_mod_ctx_t ctx)
 {
     slong i;
@@ -50,7 +50,7 @@ void fmpz_mod_poly_randtest_monic(fmpz_mod_poly_t f, flint_rand_t state,
 }
 
 static void
-fmpz_mod_poly_randtest_monic_sparse(fmpz_mod_poly_t poly, flint_rand_t state,
+fmpz_mod_poly_randtest_monic_sparse(fmpz_mod_poly_t poly, flint_rand_ptr state,
                             slong len, slong nonzero, const fmpz_mod_ctx_t ctx)
 {
     slong i;
@@ -65,7 +65,7 @@ fmpz_mod_poly_randtest_monic_sparse(fmpz_mod_poly_t poly, flint_rand_t state,
     _fmpz_mod_poly_set_length(poly, len);
 }
 
-void fmpz_mod_poly_randtest_irreducible(fmpz_mod_poly_t f, flint_rand_t state,
+void fmpz_mod_poly_randtest_irreducible(fmpz_mod_poly_t f, flint_rand_ptr state,
                                            slong len, const fmpz_mod_ctx_t ctx)
 {
     if (len == 0)
@@ -81,7 +81,7 @@ void fmpz_mod_poly_randtest_irreducible(fmpz_mod_poly_t f, flint_rand_t state,
 }
 
 void fmpz_mod_poly_randtest_monic_irreducible(fmpz_mod_poly_t f,
-                      flint_rand_t state, slong len, const fmpz_mod_ctx_t ctx)
+                      flint_rand_ptr state, slong len, const fmpz_mod_ctx_t ctx)
 {
     if (len == 0)
     {
@@ -96,7 +96,7 @@ void fmpz_mod_poly_randtest_monic_irreducible(fmpz_mod_poly_t f,
 }
 
 void fmpz_mod_poly_randtest_not_zero(fmpz_mod_poly_t f,
-                       flint_rand_t state, slong len, const fmpz_mod_ctx_t ctx)
+                       flint_rand_ptr state, slong len, const fmpz_mod_ctx_t ctx)
 {
     if (len == 0)
     {
@@ -111,7 +111,7 @@ void fmpz_mod_poly_randtest_not_zero(fmpz_mod_poly_t f,
 
 static void
 fmpz_mod_poly_randtest_monic_irreducible_sparse(fmpz_mod_poly_t poly,
-                       flint_rand_t state, slong len, const fmpz_mod_ctx_t ctx)
+                       flint_rand_ptr state, slong len, const fmpz_mod_ctx_t ctx)
 {
     slong i = 0;
     slong terms = 3;
@@ -126,7 +126,7 @@ fmpz_mod_poly_randtest_monic_irreducible_sparse(fmpz_mod_poly_t poly,
 }
 
 void fmpz_mod_poly_randtest_trinomial(fmpz_mod_poly_t poly,
-                       flint_rand_t state, slong len, const fmpz_mod_ctx_t ctx)
+                       flint_rand_ptr state, slong len, const fmpz_mod_ctx_t ctx)
 {
     ulong k;
     fmpz_mod_poly_fit_length(poly, len, ctx);
@@ -139,7 +139,7 @@ void fmpz_mod_poly_randtest_trinomial(fmpz_mod_poly_t poly,
 }
 
 void fmpz_mod_poly_randtest_pentomial(fmpz_mod_poly_t poly,
-                       flint_rand_t state, slong len, const fmpz_mod_ctx_t ctx)
+                       flint_rand_ptr state, slong len, const fmpz_mod_ctx_t ctx)
 {
     fmpz_mod_poly_fit_length(poly, len, ctx);
     _fmpz_vec_zero(poly->coeffs, len);
@@ -152,7 +152,7 @@ void fmpz_mod_poly_randtest_pentomial(fmpz_mod_poly_t poly,
 }
 
 int fmpz_mod_poly_randtest_trinomial_irreducible(fmpz_mod_poly_t poly,
-                           flint_rand_t state, slong len, slong max_attempts,
+                           flint_rand_ptr state, slong len, slong max_attempts,
                                                       const fmpz_mod_ctx_t ctx)
 {
     slong i = 0;
@@ -171,7 +171,7 @@ int fmpz_mod_poly_randtest_trinomial_irreducible(fmpz_mod_poly_t poly,
 }
 
 int fmpz_mod_poly_randtest_pentomial_irreducible(fmpz_mod_poly_t poly,
-                           flint_rand_t state, slong len, slong max_attempts,
+                           flint_rand_ptr state, slong len, slong max_attempts,
                                                       const fmpz_mod_ctx_t ctx)
 {
     slong i = 0;
@@ -190,7 +190,7 @@ int fmpz_mod_poly_randtest_pentomial_irreducible(fmpz_mod_poly_t poly,
 }
 
 void fmpz_mod_poly_randtest_sparse_irreducible(fmpz_mod_poly_t poly,
-                       flint_rand_t state, slong len, const fmpz_mod_ctx_t ctx)
+                       flint_rand_ptr state, slong len, const fmpz_mod_ctx_t ctx)
 {
     if (len < 3)
     {

--- a/fmpz_mod_poly/randtest_monic_primitive.c
+++ b/fmpz_mod_poly/randtest_monic_primitive.c
@@ -15,7 +15,7 @@
 
 void
 fmpz_mod_poly_randtest_monic_primitive(fmpz_mod_poly_t f,
-                       flint_rand_t state, slong len, const fmpz_mod_ctx_t ctx)
+                       flint_rand_ptr state, slong len, const fmpz_mod_ctx_t ctx)
 {
     fq_ctx_t fqctx;
     fq_t X;

--- a/fmpz_mod_poly_factor.h
+++ b/fmpz_mod_poly_factor.h
@@ -129,7 +129,7 @@ FLINT_DLL int fmpz_mod_poly_is_squarefree_f(fmpz_t fac,
                             const fmpz_mod_poly_t f, const fmpz_mod_ctx_t ctx);
 
 FLINT_DLL int fmpz_mod_poly_factor_equal_deg_prob(fmpz_mod_poly_t factor,
-                       flint_rand_t state, const fmpz_mod_poly_t pol, slong d,
+                       flint_rand_ptr state, const fmpz_mod_poly_t pol, slong d,
                                                      const fmpz_mod_ctx_t ctx);
 
 FLINT_DLL void fmpz_mod_poly_factor_equal_deg_with_frob(

--- a/fmpz_mod_poly_factor/factor_berlekamp.c
+++ b/fmpz_mod_poly_factor/factor_berlekamp.c
@@ -58,7 +58,7 @@ fmpz_mat_col_to_fmpz_mod_poly_shifted(fmpz_mod_poly_t poly, fmpz_mat_t mat,
 
 static void
 __fmpz_mod_poly_factor_berlekamp(fmpz_mod_poly_factor_t factors,
-         flint_rand_t state, const fmpz_mod_poly_t f, const fmpz_mod_ctx_t ctx)
+         flint_rand_ptr state, const fmpz_mod_poly_t f, const fmpz_mod_ctx_t ctx)
 {
     const slong n = fmpz_mod_poly_degree(f, ctx);
     const fmpz * p = fmpz_mod_ctx_modulus(ctx);

--- a/fmpz_mod_poly_factor/factor_equal_deg_prob.c
+++ b/fmpz_mod_poly_factor/factor_equal_deg_prob.c
@@ -17,7 +17,7 @@
 #include "ulong_extras.h"
 
 int
-fmpz_mod_poly_factor_equal_deg_prob(fmpz_mod_poly_t factor, flint_rand_t state,
+fmpz_mod_poly_factor_equal_deg_prob(fmpz_mod_poly_t factor, flint_rand_ptr state,
                   const fmpz_mod_poly_t pol, slong d, const fmpz_mod_ctx_t ctx)
 {
     const fmpz * p = fmpz_mod_ctx_modulus(ctx);

--- a/fmpz_mod_poly_factor/is_irreducible_rabin.c
+++ b/fmpz_mod_poly_factor/is_irreducible_rabin.c
@@ -76,12 +76,12 @@ int fmpz_mod_poly_is_irreducible_rabin(const fmpz_mod_poly_t f,
             n_factor_t factors;
             slong i;
 
-            n_factor_init(&factors);
-            n_factor(&factors, n, 1);
+            n_factor_init(factors);
+            n_factor(factors, n, 1);
 
-            for (i = 0; i < factors.num; i++)
+            for (i = 0; i < factors->num; i++)
             {
-                fmpz_mod_poly_frobenius_power(a, pow, f, n / factors.p[i], ctx);
+                fmpz_mod_poly_frobenius_power(a, pow, f, n / factors->p[i], ctx);
 
                 fmpz_mod_poly_sub(a, a, x, ctx);
 

--- a/fmpz_mod_poly_factor/is_irreducible_rabin_f.c
+++ b/fmpz_mod_poly_factor/is_irreducible_rabin_f.c
@@ -67,12 +67,12 @@ fmpz_mod_poly_is_irreducible_rabin_f(fmpz_t fac, const fmpz_mod_poly_t f,
             n_factor_t factors;
             slong i;
 
-            n_factor_init(&factors);
-            n_factor(&factors, n, 1);
+            n_factor_init(factors);
+            n_factor(factors, n, 1);
 
-            for (i = 0; i < factors.num; i++)
+            for (i = 0; i < factors->num; i++)
             {
-                fmpz_mod_poly_frobenius_power(a, pow, f, n / factors.p[i], ctx);
+                fmpz_mod_poly_frobenius_power(a, pow, f, n / factors->p[i], ctx);
 
                 fmpz_mod_poly_sub(a, a, x, ctx);
 

--- a/fmpz_mod_poly_factor/roots.c
+++ b/fmpz_mod_poly_factor/roots.c
@@ -26,7 +26,7 @@ static void _fmpz_mod_poly_push_roots(
     fmpz_mod_poly_t t,              /* temp */
     fmpz_mod_poly_t t2,             /* more temp */
     fmpz_mod_poly_struct * stack,   /* temp of size FLINT_BITS */
-    flint_rand_t randstate,
+    flint_rand_ptr randstate,
     const fmpz_mod_ctx_t ctx)
 {
     slong i, sp;

--- a/fmpz_mpoly.h
+++ b/fmpz_mpoly.h
@@ -121,7 +121,7 @@ typedef fmpz_mpolyd_struct fmpz_mpolyd_t[1];
 FLINT_DLL void fmpz_mpoly_ctx_init(fmpz_mpoly_ctx_t ctx, 
                                             slong nvars, const ordering_t ord);
 
-FLINT_DLL void fmpz_mpoly_ctx_init_rand(fmpz_mpoly_ctx_t mctx, flint_rand_t state, slong max_nvars);
+FLINT_DLL void fmpz_mpoly_ctx_init_rand(fmpz_mpoly_ctx_t mctx, flint_rand_ptr state, slong max_nvars);
 
 
 FLINT_DLL void fmpz_mpoly_ctx_clear(fmpz_mpoly_ctx_t ctx);
@@ -614,15 +614,15 @@ FLINT_DLL void _fmpz_mpoly_push_exp_ui(fmpz_mpoly_t A,
 
 /* Random generation *********************************************************/
 
-FLINT_DLL void fmpz_mpoly_randtest_bound(fmpz_mpoly_t A, flint_rand_t state,
+FLINT_DLL void fmpz_mpoly_randtest_bound(fmpz_mpoly_t A, flint_rand_ptr state,
                         slong length, flint_bitcnt_t coeff_bits, ulong exp_bound,
                                                    const fmpz_mpoly_ctx_t ctx);
 
-FLINT_DLL void fmpz_mpoly_randtest_bounds(fmpz_mpoly_t A, flint_rand_t state,
+FLINT_DLL void fmpz_mpoly_randtest_bounds(fmpz_mpoly_t A, flint_rand_ptr state,
                      slong length, flint_bitcnt_t coeff_bits, ulong * exp_bounds,
                                                    const fmpz_mpoly_ctx_t ctx);
 
-FLINT_DLL void fmpz_mpoly_randtest_bits(fmpz_mpoly_t A, flint_rand_t state,
+FLINT_DLL void fmpz_mpoly_randtest_bits(fmpz_mpoly_t A, flint_rand_ptr state,
                    slong length, flint_bitcnt_t coeff_bits, flint_bitcnt_t exp_bits,
                                                    const fmpz_mpoly_ctx_t ctx);
 

--- a/fmpz_mpoly/ctx_init_rand.c
+++ b/fmpz_mpoly/ctx_init_rand.c
@@ -11,7 +11,7 @@
 
 #include "fmpz_mpoly.h"
 
-void fmpz_mpoly_ctx_init_rand(fmpz_mpoly_ctx_t ctx, flint_rand_t state, slong max_nvars)
+void fmpz_mpoly_ctx_init_rand(fmpz_mpoly_ctx_t ctx, flint_rand_ptr state, slong max_nvars)
 {
     mpoly_ctx_init_rand(ctx->minfo, state, max_nvars);
 }

--- a/fmpz_mpoly/randtest_bits.c
+++ b/fmpz_mpoly/randtest_bits.c
@@ -11,7 +11,7 @@
 
 #include "fmpz_mpoly.h"
 
-void fmpz_mpoly_randtest_bits(fmpz_mpoly_t A, flint_rand_t state,
+void fmpz_mpoly_randtest_bits(fmpz_mpoly_t A, flint_rand_ptr state,
               slong length, flint_bitcnt_t coeff_bits, flint_bitcnt_t exp_bits,
                                                     const fmpz_mpoly_ctx_t ctx)
 {

--- a/fmpz_mpoly/randtest_bound.c
+++ b/fmpz_mpoly/randtest_bound.c
@@ -12,7 +12,7 @@
 
 #include "fmpz_mpoly.h"
 
-void fmpz_mpoly_randtest_bound(fmpz_mpoly_t A, flint_rand_t state,
+void fmpz_mpoly_randtest_bound(fmpz_mpoly_t A, flint_rand_ptr state,
                          slong length, flint_bitcnt_t coeff_bits, ulong exp_bound,
                                                     const fmpz_mpoly_ctx_t ctx)
 {

--- a/fmpz_mpoly/randtest_bounds.c
+++ b/fmpz_mpoly/randtest_bounds.c
@@ -11,7 +11,7 @@
 
 #include "fmpz_mpoly.h"
 
-void fmpz_mpoly_randtest_bounds(fmpz_mpoly_t A, flint_rand_t state,
+void fmpz_mpoly_randtest_bounds(fmpz_mpoly_t A, flint_rand_ptr state,
                       slong length, flint_bitcnt_t coeff_bits, ulong * exp_bounds,
                                                     const fmpz_mpoly_ctx_t ctx)
 {

--- a/fmpz_mpoly/sqrt_heap.c
+++ b/fmpz_mpoly/sqrt_heap.c
@@ -22,7 +22,7 @@
 static int _is_proved_not_square(
     int count,
     mp_limb_t * p,
-    flint_rand_t state,
+    flint_rand_ptr state,
     const fmpz * Acoeffs,
     const ulong * Aexps,
     slong Alen,

--- a/fmpz_mpoly_factor.h
+++ b/fmpz_mpoly_factor.h
@@ -324,7 +324,7 @@ FLINT_DLL int fmpz_mpolyl_gcd_brown_threaded_pool(fmpz_mpoly_t G,
 
 FLINT_DLL int fmpz_mpolyl_gcd_zippel(fmpz_mpoly_t G, fmpz_mpoly_t Abar,
                fmpz_mpoly_t Bbar, const fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                           const fmpz_mpoly_ctx_t ctx, flint_rand_t randstate);
+                           const fmpz_mpoly_ctx_t ctx, flint_rand_ptr randstate);
 
 FLINT_DLL int fmpz_mpolyl_gcd_zippel2(fmpz_mpoly_t G, fmpz_mpoly_t Abar,
                 fmpz_mpoly_t Bbar, const fmpz_mpoly_t A, const fmpz_mpoly_t B,
@@ -551,12 +551,12 @@ FLINT_DLL int fmpz_mpoly_factor_irred_zassenhaus(fmpz_mpolyv_t fac,
 FLINT_DLL int fmpz_mpoly_factor_irred_wang(fmpz_mpolyv_t fac,
                       const fmpz_mpoly_t A, const fmpz_mpoly_factor_t lcAfac,
           int lcAfac_irred, const fmpz_mpoly_t lcA, const fmpz_mpoly_ctx_t ctx,
-                    flint_rand_t state, zassenhaus_prune_t Z, int allow_shift);
+                    flint_rand_ptr state, zassenhaus_prune_t Z, int allow_shift);
 
 FLINT_DLL int fmpz_mpoly_factor_irred_zippel(fmpz_mpolyv_t fac,
                     const fmpz_mpoly_t A, const fmpz_mpoly_factor_t lcAfac,
           int lcAfac_irred, const fmpz_mpoly_t lcA, const fmpz_mpoly_ctx_t ctx,
-                                     flint_rand_t state, zassenhaus_prune_t Z);
+                                     flint_rand_ptr state, zassenhaus_prune_t Z);
 
 FLINT_DLL int fmpz_mpoly_factor_irred(fmpz_mpoly_factor_t f,
                                 const fmpz_mpoly_ctx_t ctx, unsigned int algo);

--- a/fmpz_mpoly_factor/gcd_zippel.c
+++ b/fmpz_mpoly_factor/gcd_zippel.c
@@ -55,7 +55,7 @@ int fmpz_mpolyl_gcd_zippel(
     const fmpz_mpoly_t A,
     const fmpz_mpoly_t B,
     const fmpz_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     flint_bitcnt_t coeffbitbound;
     flint_bitcnt_t coeffbits;

--- a/fmpz_mpoly_factor/gcd_zippel2.c
+++ b/fmpz_mpoly_factor/gcd_zippel2.c
@@ -1253,7 +1253,7 @@ int static _random_check_sp(
     const fmpz_mpoly_t Gamma,
     const fmpz_mpoly_ctx_t ctx,
     nmod_t ctx_sp,
-    flint_rand_t randstate,
+    flint_rand_ptr randstate,
     n_poly_polyun_stack_t St_sp)
 {
     mp_limb_t Gammaeval_sp;
@@ -1338,7 +1338,7 @@ int static _random_check_mp(
     const fmpz_mpoly_t Gamma,
     const fmpz_mpoly_ctx_t ctx,
     const fmpz_mod_ctx_t ctx_mp,
-    flint_rand_t randstate,
+    flint_rand_ptr randstate,
     fmpz_mod_poly_polyun_stack_t St_mp)
 {
     int success;

--- a/fmpz_mpoly_factor/irred_wang.c
+++ b/fmpz_mpoly_factor/irred_wang.c
@@ -19,7 +19,7 @@ int fmpz_mpoly_factor_irred_wang(
     int lcAfac_irred,
     const fmpz_mpoly_t lcA,
     const fmpz_mpoly_ctx_t ctx,
-    flint_rand_t state,
+    flint_rand_ptr state,
     zassenhaus_prune_t zas,
     int allow_shift)
 {

--- a/fmpz_mpoly_factor/irred_zippel.c
+++ b/fmpz_mpoly_factor/irred_zippel.c
@@ -434,7 +434,7 @@ static void n_bpoly_mod_eval_step(
 static int fmpz_mfactor_lift_prime_power_zippel(
     slong r,
     fmpz_mpoly_struct * B,
-    flint_rand_t state,
+    flint_rand_ptr state,
     const nmod_mpoly_struct * Bp,
     const fmpz_mpoly_t A,
     const mp_limb_t * alphap,
@@ -668,7 +668,7 @@ int fmpz_mpoly_factor_irred_zippel(
     int lcAfac_irred,
     const fmpz_mpoly_t lcA,
     const fmpz_mpoly_ctx_t ctx,
-    flint_rand_t state,
+    flint_rand_ptr state,
     zassenhaus_prune_t zas)
 {
     int success, kfails_left = 4;

--- a/fmpz_mpoly_factor/test/t-poly_pfrac.c
+++ b/fmpz_mpoly_factor/test/t-poly_pfrac.c
@@ -19,7 +19,7 @@ void _test_pfrac(
     fmpz_poly_pfrac_t I,
     const fmpz_poly_struct * b,
     slong r,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     slong i, j;
     int success, found_bad;

--- a/fmpz_poly.h
+++ b/fmpz_poly.h
@@ -217,16 +217,16 @@ FLINT_DLL void fmpz_poly_set_trunc(fmpz_poly_t res, const fmpz_poly_t poly, slon
 
 /*  Randomisation  ***********************************************************/
 
-FLINT_DLL void fmpz_poly_randtest(fmpz_poly_t f, flint_rand_t state, 
+FLINT_DLL void fmpz_poly_randtest(fmpz_poly_t f, flint_rand_ptr state, 
                                                 slong len, flint_bitcnt_t bits);
 
-FLINT_DLL void fmpz_poly_randtest_unsigned(fmpz_poly_t f, flint_rand_t state, 
+FLINT_DLL void fmpz_poly_randtest_unsigned(fmpz_poly_t f, flint_rand_ptr state, 
                                                 slong len, flint_bitcnt_t bits);
 
-FLINT_DLL void fmpz_poly_randtest_not_zero(fmpz_poly_t f, flint_rand_t state,
+FLINT_DLL void fmpz_poly_randtest_not_zero(fmpz_poly_t f, flint_rand_ptr state,
                                                 slong len, flint_bitcnt_t bits);
 
-FLINT_DLL void fmpz_poly_randtest_no_real_root(fmpz_poly_t p, flint_rand_t state,
+FLINT_DLL void fmpz_poly_randtest_no_real_root(fmpz_poly_t p, flint_rand_ptr state,
                                                 slong len, flint_bitcnt_t bits);
 
 /*  Getting and setting coefficients  ****************************************/

--- a/fmpz_poly/cyclotomic.c
+++ b/fmpz_poly/cyclotomic.c
@@ -107,23 +107,23 @@ fmpz_poly_cyclotomic(fmpz_poly_t poly, ulong n)
 
     /* Write n = q * s where q is squarefree, compute the factors of q,
       and compute phi(s) which determines the degree of the polynomial. */
-    n_factor_init(&factors);
-    n_factor(&factors, n, 1);
+    n_factor_init(factors);
+    n_factor(factors, n, 1);
     s = phi = 1;
-    for (i = 0; i < factors.num; i++)
+    for (i = 0; i < factors->num; i++)
     {
-        phi *= factors.p[i] - 1;
-        while (factors.exp[i] > 1)
+        phi *= factors->p[i] - 1;
+        while (factors->exp[i] > 1)
         {
-            s *= factors.p[i];
-            factors.exp[i]--;
+            s *= factors->p[i];
+            factors->exp[i]--;
         }
     }
 
     fmpz_poly_fit_length(poly, phi * s + 1);
 
     /* Evaluate lower half of Phi_s(x) */
-    _fmpz_poly_cyclotomic(poly->coeffs, n / s, factors.p, factors.num, phi);
+    _fmpz_poly_cyclotomic(poly->coeffs, n / s, factors->p, factors->num, phi);
 
     /* Palindromic extension */
     for (i = 0; i < (phi + 1) / 2; i++)

--- a/fmpz_poly/profile/p-div_preinv.c
+++ b/fmpz_poly/profile/p-div_preinv.c
@@ -26,7 +26,7 @@ typedef struct
    slong length;
 } info_t;
 
-void random_fmpz_poly(fmpz_poly_t pol, flint_rand_t state, slong length)
+void random_fmpz_poly(fmpz_poly_t pol, flint_rand_ptr state, slong length)
 {
    fmpz * arr;
    slong i;

--- a/fmpz_poly/profile/p-gcd.c
+++ b/fmpz_poly/profile/p-gcd.c
@@ -25,7 +25,7 @@ typedef struct
    slong bits;
 } info_t;
 
-void random_fmpz_poly(fmpz_poly_t pol, flint_rand_t state, slong bits)
+void random_fmpz_poly(fmpz_poly_t pol, flint_rand_ptr state, slong bits)
 {
    fmpz * arr;
    slong i;

--- a/fmpz_poly/profile/p-rem_powers_precomp.c
+++ b/fmpz_poly/profile/p-rem_powers_precomp.c
@@ -26,7 +26,7 @@ typedef struct
    slong length;
 } info_t;
 
-void random_fmpz_poly(fmpz_poly_t pol, flint_rand_t state, slong length)
+void random_fmpz_poly(fmpz_poly_t pol, flint_rand_ptr state, slong length)
 {
    fmpz * arr;
    slong i;

--- a/fmpz_poly/randtest.c
+++ b/fmpz_poly/randtest.c
@@ -18,7 +18,7 @@
 #include "ulong_extras.h"
 
 void
-fmpz_poly_randtest(fmpz_poly_t f, flint_rand_t state, 
+fmpz_poly_randtest(fmpz_poly_t f, flint_rand_ptr state, 
                    slong len, flint_bitcnt_t bits)
 {
     fmpz_poly_fit_length(f, len);
@@ -28,7 +28,7 @@ fmpz_poly_randtest(fmpz_poly_t f, flint_rand_t state,
 }
 
 void
-fmpz_poly_randtest_unsigned(fmpz_poly_t f, flint_rand_t state, 
+fmpz_poly_randtest_unsigned(fmpz_poly_t f, flint_rand_ptr state, 
                             slong len, flint_bitcnt_t bits)
 {
     fmpz_poly_fit_length(f, len);
@@ -38,7 +38,7 @@ fmpz_poly_randtest_unsigned(fmpz_poly_t f, flint_rand_t state,
 }
 
 void
-fmpz_poly_randtest_not_zero(fmpz_poly_t f, flint_rand_t state, 
+fmpz_poly_randtest_not_zero(fmpz_poly_t f, flint_rand_ptr state, 
                             slong len, flint_bitcnt_t bits)
 {
     if ((bits == 0) || (len == 0))

--- a/fmpz_poly/randtest_no_real_root.c
+++ b/fmpz_poly/randtest_no_real_root.c
@@ -11,7 +11,7 @@
 
 #include "fmpz_poly.h"
 
-void _quadratic(fmpz_poly_t p, flint_rand_t state, flint_bitcnt_t bits)
+void _quadratic(fmpz_poly_t p, flint_rand_ptr state, flint_bitcnt_t bits)
 {
     fmpz *a, *b, *c;
 
@@ -33,7 +33,7 @@ void _quadratic(fmpz_poly_t p, flint_rand_t state, flint_bitcnt_t bits)
     _fmpz_poly_set_length(p, 3);
 }
 
-void _even(fmpz_poly_t p, flint_rand_t state, slong len, flint_bitcnt_t bits)
+void _even(fmpz_poly_t p, flint_rand_ptr state, slong len, flint_bitcnt_t bits)
 {
     slong n, i;
 
@@ -67,7 +67,7 @@ void _even(fmpz_poly_t p, flint_rand_t state, slong len, flint_bitcnt_t bits)
     _fmpz_poly_normalise(p);
 }
 
-void fmpz_poly_randtest_no_real_root(fmpz_poly_t p, flint_rand_t state, slong len, flint_bitcnt_t bits)
+void fmpz_poly_randtest_no_real_root(fmpz_poly_t p, flint_rand_ptr state, slong len, flint_bitcnt_t bits)
 {
 
     if (len <= 0)

--- a/fmpz_poly_mat.h
+++ b/fmpz_poly_mat.h
@@ -109,13 +109,13 @@ FLINT_DLL void fmpz_poly_mat_one(fmpz_poly_mat_t mat);
 
 /* Random matrices ***********************************************************/
 
-FLINT_DLL void fmpz_poly_mat_randtest(fmpz_poly_mat_t mat, flint_rand_t state,
+FLINT_DLL void fmpz_poly_mat_randtest(fmpz_poly_mat_t mat, flint_rand_ptr state,
                                 slong len, flint_bitcnt_t bits);
 
-FLINT_DLL void fmpz_poly_mat_randtest_unsigned(fmpz_poly_mat_t mat, flint_rand_t state,
+FLINT_DLL void fmpz_poly_mat_randtest_unsigned(fmpz_poly_mat_t mat, flint_rand_ptr state,
                              slong len, flint_bitcnt_t bits);
 
-FLINT_DLL void fmpz_poly_mat_randtest_sparse(fmpz_poly_mat_t A, flint_rand_t state,
+FLINT_DLL void fmpz_poly_mat_randtest_sparse(fmpz_poly_mat_t A, flint_rand_ptr state,
                         slong len, flint_bitcnt_t bits, float density);
 
 /* Windows and concatenation */

--- a/fmpz_poly_mat/randtest.c
+++ b/fmpz_poly_mat/randtest.c
@@ -15,7 +15,7 @@
 #include "fmpz_poly_mat.h"
 
 void
-fmpz_poly_mat_randtest(fmpz_poly_mat_t A, flint_rand_t state, slong len, flint_bitcnt_t bits)
+fmpz_poly_mat_randtest(fmpz_poly_mat_t A, flint_rand_ptr state, slong len, flint_bitcnt_t bits)
 {
     slong i, j;
 

--- a/fmpz_poly_mat/randtest_sparse.c
+++ b/fmpz_poly_mat/randtest_sparse.c
@@ -16,7 +16,7 @@
 #include "ulong_extras.h"
 
 void
-fmpz_poly_mat_randtest_sparse(fmpz_poly_mat_t A, flint_rand_t state, slong len,
+fmpz_poly_mat_randtest_sparse(fmpz_poly_mat_t A, flint_rand_ptr state, slong len,
     flint_bitcnt_t bits, float density)
 {
     slong i, j;

--- a/fmpz_poly_mat/randtest_unsigned.c
+++ b/fmpz_poly_mat/randtest_unsigned.c
@@ -15,7 +15,7 @@
 #include "fmpz_poly_mat.h"
 
 void
-fmpz_poly_mat_randtest_unsigned(fmpz_poly_mat_t A, flint_rand_t state, slong len, flint_bitcnt_t bits)
+fmpz_poly_mat_randtest_unsigned(fmpz_poly_mat_t A, flint_rand_ptr state, slong len, flint_bitcnt_t bits)
 {
     slong i, j;
 

--- a/fmpz_poly_q.h
+++ b/fmpz_poly_q.h
@@ -59,11 +59,11 @@ FLINT_DLL void fmpz_poly_q_clear(fmpz_poly_q_t rop);
 
 /* Randomisation *************************************************************/
 
-FLINT_DLL void fmpz_poly_q_randtest(fmpz_poly_q_t poly, flint_rand_t state,
+FLINT_DLL void fmpz_poly_q_randtest(fmpz_poly_q_t poly, flint_rand_ptr state,
                           slong len1, flint_bitcnt_t bits1, 
                           slong len2, flint_bitcnt_t bits2);
 
-FLINT_DLL void fmpz_poly_q_randtest_not_zero(fmpz_poly_q_t poly, flint_rand_t state, 
+FLINT_DLL void fmpz_poly_q_randtest_not_zero(fmpz_poly_q_t poly, flint_rand_ptr state, 
                                    slong len1, flint_bitcnt_t bits1, 
                                    slong len2, flint_bitcnt_t bits2);
 

--- a/fmpz_poly_q/randtest.c
+++ b/fmpz_poly_q/randtest.c
@@ -11,7 +11,7 @@
 
 #include "fmpz_poly_q.h"
 
-void fmpz_poly_q_randtest(fmpz_poly_q_t poly, flint_rand_t state,
+void fmpz_poly_q_randtest(fmpz_poly_q_t poly, flint_rand_ptr state,
                           slong len1, flint_bitcnt_t bits1, 
                           slong len2, flint_bitcnt_t bits2)
 {
@@ -23,7 +23,7 @@ void fmpz_poly_q_randtest(fmpz_poly_q_t poly, flint_rand_t state,
     fmpz_poly_q_canonicalise(poly);
 }
 
-void fmpz_poly_q_randtest_not_zero(fmpz_poly_q_t poly, flint_rand_t state, 
+void fmpz_poly_q_randtest_not_zero(fmpz_poly_q_t poly, flint_rand_ptr state, 
                                    slong len1, flint_bitcnt_t bits1, 
                                    slong len2, flint_bitcnt_t bits2)
 {

--- a/fmpz_vec.h
+++ b/fmpz_vec.h
@@ -74,10 +74,10 @@ FLINT_DLL void _fmpz_vec_clear(fmpz * vec, slong len);
 
 /*  Randomisation  ***********************************************************/
 
-FLINT_DLL void _fmpz_vec_randtest(fmpz * f, flint_rand_t state, 
+FLINT_DLL void _fmpz_vec_randtest(fmpz * f, flint_rand_ptr state, 
                         slong len, flint_bitcnt_t bits);
 
-FLINT_DLL void _fmpz_vec_randtest_unsigned(fmpz * f, flint_rand_t state, 
+FLINT_DLL void _fmpz_vec_randtest_unsigned(fmpz * f, flint_rand_ptr state, 
                                  slong len, flint_bitcnt_t bits);
 
 /*  Norms  *******************************************************************/

--- a/fmpz_vec/randtest.c
+++ b/fmpz_vec/randtest.c
@@ -18,7 +18,7 @@
 #include "fmpz_vec.h"
 
 void
-_fmpz_vec_randtest(fmpz * f, flint_rand_t state, 
+_fmpz_vec_randtest(fmpz * f, flint_rand_ptr state, 
                    slong len, flint_bitcnt_t bits)
 {
     slong i, sparseness;
@@ -43,7 +43,7 @@ _fmpz_vec_randtest(fmpz * f, flint_rand_t state,
 }
 
 void
-_fmpz_vec_randtest_unsigned(fmpz * f, flint_rand_t state, 
+_fmpz_vec_randtest_unsigned(fmpz * f, flint_rand_ptr state, 
                             slong len, flint_bitcnt_t bits)
 {
     slong i, sparseness;

--- a/fq.h
+++ b/fq.h
@@ -67,9 +67,9 @@ FLINT_DLL void fq_ctx_init_conway(fq_ctx_t ctx, const fmpz_t p, slong d,
 FLINT_DLL void fq_ctx_init_modulus(fq_ctx_t ctx, const fmpz_mod_poly_t modulus,
                                    const fmpz_mod_ctx_t ctxp, const char *var);
 
-FLINT_DLL void fq_ctx_randtest(fq_ctx_t ctx, flint_rand_t state);
+FLINT_DLL void fq_ctx_randtest(fq_ctx_t ctx, flint_rand_ptr state);
 
-FLINT_DLL void fq_ctx_randtest_reducible(fq_ctx_t ctx, flint_rand_t state);
+FLINT_DLL void fq_ctx_randtest_reducible(fq_ctx_t ctx, flint_rand_ptr state);
 
 FLINT_DLL void fq_ctx_clear(fq_ctx_t ctx);
 
@@ -254,15 +254,15 @@ FLINT_DLL int fq_is_square(const fq_t op, const fq_ctx_t ctx);
 
 /* Randomisation *************************************************************/
 
-FLINT_DLL void fq_randtest(fq_t rop, flint_rand_t state, const fq_ctx_t ctx);
+FLINT_DLL void fq_randtest(fq_t rop, flint_rand_ptr state, const fq_ctx_t ctx);
 
-FLINT_DLL void fq_randtest_dense(fq_t rop, flint_rand_t state, const fq_ctx_t ctx);
+FLINT_DLL void fq_randtest_dense(fq_t rop, flint_rand_ptr state, const fq_ctx_t ctx);
 
-FLINT_DLL void fq_randtest_not_zero(fq_t rop, flint_rand_t state, const fq_ctx_t ctx);
+FLINT_DLL void fq_randtest_not_zero(fq_t rop, flint_rand_ptr state, const fq_ctx_t ctx);
 
-FLINT_DLL void fq_rand(fq_t rop, flint_rand_t state, const fq_ctx_t ctx);
+FLINT_DLL void fq_rand(fq_t rop, flint_rand_ptr state, const fq_ctx_t ctx);
 
-FLINT_DLL void fq_rand_not_zero(fq_t rop, flint_rand_t state, const fq_ctx_t ctx);
+FLINT_DLL void fq_rand_not_zero(fq_t rop, flint_rand_ptr state, const fq_ctx_t ctx);
 
 
 /* Comparison ****************************************************************/

--- a/fq/ctx_randtest.c
+++ b/fq/ctx_randtest.c
@@ -14,7 +14,7 @@
 #include "fq.h"
 
 void
-fq_ctx_randtest(fq_ctx_t ctx, flint_rand_t state)
+fq_ctx_randtest(fq_ctx_t ctx, flint_rand_ptr state)
 {
     fmpz_mod_poly_t modulus;
     fmpz_t p, x;

--- a/fq/ctx_randtest_reducible.c
+++ b/fq/ctx_randtest_reducible.c
@@ -12,7 +12,7 @@
 #include "fq.h"
 
 void
-fq_ctx_randtest_reducible(fq_ctx_t ctx, flint_rand_t state)
+fq_ctx_randtest_reducible(fq_ctx_t ctx, flint_rand_ptr state)
 {
     fmpz_mod_ctx_t ctxp;
     fmpz_mod_poly_t mod;

--- a/fq/rand.c
+++ b/fq/rand.c
@@ -13,7 +13,7 @@
 
 
 void
-fq_rand(fq_t rop, flint_rand_t state, const fq_ctx_t ctx)
+fq_rand(fq_t rop, flint_rand_ptr state, const fq_ctx_t ctx)
 {
     const slong d = fq_ctx_degree(ctx);
     slong i;
@@ -29,7 +29,7 @@ fq_rand(fq_t rop, flint_rand_t state, const fq_ctx_t ctx)
     _fmpz_poly_normalise(rop);
 }
 
-void fq_rand_not_zero(fq_t rop, flint_rand_t state, const fq_ctx_t ctx)
+void fq_rand_not_zero(fq_t rop, flint_rand_ptr state, const fq_ctx_t ctx)
 {
     int tries = 3;
 

--- a/fq/randtest.c
+++ b/fq/randtest.c
@@ -14,7 +14,7 @@
 #include "fq.h"
 
 void
-fq_randtest(fq_t rop, flint_rand_t state, const fq_ctx_t ctx)
+fq_randtest(fq_t rop, flint_rand_ptr state, const fq_ctx_t ctx)
 {
     const slong d = fq_ctx_degree(ctx);
     slong i, sparse;
@@ -42,7 +42,7 @@ fq_randtest(fq_t rop, flint_rand_t state, const fq_ctx_t ctx)
 }
 
 void
-fq_randtest_dense(fq_t rop, flint_rand_t state, const fq_ctx_t ctx)
+fq_randtest_dense(fq_t rop, flint_rand_ptr state, const fq_ctx_t ctx)
 {
     const slong d = fq_ctx_degree(ctx);
     slong i;
@@ -61,7 +61,7 @@ fq_randtest_dense(fq_t rop, flint_rand_t state, const fq_ctx_t ctx)
 }
 
 void
-fq_randtest_not_zero(fq_t rop, flint_rand_t state, const fq_ctx_t ctx)
+fq_randtest_not_zero(fq_t rop, flint_rand_ptr state, const fq_ctx_t ctx)
 {
     slong i;
 

--- a/fq_default.h
+++ b/fq_default.h
@@ -835,7 +835,7 @@ FQ_DEFAULT_INLINE int fq_default_is_square(const fq_default_t op,
 /* Randomisation *************************************************************/
 
 FQ_DEFAULT_INLINE void fq_default_randtest(fq_default_t rop,
-		                flint_rand_t state, const fq_default_ctx_t ctx)
+		                flint_rand_ptr state, const fq_default_ctx_t ctx)
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
@@ -860,7 +860,7 @@ FQ_DEFAULT_INLINE void fq_default_randtest(fq_default_t rop,
 }
 
 FQ_DEFAULT_INLINE void fq_default_randtest_not_zero(fq_default_t rop,
-		                flint_rand_t state, const fq_default_ctx_t ctx)
+		                flint_rand_ptr state, const fq_default_ctx_t ctx)
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
@@ -885,7 +885,7 @@ FQ_DEFAULT_INLINE void fq_default_randtest_not_zero(fq_default_t rop,
 }
 
 FQ_DEFAULT_INLINE void fq_default_rand(fq_default_t rop,
-		                flint_rand_t state, const fq_default_ctx_t ctx)
+		                flint_rand_ptr state, const fq_default_ctx_t ctx)
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
@@ -910,7 +910,7 @@ FQ_DEFAULT_INLINE void fq_default_rand(fq_default_t rop,
 }
 
 FQ_DEFAULT_INLINE void fq_default_rand_not_zero(fq_default_t rop,
-		                flint_rand_t state, const fq_default_ctx_t ctx)
+		                flint_rand_ptr state, const fq_default_ctx_t ctx)
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {

--- a/fq_default_mat.h
+++ b/fq_default_mat.h
@@ -896,7 +896,7 @@ int fq_default_mat_print_pretty(const fq_default_mat_t mat,
 /* Random matrix generation  *************************************************/
 
 FQ_DEFAULT_MAT_INLINE void fq_default_mat_randtest(fq_default_mat_t mat,
-                                flint_rand_t state, const fq_default_ctx_t ctx)
+                                flint_rand_ptr state, const fq_default_ctx_t ctx)
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
@@ -921,7 +921,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_randtest(fq_default_mat_t mat,
 }
 
 FQ_DEFAULT_MAT_INLINE void fq_default_mat_randrank(fq_default_mat_t mat,
-                    flint_rand_t state, slong rank, const fq_default_ctx_t ctx)
+                    flint_rand_ptr state, slong rank, const fq_default_ctx_t ctx)
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
@@ -948,7 +948,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_randrank(fq_default_mat_t mat,
 
 FQ_DEFAULT_MAT_INLINE
 void fq_default_mat_randops(fq_default_mat_t mat,
-                   slong count, flint_rand_t state, const fq_default_ctx_t ctx)
+                   slong count, flint_rand_ptr state, const fq_default_ctx_t ctx)
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
@@ -974,7 +974,7 @@ void fq_default_mat_randops(fq_default_mat_t mat,
 
 FQ_DEFAULT_MAT_INLINE
 void fq_default_mat_randtril(fq_default_mat_t mat,
-                      flint_rand_t state, int unit, const fq_default_ctx_t ctx)
+                      flint_rand_ptr state, int unit, const fq_default_ctx_t ctx)
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
@@ -1000,7 +1000,7 @@ void fq_default_mat_randtril(fq_default_mat_t mat,
 
 FQ_DEFAULT_MAT_INLINE
 void fq_default_mat_randtriu(fq_default_mat_t mat,
-                      flint_rand_t state, int unit, const fq_default_ctx_t ctx)
+                      flint_rand_ptr state, int unit, const fq_default_ctx_t ctx)
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {

--- a/fq_default_poly.h
+++ b/fq_default_poly.h
@@ -310,7 +310,7 @@ fq_default_poly_degree(const fq_default_poly_t poly,
 /*  Randomisation  ***********************************************************/
 
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_randtest(fq_default_poly_t f,
-                     flint_rand_t state, slong len, const fq_default_ctx_t ctx)
+                     flint_rand_ptr state, slong len, const fq_default_ctx_t ctx)
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
@@ -336,7 +336,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_randtest(fq_default_poly_t f,
 
 FQ_DEFAULT_POLY_INLINE
 void fq_default_poly_randtest_not_zero(fq_default_poly_t f,
-                     flint_rand_t state, slong len, const fq_default_ctx_t ctx)
+                     flint_rand_ptr state, slong len, const fq_default_ctx_t ctx)
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
@@ -363,7 +363,7 @@ void fq_default_poly_randtest_not_zero(fq_default_poly_t f,
 
 FQ_DEFAULT_POLY_INLINE
 void fq_default_poly_randtest_monic(fq_default_poly_t f,
-                     flint_rand_t state, slong len, const fq_default_ctx_t ctx)
+                     flint_rand_ptr state, slong len, const fq_default_ctx_t ctx)
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
@@ -390,7 +390,7 @@ void fq_default_poly_randtest_monic(fq_default_poly_t f,
 
 FQ_DEFAULT_POLY_INLINE
 void fq_default_poly_randtest_irreducible(fq_default_poly_t f,
-                     flint_rand_t state, slong len, const fq_default_ctx_t ctx)
+                     flint_rand_ptr state, slong len, const fq_default_ctx_t ctx)
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {

--- a/fq_mat_templates.h
+++ b/fq_mat_templates.h
@@ -251,23 +251,23 @@ int TEMPLATE(T, mat_print_pretty)(const TEMPLATE(T, mat_t) mat,
 
 /* Random matrix generation  *************************************************/
 
-FLINT_DLL void TEMPLATE(T, mat_randtest)(TEMPLATE(T, mat_t) mat, flint_rand_t state,
+FLINT_DLL void TEMPLATE(T, mat_randtest)(TEMPLATE(T, mat_t) mat, flint_rand_ptr state,
                           const TEMPLATE(T, ctx_t) ctx);
 
-FLINT_DLL void TEMPLATE(T, mat_randrank)(TEMPLATE(T, mat_t) mat, flint_rand_t state,
+FLINT_DLL void TEMPLATE(T, mat_randrank)(TEMPLATE(T, mat_t) mat, flint_rand_ptr state,
                           slong rank, const TEMPLATE(T, ctx_t) ctx);
 
-FLINT_DLL int TEMPLATE(T, mat_randpermdiag)(TEMPLATE(T, mat_t) mat, flint_rand_t state,
+FLINT_DLL int TEMPLATE(T, mat_randpermdiag)(TEMPLATE(T, mat_t) mat, flint_rand_ptr state,
                               TEMPLATE(T, struct) * diag, slong n,
                               const TEMPLATE(T, ctx_t) ctx);
 
 FLINT_DLL void TEMPLATE(T, mat_randops)(TEMPLATE(T, mat_t) mat, slong count,
-                         flint_rand_t state, const TEMPLATE(T, ctx_t) ctx);
+                         flint_rand_ptr state, const TEMPLATE(T, ctx_t) ctx);
 
-FLINT_DLL void TEMPLATE(T, mat_randtril)(TEMPLATE(T, mat_t) mat, flint_rand_t state,
+FLINT_DLL void TEMPLATE(T, mat_randtril)(TEMPLATE(T, mat_t) mat, flint_rand_ptr state,
                           int unit, const TEMPLATE(T, ctx_t) ctx);
 
-FLINT_DLL void TEMPLATE(T, mat_randtriu)(TEMPLATE(T, mat_t) mat, flint_rand_t state,
+FLINT_DLL void TEMPLATE(T, mat_randtriu)(TEMPLATE(T, mat_t) mat, flint_rand_ptr state,
                           int unit, const TEMPLATE(T, ctx_t) ctx);
 
 /* Norms */

--- a/fq_mat_templates/randops.c
+++ b/fq_mat_templates/randops.c
@@ -16,7 +16,7 @@
 
 void
 TEMPLATE(T, mat_randops) (TEMPLATE(T, mat_t) mat, slong count,
-                          flint_rand_t state, const TEMPLATE(T, ctx_t) ctx)
+                          flint_rand_ptr state, const TEMPLATE(T, ctx_t) ctx)
 {
     slong c, i, j, k;
     slong m = mat->r;

--- a/fq_mat_templates/randpermdiag.c
+++ b/fq_mat_templates/randpermdiag.c
@@ -19,7 +19,7 @@
 #include "perm.h"
 
 int
-TEMPLATE(T, mat_randpermdiag) (TEMPLATE(T, mat_t) mat, flint_rand_t state,
+TEMPLATE(T, mat_randpermdiag) (TEMPLATE(T, mat_t) mat, flint_rand_ptr state,
                                TEMPLATE(T, struct) * diag, slong n,
                                const TEMPLATE(T, ctx_t) ctx)
 {

--- a/fq_mat_templates/randrank.c
+++ b/fq_mat_templates/randrank.c
@@ -15,7 +15,7 @@
 #include "templates.h"
 
 void
-TEMPLATE(T, mat_randrank) (TEMPLATE(T, mat_t) mat, flint_rand_t state,
+TEMPLATE(T, mat_randrank) (TEMPLATE(T, mat_t) mat, flint_rand_ptr state,
                            slong rank, const TEMPLATE(T, ctx_t) ctx)
 {
     slong i;

--- a/fq_mat_templates/randtest.c
+++ b/fq_mat_templates/randtest.c
@@ -15,7 +15,7 @@
 #include "templates.h"
 
 void
-TEMPLATE(T, mat_randtest) (TEMPLATE(T, mat_t) mat, flint_rand_t state,
+TEMPLATE(T, mat_randtest) (TEMPLATE(T, mat_t) mat, flint_rand_ptr state,
                            const TEMPLATE(T, ctx_t) ctx)
 {
     slong r, c, i, j;

--- a/fq_mat_templates/randtril.c
+++ b/fq_mat_templates/randtril.c
@@ -15,7 +15,7 @@
 #include "templates.h"
 
 void
-TEMPLATE(T, mat_randtril) (TEMPLATE(T, mat_t) mat, flint_rand_t state,
+TEMPLATE(T, mat_randtril) (TEMPLATE(T, mat_t) mat, flint_rand_ptr state,
                            int unit, const TEMPLATE(T, ctx_t) ctx)
 {
     TEMPLATE(T, struct) * e;

--- a/fq_mat_templates/randtriu.c
+++ b/fq_mat_templates/randtriu.c
@@ -15,7 +15,7 @@
 #include "templates.h"
 
 void
-TEMPLATE(T, mat_randtriu) (TEMPLATE(T, mat_t) mat, flint_rand_t state,
+TEMPLATE(T, mat_randtriu) (TEMPLATE(T, mat_t) mat, flint_rand_ptr state,
                            int unit, const TEMPLATE(T, ctx_t) ctx)
 {
     TEMPLATE(T, struct) * e;

--- a/fq_nmod.h
+++ b/fq_nmod.h
@@ -68,9 +68,9 @@ FLINT_DLL void fq_nmod_ctx_init_modulus(fq_nmod_ctx_t ctx,
                               const nmod_poly_t modulus,
                               const char *var);
 
-FLINT_DLL void fq_nmod_ctx_randtest(fq_nmod_ctx_t ctx, flint_rand_t state);
+FLINT_DLL void fq_nmod_ctx_randtest(fq_nmod_ctx_t ctx, flint_rand_ptr state);
 
-FLINT_DLL void fq_nmod_ctx_randtest_reducible(fq_nmod_ctx_t ctx, flint_rand_t state);
+FLINT_DLL void fq_nmod_ctx_randtest_reducible(fq_nmod_ctx_t ctx, flint_rand_ptr state);
 
 FLINT_DLL void fq_nmod_ctx_clear(fq_nmod_ctx_t ctx);
 
@@ -284,15 +284,15 @@ FLINT_DLL int fq_nmod_is_square(const fq_nmod_t op, const fq_nmod_ctx_t ctx);
 
 /* Randomisation *************************************************************/
 
-FLINT_DLL void fq_nmod_randtest(fq_nmod_t rop, flint_rand_t state, const fq_nmod_ctx_t ctx);
+FLINT_DLL void fq_nmod_randtest(fq_nmod_t rop, flint_rand_ptr state, const fq_nmod_ctx_t ctx);
 
-FLINT_DLL void fq_nmod_randtest_dense(fq_nmod_t rop, flint_rand_t state, const fq_nmod_ctx_t ctx);
+FLINT_DLL void fq_nmod_randtest_dense(fq_nmod_t rop, flint_rand_ptr state, const fq_nmod_ctx_t ctx);
 
-FLINT_DLL void fq_nmod_randtest_not_zero(fq_nmod_t rop, flint_rand_t state, const fq_nmod_ctx_t ctx);
+FLINT_DLL void fq_nmod_randtest_not_zero(fq_nmod_t rop, flint_rand_ptr state, const fq_nmod_ctx_t ctx);
 
-FLINT_DLL void fq_nmod_rand(fq_nmod_t rop, flint_rand_t state, const fq_nmod_ctx_t ctx);
+FLINT_DLL void fq_nmod_rand(fq_nmod_t rop, flint_rand_ptr state, const fq_nmod_ctx_t ctx);
 
-FLINT_DLL void fq_nmod_rand_not_zero(fq_nmod_t rop, flint_rand_t state, const fq_nmod_ctx_t ctx);
+FLINT_DLL void fq_nmod_rand_not_zero(fq_nmod_t rop, flint_rand_ptr state, const fq_nmod_ctx_t ctx);
 
 
 /* Comparison ****************************************************************/

--- a/fq_nmod/ctx_randtest.c
+++ b/fq_nmod/ctx_randtest.c
@@ -14,7 +14,7 @@
 #include "fq_nmod.h"
 
 void
-fq_nmod_ctx_randtest(fq_nmod_ctx_t ctx, flint_rand_t state)
+fq_nmod_ctx_randtest(fq_nmod_ctx_t ctx, flint_rand_ptr state)
 {
     nmod_poly_t modulus;
     mp_limb_t x;

--- a/fq_nmod/ctx_randtest_reducible.c
+++ b/fq_nmod/ctx_randtest_reducible.c
@@ -12,7 +12,7 @@
 #include "fq_nmod.h"
 
 void
-fq_nmod_ctx_randtest_reducible(fq_nmod_ctx_t ctx, flint_rand_t state)
+fq_nmod_ctx_randtest_reducible(fq_nmod_ctx_t ctx, flint_rand_ptr state)
 {
     fmpz_t p;
     slong d;

--- a/fq_nmod/rand.c
+++ b/fq_nmod/rand.c
@@ -12,7 +12,7 @@
 #include "fq_nmod.h"
 
 
-void fq_nmod_rand(fq_nmod_t rop, flint_rand_t state, const fq_nmod_ctx_t ctx)
+void fq_nmod_rand(fq_nmod_t rop, flint_rand_ptr state, const fq_nmod_ctx_t ctx)
 {
     const slong d = fq_nmod_ctx_degree(ctx);
     slong i;
@@ -27,7 +27,7 @@ void fq_nmod_rand(fq_nmod_t rop, flint_rand_t state, const fq_nmod_ctx_t ctx)
 }
 
 
-void fq_nmod_rand_not_zero(fq_nmod_t rop, flint_rand_t state, const fq_nmod_ctx_t ctx)
+void fq_nmod_rand_not_zero(fq_nmod_t rop, flint_rand_ptr state, const fq_nmod_ctx_t ctx)
 {
     int tries = 3;
 

--- a/fq_nmod/randtest.c
+++ b/fq_nmod/randtest.c
@@ -13,7 +13,7 @@
 
 #include "fq_nmod.h"
 
-void fq_nmod_randtest(fq_nmod_t rop, flint_rand_t state, const fq_nmod_ctx_t ctx)
+void fq_nmod_randtest(fq_nmod_t rop, flint_rand_ptr state, const fq_nmod_ctx_t ctx)
 {
     const slong d = fq_nmod_ctx_degree(ctx);
     slong i, sparse;
@@ -40,7 +40,7 @@ void fq_nmod_randtest(fq_nmod_t rop, flint_rand_t state, const fq_nmod_ctx_t ctx
     _nmod_poly_normalise(rop);
 }
 
-void fq_nmod_randtest_dense(fq_nmod_t rop, flint_rand_t state, const fq_nmod_ctx_t ctx)
+void fq_nmod_randtest_dense(fq_nmod_t rop, flint_rand_ptr state, const fq_nmod_ctx_t ctx)
 {
     const slong d = fq_nmod_ctx_degree(ctx);
     slong i;
@@ -56,7 +56,7 @@ void fq_nmod_randtest_dense(fq_nmod_t rop, flint_rand_t state, const fq_nmod_ctx
     _nmod_poly_normalise(rop);
 }
 
-void fq_nmod_randtest_not_zero(fq_nmod_t rop, flint_rand_t state, const fq_nmod_ctx_t ctx)
+void fq_nmod_randtest_not_zero(fq_nmod_t rop, flint_rand_ptr state, const fq_nmod_ctx_t ctx)
 {
     slong i;
 

--- a/fq_nmod_mpoly.h
+++ b/fq_nmod_mpoly.h
@@ -198,19 +198,19 @@ FLINT_DLL bad_fq_nmod_embed_struct * bad_fq_nmod_mpoly_embed_chooser_init(
     bad_fq_nmod_mpoly_embed_chooser_t embc,
     fq_nmod_mpoly_ctx_t ectx,
     const fq_nmod_mpoly_ctx_t ctx,
-    flint_rand_t randstate);
+    flint_rand_ptr randstate);
 
 FLINT_DLL void bad_fq_nmod_mpoly_embed_chooser_clear(
     bad_fq_nmod_mpoly_embed_chooser_t embc,
     fq_nmod_mpoly_ctx_t ectx,
     const fq_nmod_mpoly_ctx_t ctx,
-    flint_rand_t randstate);
+    flint_rand_ptr randstate);
 
 FLINT_DLL bad_fq_nmod_embed_struct * bad_fq_nmod_mpoly_embed_chooser_next(
     bad_fq_nmod_mpoly_embed_chooser_t embc,
     fq_nmod_mpoly_ctx_t ectx,
     const fq_nmod_mpoly_ctx_t ctx,
-    flint_rand_t randstate);
+    flint_rand_ptr randstate);
 
 
 /* Context object ************************************************************/
@@ -222,7 +222,7 @@ FLINT_DLL void fq_nmod_mpoly_ctx_init(fq_nmod_mpoly_ctx_t ctx, slong nvars,
                               const ordering_t ord, const fq_nmod_ctx_t fqctx);
 
 FLINT_DLL void fq_nmod_mpoly_ctx_init_rand(fq_nmod_mpoly_ctx_t ctx,
-                                       flint_rand_t state, slong max_nvars,
+                                       flint_rand_ptr state, slong max_nvars,
                                           flint_bitcnt_t p_bits, slong deg_bound);
 
 FLINT_DLL void fq_nmod_mpoly_ctx_clear(fq_nmod_mpoly_ctx_t ctx);
@@ -664,13 +664,13 @@ FLINT_DLL void _fq_nmod_mpoly_push_exp_ui(fq_nmod_mpoly_t A,
 
 /* Random generation *********************************************************/
 
-FLINT_DLL void fq_nmod_mpoly_randtest_bound(fq_nmod_mpoly_t A, flint_rand_t state,
+FLINT_DLL void fq_nmod_mpoly_randtest_bound(fq_nmod_mpoly_t A, flint_rand_ptr state,
                  slong length, ulong exp_bound, const fq_nmod_mpoly_ctx_t ctx);
 
-FLINT_DLL void fq_nmod_mpoly_randtest_bounds(fq_nmod_mpoly_t A, flint_rand_t state,
+FLINT_DLL void fq_nmod_mpoly_randtest_bounds(fq_nmod_mpoly_t A, flint_rand_ptr state,
               slong length, ulong * exp_bounds, const fq_nmod_mpoly_ctx_t ctx);
 
-FLINT_DLL void fq_nmod_mpoly_randtest_bits(fq_nmod_mpoly_t A, flint_rand_t state,
+FLINT_DLL void fq_nmod_mpoly_randtest_bits(fq_nmod_mpoly_t A, flint_rand_ptr state,
             slong length, flint_bitcnt_t exp_bits, const fq_nmod_mpoly_ctx_t ctx);
 
 
@@ -1200,7 +1200,7 @@ FLINT_DLL void fq_nmod_mpolyu_mul_mpoly_inplace(fq_nmod_mpolyu_t A,
 
 FLINT_DLL int fq_nmod_mpolyu_gcdm_zippel(fq_nmod_mpolyu_t G,
              fq_nmod_mpolyu_t Abar, fq_nmod_mpolyu_t Bbar,  fq_nmod_mpolyu_t A,
-          fq_nmod_mpolyu_t B, fq_nmod_mpoly_ctx_t ctx, flint_rand_t randstate);
+          fq_nmod_mpolyu_t B, fq_nmod_mpoly_ctx_t ctx, flint_rand_ptr randstate);
 
 FQ_NMOD_MPOLY_INLINE mp_limb_t * fq_nmod_mpolyu_leadcoeff(
                        const fq_nmod_mpolyu_t A, const fq_nmod_mpoly_ctx_t ctx)
@@ -1386,7 +1386,7 @@ FLINT_DLL void fq_nmod_next_not_zero(fq_nmod_t alpha, const fq_nmod_ctx_t fqctx)
 FLINT_DLL nmod_gcds_ret_t fq_nmod_mpolyu_gcds_zippel(fq_nmod_mpolyu_t G,
                 fq_nmod_mpolyu_t A, fq_nmod_mpolyu_t B, fq_nmod_mpolyu_t f,
                                     slong var, const fq_nmod_mpoly_ctx_t ctx,
-                                     flint_rand_t randstate, slong * degbound);
+                                     flint_rand_ptr randstate, slong * degbound);
 
 FLINT_DLL int fq_nmod_mpolyu_gcdp_zippel_univar(fq_nmod_mpolyu_t G,
             fq_nmod_mpolyu_t Abar, fq_nmod_mpolyu_t Bbar, fq_nmod_mpolyu_t A,
@@ -1398,7 +1398,7 @@ FLINT_DLL int fq_nmod_mpolyu_gcdp_zippel_univar_no_cofactors(fq_nmod_mpolyu_t G,
 FLINT_DLL int fq_nmod_mpolyu_gcdp_zippel(fq_nmod_mpolyu_t G,
               fq_nmod_mpolyu_t Abar, fq_nmod_mpolyu_t Bbar, fq_nmod_mpolyu_t A,
                   fq_nmod_mpolyu_t B, slong var, const fq_nmod_mpoly_ctx_t ctx,
-                                                       flint_rand_t randstate);
+                                                       flint_rand_ptr randstate);
 
 FLINT_DLL int fq_nmod_mpolyn_gcd_brown_smprime(fq_nmod_mpolyn_t G,
          fq_nmod_mpolyn_t Abar, fq_nmod_mpolyn_t Bbar, fq_nmod_mpolyn_t A,

--- a/fq_nmod_mpoly/ctx_init_rand.c
+++ b/fq_nmod_mpoly/ctx_init_rand.c
@@ -11,7 +11,7 @@
 
 #include "fq_nmod_mpoly.h"
 
-void fq_nmod_mpoly_ctx_init_rand(fq_nmod_mpoly_ctx_t ctx, flint_rand_t state,
+void fq_nmod_mpoly_ctx_init_rand(fq_nmod_mpoly_ctx_t ctx, flint_rand_ptr state,
                     slong max_nvars, flint_bitcnt_t p_bits_bound, slong deg_bound)
 {
     ulong p;

--- a/fq_nmod_mpoly/fq_nmod_embed.c
+++ b/fq_nmod_mpoly/fq_nmod_embed.c
@@ -574,7 +574,7 @@ void bad_fq_nmod_embed_sm_elem_to_lg(
 bad_fq_nmod_embed_struct *
 bad_fq_nmod_mpoly_embed_chooser_init(bad_fq_nmod_mpoly_embed_chooser_t embc,
                   fq_nmod_mpoly_ctx_t ectx, const fq_nmod_mpoly_ctx_t ctx,
-                                                        flint_rand_t randstate)
+                                                        flint_rand_ptr randstate)
 {
     nmod_poly_t ext_modulus;
     fq_nmod_ctx_t ext_fqctx;
@@ -609,7 +609,7 @@ bad_fq_nmod_mpoly_embed_chooser_init(bad_fq_nmod_mpoly_embed_chooser_t embc,
 void
 bad_fq_nmod_mpoly_embed_chooser_clear(bad_fq_nmod_mpoly_embed_chooser_t embc,
                   fq_nmod_mpoly_ctx_t ectx, const fq_nmod_mpoly_ctx_t ctx,
-                                                        flint_rand_t randstate)
+                                                        flint_rand_ptr randstate)
 {
     bad_fq_nmod_embed_array_clear(embc->embed, embc->m);
     fq_nmod_mpoly_ctx_clear(ectx);
@@ -620,7 +620,7 @@ bad_fq_nmod_mpoly_embed_chooser_clear(bad_fq_nmod_mpoly_embed_chooser_t embc,
 bad_fq_nmod_embed_struct *
 bad_fq_nmod_mpoly_embed_chooser_next(bad_fq_nmod_mpoly_embed_chooser_t embc,
                   fq_nmod_mpoly_ctx_t ectx, const fq_nmod_mpoly_ctx_t ctx,
-                                                        flint_rand_t randstate)
+                                                        flint_rand_ptr randstate)
 {
     nmod_poly_t ext_modulus;
     fq_nmod_ctx_t ext_fqctx;

--- a/fq_nmod_mpoly/gcd_zippel.c
+++ b/fq_nmod_mpoly/gcd_zippel.c
@@ -19,7 +19,7 @@ int fq_nmod_mpolyu_gcdm_zippel_bivar(
     fq_nmod_mpolyu_t A,
     fq_nmod_mpolyu_t B,
     fq_nmod_mpoly_ctx_t ctx,
-    flint_rand_t randstate)
+    flint_rand_ptr randstate)
 {
     slong var = 0;
     slong Alastdeg, Blastdeg;
@@ -216,7 +216,7 @@ int fq_nmod_mpolyu_gcdm_zippel(
     fq_nmod_mpolyu_t A,
     fq_nmod_mpolyu_t B,
     fq_nmod_mpoly_ctx_t ctx,
-    flint_rand_t randstate)
+    flint_rand_ptr randstate)
 {
     slong degbound;
     slong bound;

--- a/fq_nmod_mpoly/mpolyu_gcdp_zippel.c
+++ b/fq_nmod_mpoly/mpolyu_gcdp_zippel.c
@@ -371,7 +371,7 @@ nmod_gcds_ret_t fq_nmod_mpolyu_gcds_zippel(
     fq_nmod_mpolyu_t f,
     slong var,
     const fq_nmod_mpoly_ctx_t ctx,
-    flint_rand_t randstate,
+    flint_rand_ptr randstate,
     slong * degbound)
 {
     slong d = fq_nmod_ctx_degree(ctx->fqctx);
@@ -942,7 +942,7 @@ int fq_nmod_mpolyu_gcdp_zippel_bivar(
     fq_nmod_mpolyu_t A,
     fq_nmod_mpolyu_t B,
     const fq_nmod_mpoly_ctx_t ctx,
-    flint_rand_t randstate)
+    flint_rand_ptr randstate)
 {
     slong var = 0;
     slong Alastdeg;
@@ -1180,7 +1180,7 @@ int fq_nmod_mpolyu_gcdp_zippel(
     fq_nmod_mpolyu_t B,
     slong var,
     const fq_nmod_mpoly_ctx_t ctx,
-    flint_rand_t randstate)
+    flint_rand_ptr randstate)
 {
     slong lastdeg;
     slong Alastdeg;

--- a/fq_nmod_mpoly/randtest_bits.c
+++ b/fq_nmod_mpoly/randtest_bits.c
@@ -13,7 +13,7 @@
 
 void fq_nmod_mpoly_randtest_bits(
     fq_nmod_mpoly_t A,
-    flint_rand_t state,
+    flint_rand_ptr state,
     slong length,
     flint_bitcnt_t exp_bits,
     const fq_nmod_mpoly_ctx_t ctx)

--- a/fq_nmod_mpoly/randtest_bound.c
+++ b/fq_nmod_mpoly/randtest_bound.c
@@ -13,7 +13,7 @@
 
 void fq_nmod_mpoly_randtest_bound(
     fq_nmod_mpoly_t A,
-    flint_rand_t state,
+    flint_rand_ptr state,
     slong length,
     ulong exp_bound,
     const fq_nmod_mpoly_ctx_t ctx)

--- a/fq_nmod_mpoly/randtest_bounds.c
+++ b/fq_nmod_mpoly/randtest_bounds.c
@@ -11,7 +11,7 @@
 
 #include "fq_nmod_mpoly.h"
 
-void fq_nmod_mpoly_randtest_bounds(fq_nmod_mpoly_t A, flint_rand_t state,
+void fq_nmod_mpoly_randtest_bounds(fq_nmod_mpoly_t A, flint_rand_ptr state,
                slong length, ulong * exp_bounds, const fq_nmod_mpoly_ctx_t ctx)
 {
     slong d = fq_nmod_ctx_degree(ctx->fqctx);    

--- a/fq_nmod_mpoly/sqrt_heap.c
+++ b/fq_nmod_mpoly/sqrt_heap.c
@@ -14,7 +14,7 @@
 /* try to prove that A is not a square */
 static int _is_proved_not_square(
     int count,
-    flint_rand_t state,
+    flint_rand_ptr state,
     const mp_limb_t * Acoeffs,
     const ulong * Aexps,
     slong Alen,

--- a/fq_nmod_mpoly/test/t-mpolyuu_divides.c
+++ b/fq_nmod_mpoly/test/t-mpolyuu_divides.c
@@ -18,7 +18,7 @@ void univar_divides_check(
     slong ii,
     slong jj,
     const char * name,
-    flint_rand_t randstate)
+    flint_rand_ptr randstate)
 {
     int divides, udivides;
     fq_nmod_mpoly_ctx_t uctx;

--- a/fq_nmod_mpoly_factor.h
+++ b/fq_nmod_mpoly_factor.h
@@ -244,7 +244,7 @@ FLINT_DLL int n_fq_bpoly_factor_lgprime(
     n_tpoly_t F,
     n_bpoly_t B,
     const fq_nmod_ctx_t ctx,
-    flint_rand_t state);
+    flint_rand_ptr state);
 
 /*****************************************************************************/
 
@@ -356,13 +356,13 @@ FLINT_DLL int fq_nmod_mpoly_factor_irred_smprime_zassenhaus(
     fq_nmod_mpolyv_t fac,
     const fq_nmod_mpoly_t A,
     const fq_nmod_mpoly_ctx_t ctx,
-    flint_rand_t state);
+    flint_rand_ptr state);
 
 FLINT_DLL int fq_nmod_mpoly_factor_irred_lgprime_zassenhaus(
     fq_nmod_mpolyv_t fac,
     const fq_nmod_mpoly_t A,
     const fq_nmod_mpoly_ctx_t ctx,
-    flint_rand_t state);
+    flint_rand_ptr state);
 
 FLINT_DLL int fq_nmod_mpoly_factor_irred_smprime_wang(
     fq_nmod_mpolyv_t fac,
@@ -370,7 +370,7 @@ FLINT_DLL int fq_nmod_mpoly_factor_irred_smprime_wang(
     const fq_nmod_mpoly_factor_t lcAfac,
     const fq_nmod_mpoly_t lcA,
     const fq_nmod_mpoly_ctx_t ctx,
-    flint_rand_t state);
+    flint_rand_ptr state);
 
 FLINT_DLL int fq_nmod_mpoly_factor_irred_lgprime_wang(
     fq_nmod_mpolyv_t Af,
@@ -378,7 +378,7 @@ FLINT_DLL int fq_nmod_mpoly_factor_irred_lgprime_wang(
     const fq_nmod_mpoly_factor_t lcAfac,
     const fq_nmod_mpoly_t lcA,
     const fq_nmod_mpoly_ctx_t ctx,
-    flint_rand_t state);
+    flint_rand_ptr state);
 
 FLINT_DLL int fq_nmod_mpoly_factor_irred_smprime_zippel(
     fq_nmod_mpolyv_t fac,
@@ -386,7 +386,7 @@ FLINT_DLL int fq_nmod_mpoly_factor_irred_smprime_zippel(
     const fq_nmod_mpoly_factor_t lcAfac,
     const fq_nmod_mpoly_t lcA,
     const fq_nmod_mpoly_ctx_t ctx,
-    flint_rand_t state);
+    flint_rand_ptr state);
 
 FLINT_DLL int fq_nmod_mpoly_factor_irred_lgprime_zippel(
     fq_nmod_mpolyv_t Af,
@@ -394,7 +394,7 @@ FLINT_DLL int fq_nmod_mpoly_factor_irred_lgprime_zippel(
     const fq_nmod_mpoly_factor_t lcAfac,
     const fq_nmod_mpoly_t lcA,
     const fq_nmod_mpoly_ctx_t ctx,
-    flint_rand_t state);
+    flint_rand_ptr state);
 
 /*****************************************************************************/
 

--- a/fq_nmod_mpoly_factor/irred_lgprime.c
+++ b/fq_nmod_mpoly_factor/irred_lgprime.c
@@ -131,7 +131,7 @@ int fq_nmod_mpoly_factor_irred_lgprime_zassenhaus(
     fq_nmod_mpolyv_t Af,
     const fq_nmod_mpoly_t A,
     const fq_nmod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int success;
     fq_nmod_mpolyv_t eAf;
@@ -232,7 +232,7 @@ int fq_nmod_mpoly_factor_irred_lgprime_wang(
     const fq_nmod_mpoly_factor_t lcAfac,
     const fq_nmod_mpoly_t lcA,
     const fq_nmod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int success;
     fq_nmod_mpoly_factor_t elcAfac;
@@ -297,7 +297,7 @@ int fq_nmod_mpoly_factor_irred_lgprime_zippel(
     const fq_nmod_mpoly_factor_t lcAfac,
     const fq_nmod_mpoly_t lcA,
     const fq_nmod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int success;
     fq_nmod_mpoly_factor_t elcAfac;

--- a/fq_nmod_mpoly_factor/irred_smprime_wang.c
+++ b/fq_nmod_mpoly_factor/irred_smprime_wang.c
@@ -18,7 +18,7 @@ int fq_nmod_mpoly_factor_irred_smprime_wang(
     const fq_nmod_mpoly_factor_t lcAfac,
     const fq_nmod_mpoly_t lcA,
     const fq_nmod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     slong d = fq_nmod_ctx_degree(ctx->fqctx);
     int success;

--- a/fq_nmod_mpoly_factor/irred_smprime_zassenhaus.c
+++ b/fq_nmod_mpoly_factor/irred_smprime_zassenhaus.c
@@ -131,7 +131,7 @@ int fq_nmod_mpoly_factor_irred_smprime_zassenhaus(
     fq_nmod_mpolyv_t fac,
     const fq_nmod_mpoly_t A,
     const fq_nmod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int tries_left = 10;
     int success;

--- a/fq_nmod_mpoly_factor/irred_smprime_zippel.c
+++ b/fq_nmod_mpoly_factor/irred_smprime_zippel.c
@@ -1021,7 +1021,7 @@ int fq_nmod_mpoly_hlift_zippel(
     const fq_nmod_mpoly_t A,
     const slong * degs,
     const fq_nmod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int success, betas_in_fp;
     slong i;
@@ -1263,7 +1263,7 @@ int fq_nmod_mpoly_factor_irred_smprime_zippel(
     const fq_nmod_mpoly_factor_t lcAfac,
     const fq_nmod_mpoly_t lcA,
     const fq_nmod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     slong d = fq_nmod_ctx_degree(ctx->fqctx);
     int success;

--- a/fq_nmod_mpoly_factor/n_bpoly_fq_factor_lgprime.c
+++ b/fq_nmod_mpoly_factor/n_bpoly_fq_factor_lgprime.c
@@ -713,7 +713,7 @@ int n_fq_bpoly_factor_lgprime(
     n_tpoly_t F,
     n_bpoly_t B,
     const fq_nmod_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int success;
     slong i, r, edeg;

--- a/fq_poly_factor_templates.h
+++ b/fq_poly_factor_templates.h
@@ -91,7 +91,7 @@ FLINT_DLL void TEMPLATE(T, poly_factor_distinct_deg)(TEMPLATE(T, poly_factor_t) 
                                       const TEMPLATE(T, ctx_t) ctx);
 
 FLINT_DLL int TEMPLATE(T, poly_factor_equal_deg_prob)(TEMPLATE(T, poly_t) factor,
-                                        flint_rand_t state,
+                                        flint_rand_ptr state,
                                         const TEMPLATE(T, poly_t) pol, slong d,
                                         const TEMPLATE(T, ctx_t) ctx);
 

--- a/fq_poly_factor_templates/factor_berlekamp.c
+++ b/fq_poly_factor_templates/factor_berlekamp.c
@@ -64,7 +64,7 @@ TEMPLATE(T, mat_col_to_shifted) (TEMPLATE(T, poly_t) poly,
 
 static void
 __TEMPLATE(T, poly_factor_berlekamp) (TEMPLATE(T, poly_factor_t) factors,
-                                      flint_rand_t state,
+                                      flint_rand_ptr state,
                                       const TEMPLATE(T, poly_t) f,
                                       const TEMPLATE(T, ctx_t) ctx)
 {

--- a/fq_poly_factor_templates/factor_equal_deg_prob.c
+++ b/fq_poly_factor_templates/factor_equal_deg_prob.c
@@ -21,7 +21,7 @@
 #include "ulong_extras.h"
 int
 TEMPLATE(T, poly_factor_equal_deg_prob) (TEMPLATE(T, poly_t) factor,
-                                         flint_rand_t state,
+                                         flint_rand_ptr state,
                                          const TEMPLATE(T, poly_t) pol,
                                          slong d,
                                          const TEMPLATE(T, ctx_t) ctx)

--- a/fq_poly_factor_templates/roots.c
+++ b/fq_poly_factor_templates/roots.c
@@ -23,7 +23,7 @@ void _TEMPLATE(T, poly_split_rabin)(
     const fmpz_t halfq,         /* (q-1)/2  or 0 in characteristic 2 */
     TEMPLATE(T, poly_t) t,      /* temp space */
     TEMPLATE(T, poly_t) t2,     /* temp space */
-    flint_rand_t randstate,
+    flint_rand_ptr randstate,
     const TEMPLATE(T, ctx_t) ctx)
 {
     slong i;
@@ -94,7 +94,7 @@ static void _TEMPLATE(T, poly_push_roots)(
     TEMPLATE(T, poly_t) t,              /* temp */
     TEMPLATE(T, poly_t) t2,             /* more temp */
     TEMPLATE(T, poly_struct) * stack,   /* temp of size FLINT_BITS */
-    flint_rand_t randstate,
+    flint_rand_ptr randstate,
     const TEMPLATE(T, ctx_t) ctx)
 {
     slong i, sp;

--- a/fq_poly_templates.h
+++ b/fq_poly_templates.h
@@ -96,17 +96,17 @@ TEMPLATE(T, poly_lead)(const TEMPLATE(T, poly_t) poly,
 
 /*  Randomisation  ***********************************************************/
 
-FLINT_DLL void TEMPLATE(T, poly_randtest)(TEMPLATE(T, poly_t) f, flint_rand_t state,
+FLINT_DLL void TEMPLATE(T, poly_randtest)(TEMPLATE(T, poly_t) f, flint_rand_ptr state,
                            slong len, const TEMPLATE(T, ctx_t) ctx);
 
-FLINT_DLL void TEMPLATE(T, poly_randtest_not_zero)(TEMPLATE(T, poly_t) f, flint_rand_t state,
+FLINT_DLL void TEMPLATE(T, poly_randtest_not_zero)(TEMPLATE(T, poly_t) f, flint_rand_ptr state,
                                     slong len, const TEMPLATE(T, ctx_t) ctx);
 
-FLINT_DLL void TEMPLATE(T, poly_randtest_monic) (TEMPLATE(T, poly_t) f, flint_rand_t state,
+FLINT_DLL void TEMPLATE(T, poly_randtest_monic) (TEMPLATE(T, poly_t) f, flint_rand_ptr state,
                                   slong len, const TEMPLATE(T, ctx_t) ctx);
 
 FLINT_DLL void TEMPLATE(T, poly_randtest_irreducible) (TEMPLATE(T, poly_t) f,
-                                        flint_rand_t state, slong len,
+                                        flint_rand_ptr state, slong len,
                                         const TEMPLATE(T, ctx_t) ctx);
 
 

--- a/fq_poly_templates/randtest.c
+++ b/fq_poly_templates/randtest.c
@@ -16,7 +16,7 @@
 #include "templates.h"
 
 void
-TEMPLATE(T, poly_randtest) (TEMPLATE(T, poly_t) f, flint_rand_t state,
+TEMPLATE(T, poly_randtest) (TEMPLATE(T, poly_t) f, flint_rand_ptr state,
                             slong len, const TEMPLATE(T, ctx_t) ctx)
 {
     slong i;
@@ -31,7 +31,7 @@ TEMPLATE(T, poly_randtest) (TEMPLATE(T, poly_t) f, flint_rand_t state,
 }
 
 void
-TEMPLATE(T, poly_randtest_not_zero) (TEMPLATE(T, poly_t) f, flint_rand_t state,
+TEMPLATE(T, poly_randtest_not_zero) (TEMPLATE(T, poly_t) f, flint_rand_ptr state,
                                      slong len, const TEMPLATE(T, ctx_t) ctx)
 {
     slong i;

--- a/fq_poly_templates/randtest_irreducible.c
+++ b/fq_poly_templates/randtest_irreducible.c
@@ -15,7 +15,7 @@
 
 void
 TEMPLATE(T, poly_randtest_irreducible) (TEMPLATE(T, poly_t) f,
-                                        flint_rand_t state, slong len,
+                                        flint_rand_ptr state, slong len,
                                         const TEMPLATE(T, ctx_t) ctx)
 {
     TEMPLATE(T, poly_t) xq, xqi, x, g_i, finv;

--- a/fq_poly_templates/randtest_monic.c
+++ b/fq_poly_templates/randtest_monic.c
@@ -16,7 +16,7 @@
 #include "templates.h"
 
 void
-TEMPLATE(T, poly_randtest_monic) (TEMPLATE(T, poly_t) f, flint_rand_t state,
+TEMPLATE(T, poly_randtest_monic) (TEMPLATE(T, poly_t) f, flint_rand_ptr state,
                                   slong len, const TEMPLATE(T, ctx_t) ctx)
 {
     slong i;

--- a/fq_vec_templates.h
+++ b/fq_vec_templates.h
@@ -28,7 +28,7 @@ FLINT_DLL void _TEMPLATE(T, vec_clear)(TEMPLATE(T, struct) * vec, slong len,
 
 /*  Randomisation  ***********************************************************/
 FLINT_DLL void _TEMPLATE(T, vec_randtest)(TEMPLATE(T, struct) * f, 
-                           flint_rand_t state, 
+                           flint_rand_ptr state, 
                            slong len, 
                            const TEMPLATE(T, ctx_t) ctx);
 

--- a/fq_vec_templates/randtest.c
+++ b/fq_vec_templates/randtest.c
@@ -18,7 +18,7 @@
 
 void
 _TEMPLATE(T, vec_randtest) (TEMPLATE(T, struct) * f,
-                            flint_rand_t state,
+                            flint_rand_ptr state,
                             slong len, const TEMPLATE(T, ctx_t) ctx)
 {
     slong i, sparseness;

--- a/fq_zech.h
+++ b/fq_zech.h
@@ -74,9 +74,9 @@ FLINT_DLL int fq_zech_ctx_init_modulus_check(fq_zech_ctx_t ctx,
                               const nmod_poly_t modulus,
                               const char *var);
 
-FLINT_DLL void fq_zech_ctx_randtest(fq_zech_ctx_t ctx, flint_rand_t state);
+FLINT_DLL void fq_zech_ctx_randtest(fq_zech_ctx_t ctx, flint_rand_ptr state);
 
-FLINT_DLL void fq_zech_ctx_randtest_reducible(fq_zech_ctx_t ctx, flint_rand_t state);
+FLINT_DLL void fq_zech_ctx_randtest_reducible(fq_zech_ctx_t ctx, flint_rand_ptr state);
 
 FLINT_DLL void fq_zech_ctx_clear(fq_zech_ctx_t ctx);
 
@@ -200,16 +200,16 @@ FLINT_DLL int fq_zech_is_square(const fq_zech_t op1, const fq_zech_ctx_t ctx);
 
 /* Randomisation *************************************************************/
 
-FLINT_DLL void fq_zech_randtest(fq_zech_t rop, flint_rand_t state,
+FLINT_DLL void fq_zech_randtest(fq_zech_t rop, flint_rand_ptr state,
                       const fq_zech_ctx_t ctx);
 
-FLINT_DLL void fq_zech_randtest_not_zero(fq_zech_t rop, flint_rand_t state,
+FLINT_DLL void fq_zech_randtest_not_zero(fq_zech_t rop, flint_rand_ptr state,
                                const fq_zech_ctx_t ctx);
 
-FLINT_DLL void fq_zech_rand(fq_zech_t rop, flint_rand_t state,
+FLINT_DLL void fq_zech_rand(fq_zech_t rop, flint_rand_ptr state,
                                                       const fq_zech_ctx_t ctx);
 
-FLINT_DLL void fq_zech_rand_not_zero(fq_zech_t rop, flint_rand_t state,
+FLINT_DLL void fq_zech_rand_not_zero(fq_zech_t rop, flint_rand_ptr state,
                                                       const fq_zech_ctx_t ctx);
 
 /* Comparison ****************************************************************/

--- a/fq_zech/ctx_randtest.c
+++ b/fq_zech/ctx_randtest.c
@@ -16,7 +16,7 @@
 #include <math.h>
 
 void
-fq_zech_ctx_randtest(fq_zech_ctx_t ctx, flint_rand_t state)
+fq_zech_ctx_randtest(fq_zech_ctx_t ctx, flint_rand_ptr state)
 {
     fmpz_t p;
     slong max_d, d;

--- a/fq_zech/ctx_randtest_reducible.c
+++ b/fq_zech/ctx_randtest_reducible.c
@@ -12,7 +12,7 @@
 #include "fq_zech.h"
 
 void
-fq_zech_ctx_randtest_reducible(fq_zech_ctx_t ctx, flint_rand_t state)
+fq_zech_ctx_randtest_reducible(fq_zech_ctx_t ctx, flint_rand_ptr state)
 {
     fq_zech_ctx_randtest(ctx, state);
 }

--- a/fq_zech/rand.c
+++ b/fq_zech/rand.c
@@ -12,13 +12,13 @@
 #include "fq_zech.h"
 
 void
-fq_zech_rand(fq_zech_t rop, flint_rand_t state, const fq_zech_ctx_t ctx)
+fq_zech_rand(fq_zech_t rop, flint_rand_ptr state, const fq_zech_ctx_t ctx)
 {
     rop->value = n_urandint(state, ctx->qm1 + 1);
 }
 
 void
-fq_zech_rand_not_zero(fq_zech_t rop, flint_rand_t state, const fq_zech_ctx_t ctx)
+fq_zech_rand_not_zero(fq_zech_t rop, flint_rand_ptr state, const fq_zech_ctx_t ctx)
 {
     rop->value = n_urandint(state, ctx->qm1);
 }

--- a/fq_zech/randtest.c
+++ b/fq_zech/randtest.c
@@ -12,13 +12,13 @@
 #include "fq_zech.h"
 
 void
-fq_zech_randtest(fq_zech_t rop, flint_rand_t state, const fq_zech_ctx_t ctx)
+fq_zech_randtest(fq_zech_t rop, flint_rand_ptr state, const fq_zech_ctx_t ctx)
 {
     rop->value = n_randint(state, ctx->qm1 + 1);
 }
 
 void
-fq_zech_randtest_not_zero(fq_zech_t rop, flint_rand_t state,
+fq_zech_randtest_not_zero(fq_zech_t rop, flint_rand_ptr state,
                           const fq_zech_ctx_t ctx)
 {
     rop->value = n_randint(state, ctx->qm1);

--- a/fq_zech_mpoly.h
+++ b/fq_zech_mpoly.h
@@ -534,13 +534,13 @@ FLINT_DLL void _fq_zech_mpoly_push_exp_ui(fq_zech_mpoly_t A,
 
 /* Random generation *********************************************************/
 
-FLINT_DLL void fq_zech_mpoly_randtest_bound(fq_zech_mpoly_t A, flint_rand_t state,
+FLINT_DLL void fq_zech_mpoly_randtest_bound(fq_zech_mpoly_t A, flint_rand_ptr state,
                  slong length, ulong exp_bound, const fq_zech_mpoly_ctx_t ctx);
 
-FLINT_DLL void fq_zech_mpoly_randtest_bounds(fq_zech_mpoly_t A, flint_rand_t state,
+FLINT_DLL void fq_zech_mpoly_randtest_bounds(fq_zech_mpoly_t A, flint_rand_ptr state,
               slong length, ulong * exp_bounds, const fq_zech_mpoly_ctx_t ctx);
 
-FLINT_DLL void fq_zech_mpoly_randtest_bits(fq_zech_mpoly_t A, flint_rand_t state,
+FLINT_DLL void fq_zech_mpoly_randtest_bits(fq_zech_mpoly_t A, flint_rand_ptr state,
             slong length, flint_bitcnt_t exp_bits, const fq_zech_mpoly_ctx_t ctx);
 
 

--- a/fq_zech_mpoly_factor.h
+++ b/fq_zech_mpoly_factor.h
@@ -275,7 +275,7 @@ FLINT_DLL int fq_zech_bpoly_factor_lgprime(
     fq_zech_tpoly_t F,
     fq_zech_bpoly_t B,
     const fq_zech_ctx_t ctx,
-    flint_rand_t state);
+    flint_rand_ptr state);
 
 /*****************************************************************************/
 
@@ -592,13 +592,13 @@ FLINT_DLL int fq_zech_mpoly_factor_irred_smprime_zassenhaus(
     fq_zech_mpolyv_t fac,
     const fq_zech_mpoly_t A,
     const fq_zech_mpoly_ctx_t ctx,
-    flint_rand_t state);
+    flint_rand_ptr state);
 
 FLINT_DLL int fq_zech_mpoly_factor_irred_lgprime_zassenhaus(
     fq_zech_mpolyv_t fac,
     const fq_zech_mpoly_t A,
     const fq_zech_mpoly_ctx_t ctx,
-    flint_rand_t state);
+    flint_rand_ptr state);
 
 FLINT_DLL int fq_zech_mpoly_factor_irred_smprime_wang(
     fq_zech_mpolyv_t fac,
@@ -606,7 +606,7 @@ FLINT_DLL int fq_zech_mpoly_factor_irred_smprime_wang(
     const fq_zech_mpoly_factor_t lcAfac,
     const fq_zech_mpoly_t lcA,
     const fq_zech_mpoly_ctx_t ctx,
-    flint_rand_t state);
+    flint_rand_ptr state);
 
 FLINT_DLL int fq_zech_mpoly_factor_irred_lgprime_wang(
     fq_zech_mpolyv_t Af,
@@ -614,7 +614,7 @@ FLINT_DLL int fq_zech_mpoly_factor_irred_lgprime_wang(
     const fq_zech_mpoly_factor_t lcAfac,
     const fq_zech_mpoly_t lcA,
     const fq_zech_mpoly_ctx_t ctx,
-    flint_rand_t state);
+    flint_rand_ptr state);
 
 FLINT_DLL int fq_zech_mpoly_factor_irred_smprime_zippel(
     fq_zech_mpolyv_t fac,
@@ -622,7 +622,7 @@ FLINT_DLL int fq_zech_mpoly_factor_irred_smprime_zippel(
     const fq_zech_mpoly_factor_t lcAfac,
     const fq_zech_mpoly_t lcA,
     const fq_zech_mpoly_ctx_t ctx,
-    flint_rand_t state);
+    flint_rand_ptr state);
 
 FLINT_DLL int fq_zech_mpoly_factor_irred_lgprime_zippel(
     fq_zech_mpolyv_t Af,
@@ -630,7 +630,7 @@ FLINT_DLL int fq_zech_mpoly_factor_irred_lgprime_zippel(
     const fq_zech_mpoly_factor_t lcAfac,
     const fq_zech_mpoly_t lcA,
     const fq_zech_mpoly_ctx_t ctx,
-    flint_rand_t state);
+    flint_rand_ptr state);
 
 /*****************************************************************************/
 

--- a/fq_zech_mpoly_factor/irred_smprime_wang.c
+++ b/fq_zech_mpoly_factor/irred_smprime_wang.c
@@ -18,7 +18,7 @@ int fq_zech_mpoly_factor_irred_smprime_wang(
     const fq_zech_mpoly_factor_t lcAfac,
     const fq_zech_mpoly_t lcA,
     const fq_zech_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int success;
     int alphas_tries_remaining, alphabetas_tries_remaining, alphabetas_length;

--- a/fq_zech_mpoly_factor/irred_smprime_zassenhaus.c
+++ b/fq_zech_mpoly_factor/irred_smprime_zassenhaus.c
@@ -132,7 +132,7 @@ int fq_zech_mpoly_factor_irred_smprime_zassenhaus(
     fq_zech_mpolyv_t fac,
     const fq_zech_mpoly_t A,
     const fq_zech_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int tries_left = 10;
     int success;

--- a/fq_zech_mpoly_factor/irred_smprime_zippel.c
+++ b/fq_zech_mpoly_factor/irred_smprime_zippel.c
@@ -873,7 +873,7 @@ int fq_zech_mpoly_hlift_zippel(
     const fq_zech_mpoly_t A,
     const slong * degs,
     const fq_zech_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int success;
     slong i;
@@ -1072,7 +1072,7 @@ int fq_zech_mpoly_factor_irred_smprime_zippel(
     const fq_zech_mpoly_factor_t lcAfac,
     const fq_zech_mpoly_t lcA,
     const fq_zech_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int success;
     int alphas_tries_remaining, alphabetas_tries_remaining, alphabetas_length;

--- a/long_extras.h
+++ b/long_extras.h
@@ -61,11 +61,11 @@ int z_mat22_det_is_negative(slong m11, slong m12, slong m21, slong m22)
 
 /* Randomisation  ************************************************************/
 
-FLINT_DLL mp_limb_signed_t z_randtest(flint_rand_t state);
+FLINT_DLL mp_limb_signed_t z_randtest(flint_rand_ptr state);
 
-FLINT_DLL mp_limb_signed_t z_randtest_not_zero(flint_rand_t state);
+FLINT_DLL mp_limb_signed_t z_randtest_not_zero(flint_rand_ptr state);
 
-FLINT_DLL mp_limb_signed_t z_randint(flint_rand_t state, mp_limb_t limit);
+FLINT_DLL mp_limb_signed_t z_randint(flint_rand_ptr state, mp_limb_t limit);
 
 /*****************************************************************************/
 

--- a/long_extras/randint.c
+++ b/long_extras/randint.c
@@ -16,7 +16,7 @@
 #include "ulong_extras.h"
 #include "long_extras.h"
 
-mp_limb_signed_t z_randint(flint_rand_t state, mp_limb_t limit)
+mp_limb_signed_t z_randint(flint_rand_ptr state, mp_limb_t limit)
 {
     mp_limb_signed_t z;
 

--- a/long_extras/randtest.c
+++ b/long_extras/randtest.c
@@ -17,7 +17,7 @@
 #include "ulong_extras.h"
 #include "long_extras.h"
 
-mp_limb_signed_t z_randtest(flint_rand_t state)
+mp_limb_signed_t z_randtest(flint_rand_ptr state)
 {
     mp_limb_t m;
     mp_limb_signed_t z;
@@ -48,7 +48,7 @@ mp_limb_signed_t z_randtest(flint_rand_t state)
     return z;
 }
 
-mp_limb_signed_t z_randtest_not_zero(flint_rand_t state)
+mp_limb_signed_t z_randtest_not_zero(flint_rand_ptr state)
 {
     mp_limb_signed_t z;
 

--- a/mpf_mat.h
+++ b/mpf_mat.h
@@ -104,7 +104,7 @@ FLINT_DLL void mpf_mat_print(const mpf_mat_t mat);
 
 /* Random matrix generation  *************************************************/
 
-FLINT_DLL void mpf_mat_randtest(mpf_mat_t mat, flint_rand_t state, flint_bitcnt_t bits);
+FLINT_DLL void mpf_mat_randtest(mpf_mat_t mat, flint_rand_ptr state, flint_bitcnt_t bits);
 
 /* Multiplication */
 

--- a/mpf_mat/randtest.c
+++ b/mpf_mat/randtest.c
@@ -13,7 +13,7 @@
 #include "mpf_mat.h"
 
 void
-mpf_mat_randtest(mpf_mat_t mat, flint_rand_t state, flint_bitcnt_t bits)
+mpf_mat_randtest(mpf_mat_t mat, flint_rand_ptr state, flint_bitcnt_t bits)
 {
     slong r, c, i, j;
 

--- a/mpf_vec.h
+++ b/mpf_vec.h
@@ -35,7 +35,7 @@ FLINT_DLL void _mpf_vec_clear(mpf * vec, slong len);
 
 /*  Randomisation  ***********************************************************/
 
-FLINT_DLL void _mpf_vec_randtest(mpf * f, flint_rand_t state, 
+FLINT_DLL void _mpf_vec_randtest(mpf * f, flint_rand_ptr state, 
                         slong len, flint_bitcnt_t bits);
 
 /*  Assignment and basic manipulation  ***************************************/

--- a/mpf_vec/randtest.c
+++ b/mpf_vec/randtest.c
@@ -12,7 +12,7 @@
 #include "mpf_vec.h"
 
 void
-_mpf_vec_randtest(mpf * f, flint_rand_t state, slong len, flint_bitcnt_t bits)
+_mpf_vec_randtest(mpf * f, flint_rand_ptr state, slong len, flint_bitcnt_t bits)
 {
     slong i;
 

--- a/mpfr_mat.h
+++ b/mpfr_mat.h
@@ -79,7 +79,7 @@ FLINT_DLL void mpfr_mat_zero(mpfr_mat_t mat);
 
 /* Random matrix generation  *************************************************/
 
-FLINT_DLL void mpfr_mat_randtest(mpfr_mat_t mat, flint_rand_t state);
+FLINT_DLL void mpfr_mat_randtest(mpfr_mat_t mat, flint_rand_ptr state);
 
 /* Multiplication */
 

--- a/mpfr_mat/randtest.c
+++ b/mpfr_mat/randtest.c
@@ -14,7 +14,7 @@
 #include "mpfr_mat.h"
 
 void
-mpfr_mat_randtest(mpfr_mat_t mat, flint_rand_t state)
+mpfr_mat_randtest(mpfr_mat_t mat, flint_rand_ptr state)
 {
     slong r, c, i, j;
 

--- a/mpfr_vec.h
+++ b/mpfr_vec.h
@@ -29,7 +29,7 @@ FLINT_DLL flint_mpfr * _mpfr_vec_init(slong length, flint_bitcnt_t prec);
 
 FLINT_DLL void _mpfr_vec_clear(flint_mpfr * vec, slong length);
 
-FLINT_DLL void _mpfr_vec_randtest(flint_mpfr * f, flint_rand_t state, slong len);
+FLINT_DLL void _mpfr_vec_randtest(flint_mpfr * f, flint_rand_ptr state, slong len);
 
 FLINT_DLL void _mpfr_vec_zero(flint_mpfr * vec, slong length);
 

--- a/mpfr_vec/randtest.c
+++ b/mpfr_vec/randtest.c
@@ -13,7 +13,7 @@
 #include "mpfr_vec.h"
 
 void
-_mpfr_vec_randtest(flint_mpfr * f, flint_rand_t state, slong len)
+_mpfr_vec_randtest(flint_mpfr * f, flint_rand_ptr state, slong len)
 {
     slong i;
 

--- a/mpoly.h
+++ b/mpoly.h
@@ -88,9 +88,9 @@ typedef mpoly_ctx_struct mpoly_ctx_t[1];
 
 FLINT_DLL void mpoly_ctx_init(mpoly_ctx_t ctx, slong nvars, const ordering_t ord);
 
-FLINT_DLL void mpoly_ctx_init_rand(mpoly_ctx_t mctx, flint_rand_t state, slong max_nvars);
+FLINT_DLL void mpoly_ctx_init_rand(mpoly_ctx_t mctx, flint_rand_ptr state, slong max_nvars);
 
-FLINT_DLL void mpoly_monomial_randbits_fmpz(fmpz * exp, flint_rand_t state, flint_bitcnt_t exp_bits, const mpoly_ctx_t mctx);
+FLINT_DLL void mpoly_monomial_randbits_fmpz(fmpz * exp, flint_rand_ptr state, flint_bitcnt_t exp_bits, const mpoly_ctx_t mctx);
 
 FLINT_DLL void mpoly_ctx_clear(mpoly_ctx_t mctx);
 
@@ -243,7 +243,7 @@ MPOLY_INLINE slong mpoly_rbtree_fmpz_head(const mpoly_rbtree_fmpz_t T)
 /* Orderings *****************************************************************/
 
 MPOLY_INLINE
-ordering_t mpoly_ordering_randtest(flint_rand_t state)
+ordering_t mpoly_ordering_randtest(flint_rand_ptr state)
 {
    return (ordering_t) n_randint(state, MPOLY_NUM_ORDERINGS);
 }
@@ -1475,7 +1475,7 @@ FLINT_DLL int mpoly_test_irreducible(ulong * Aexps, flint_bitcnt_t Abits,
                                             slong Alen, const mpoly_ctx_t ctx);
 
 FLINT_DLL int _mpoly_test_irreducible(slong * Aexps, slong stride, slong Alen,
-                            slong nvars, flint_rand_t state, slong tries_left);
+                            slong nvars, flint_rand_ptr state, slong tries_left);
 
 typedef struct {
     slong mvars;

--- a/mpoly/ctx_init_rand.c
+++ b/mpoly/ctx_init_rand.c
@@ -11,7 +11,7 @@
 
 #include "mpoly.h"
 
-void mpoly_ctx_init_rand(mpoly_ctx_t mctx, flint_rand_t state, slong max_nvars)
+void mpoly_ctx_init_rand(mpoly_ctx_t mctx, flint_rand_ptr state, slong max_nvars)
 {
     ordering_t ord;
     slong nvars;

--- a/mpoly/randbits_fmpz.c
+++ b/mpoly/randbits_fmpz.c
@@ -17,7 +17,7 @@
     Get a user exponent "exp"' such that it can be packed into "exp_bits" bits.
     The count "exp_bits" includes the extra bits for the sign.
 */
-void mpoly_monomial_randbits_fmpz(fmpz * exp, flint_rand_t state,
+void mpoly_monomial_randbits_fmpz(fmpz * exp, flint_rand_ptr state,
                                   flint_bitcnt_t exp_bits, const mpoly_ctx_t mctx)
 {
     slong j;

--- a/mpoly/test_irreducible.c
+++ b/mpoly/test_irreducible.c
@@ -632,7 +632,7 @@ static int convex_hull_is_indecomposable(
 
 static void z_rand_vec_primitive(
     slong * v, slong len,
-    flint_rand_t state,
+    flint_rand_ptr state,
     mp_limb_t bound)
 {
     slong i, g;
@@ -775,7 +775,7 @@ static int _test_indecomposable3(
 int _mpoly_test_irreducible(
     slong * Aexps, slong stride, slong Alen,
     slong nvars,
-    flint_rand_t state,
+    flint_rand_ptr state,
     slong tries_left)   /* what they call the "projection bound" */
 {
     int success;

--- a/n_poly.h
+++ b/n_poly.h
@@ -734,7 +734,7 @@ FLINT_DLL int n_fq_is_canonical(
 
 FLINT_DLL void n_fq_randtest_not_zero(
     mp_limb_t * a,
-    flint_rand_t state,
+    flint_rand_ptr state,
     const fq_nmod_ctx_t ctx);
 
 FLINT_DLL char * n_fq_get_str_pretty(
@@ -1108,7 +1108,7 @@ FLINT_DLL void n_fq_poly_set(
 
 FLINT_DLL void n_fq_poly_randtest(
     n_fq_poly_t A,
-    flint_rand_t state,
+    flint_rand_ptr state,
     slong len,
     const fq_nmod_ctx_t ctx);
 

--- a/n_poly/n_fq.c
+++ b/n_poly/n_fq.c
@@ -91,7 +91,7 @@ void n_fq_print_pretty(
 
 void n_fq_randtest_not_zero(
     mp_limb_t * a,
-    flint_rand_t state,
+    flint_rand_ptr state,
     const fq_nmod_ctx_t ctx)
 {
     slong d = fq_nmod_ctx_degree(ctx);

--- a/n_poly/n_fq_poly.c
+++ b/n_poly/n_fq_poly.c
@@ -84,7 +84,7 @@ void n_fq_poly_print_pretty(
 
 void n_fq_poly_randtest(
     n_poly_t A,
-    flint_rand_t state,
+    flint_rand_ptr state,
     slong len,
     const fq_nmod_ctx_t ctx)
 {

--- a/nmod_mat.h
+++ b/nmod_mat.h
@@ -119,14 +119,14 @@ FLINT_DLL void nmod_mat_concat_vertical(nmod_mat_t res,
                            const nmod_mat_t mat1,  const nmod_mat_t mat2);
 
 /* Random matrix generation */
-FLINT_DLL void nmod_mat_randtest(nmod_mat_t mat, flint_rand_t state);
-FLINT_DLL void nmod_mat_randfull(nmod_mat_t mat, flint_rand_t state);
-FLINT_DLL int nmod_mat_randpermdiag(nmod_mat_t mat, flint_rand_t state,
+FLINT_DLL void nmod_mat_randtest(nmod_mat_t mat, flint_rand_ptr state);
+FLINT_DLL void nmod_mat_randfull(nmod_mat_t mat, flint_rand_ptr state);
+FLINT_DLL int nmod_mat_randpermdiag(nmod_mat_t mat, flint_rand_ptr state,
                  mp_srcptr diag, slong n);
-FLINT_DLL void nmod_mat_randrank(nmod_mat_t, flint_rand_t state, slong rank);
-FLINT_DLL void nmod_mat_randops(nmod_mat_t mat, slong count, flint_rand_t state);
-FLINT_DLL void nmod_mat_randtril(nmod_mat_t mat, flint_rand_t state, int unit);
-FLINT_DLL void nmod_mat_randtriu(nmod_mat_t mat, flint_rand_t state, int unit);
+FLINT_DLL void nmod_mat_randrank(nmod_mat_t, flint_rand_ptr state, slong rank);
+FLINT_DLL void nmod_mat_randops(nmod_mat_t mat, slong count, flint_rand_ptr state);
+FLINT_DLL void nmod_mat_randtril(nmod_mat_t mat, flint_rand_ptr state, int unit);
+FLINT_DLL void nmod_mat_randtriu(nmod_mat_t mat, flint_rand_ptr state, int unit);
 
 
 FLINT_DLL int nmod_mat_fprint_pretty(FILE* file, const nmod_mat_t mat);

--- a/nmod_mat/randfull.c
+++ b/nmod_mat/randfull.c
@@ -15,7 +15,7 @@
 #include "nmod_mat.h"
 
 void
-nmod_mat_randfull(nmod_mat_t mat, flint_rand_t state)
+nmod_mat_randfull(nmod_mat_t mat, flint_rand_ptr state)
 {
     slong i;
 

--- a/nmod_mat/randops.c
+++ b/nmod_mat/randops.c
@@ -17,7 +17,7 @@
 
 
 void
-nmod_mat_randops(nmod_mat_t mat, slong count, flint_rand_t state)
+nmod_mat_randops(nmod_mat_t mat, slong count, flint_rand_ptr state)
 {
     slong c, i, j, k;
     slong m = mat->r;

--- a/nmod_mat/randpermdiag.c
+++ b/nmod_mat/randpermdiag.c
@@ -16,7 +16,7 @@
 #include "perm.h"
 
 int
-nmod_mat_randpermdiag(nmod_mat_t mat, flint_rand_t state,
+nmod_mat_randpermdiag(nmod_mat_t mat, flint_rand_ptr state,
                             mp_srcptr diag, slong n)
 {
     int parity;

--- a/nmod_mat/randrank.c
+++ b/nmod_mat/randrank.c
@@ -17,7 +17,7 @@
 
 
 void
-nmod_mat_randrank(nmod_mat_t mat, flint_rand_t state, slong rank)
+nmod_mat_randrank(nmod_mat_t mat, flint_rand_ptr state, slong rank)
 {
     slong i;
     mp_limb_t * diag;

--- a/nmod_mat/randtest.c
+++ b/nmod_mat/randtest.c
@@ -15,7 +15,7 @@
 #include "nmod_mat.h"
 
 void
-nmod_mat_randtest(nmod_mat_t mat, flint_rand_t state)
+nmod_mat_randtest(nmod_mat_t mat, flint_rand_ptr state)
 {
     _nmod_vec_randtest(mat->entries, state, mat->r * mat->c, mat->mod);
 }

--- a/nmod_mat/randtril.c
+++ b/nmod_mat/randtril.c
@@ -15,7 +15,7 @@
 #include "nmod_mat.h"
 
 void
-nmod_mat_randtril(nmod_mat_t mat, flint_rand_t state, int unit)
+nmod_mat_randtril(nmod_mat_t mat, flint_rand_ptr state, int unit)
 {
     slong i, j;
 

--- a/nmod_mat/randtriu.c
+++ b/nmod_mat/randtriu.c
@@ -15,7 +15,7 @@
 #include "nmod_mat.h"
 
 void
-nmod_mat_randtriu(nmod_mat_t mat, flint_rand_t state, int unit)
+nmod_mat_randtriu(nmod_mat_t mat, flint_rand_ptr state, int unit)
 {
     slong i, j;
 

--- a/nmod_mat/test/t-mul_blas.c
+++ b/nmod_mat/test/t-mul_blas.c
@@ -18,7 +18,7 @@
 #include "ulong_extras.h"
 
 /* generate a worst case matrix for blas */
-void nmod_mat_randfull_half(nmod_mat_t mat, flint_rand_t state)
+void nmod_mat_randfull_half(nmod_mat_t mat, flint_rand_ptr state)
 {
     slong i, j;
     slong r = mat->r;

--- a/nmod_mpoly.h
+++ b/nmod_mpoly.h
@@ -315,7 +315,7 @@ slong nmod_poly_stack_size_mpolyn(const nmod_poly_stack_t S)
 FLINT_DLL void nmod_mpoly_ctx_init(nmod_mpoly_ctx_t ctx, 
                          slong nvars, const ordering_t ord, mp_limb_t modulus);
 
-FLINT_DLL void nmod_mpoly_ctx_init_rand(nmod_mpoly_ctx_t ctx, flint_rand_t state,
+FLINT_DLL void nmod_mpoly_ctx_init_rand(nmod_mpoly_ctx_t ctx, flint_rand_ptr state,
                                            slong max_nvars, mp_limb_t modulus);
 
 FLINT_DLL void nmod_mpoly_ctx_clear(nmod_mpoly_ctx_t ctx);
@@ -748,13 +748,13 @@ FLINT_DLL void _nmod_mpoly_push_exp_ui(nmod_mpoly_t A,
 
 /* Random generation *********************************************************/
 
-FLINT_DLL void nmod_mpoly_randtest_bounds(nmod_mpoly_t A, flint_rand_t state,
+FLINT_DLL void nmod_mpoly_randtest_bounds(nmod_mpoly_t A, flint_rand_ptr state,
                  slong length, ulong * exp_bounds, const nmod_mpoly_ctx_t ctx);
 
-FLINT_DLL void nmod_mpoly_randtest_bound(nmod_mpoly_t A, flint_rand_t state,
+FLINT_DLL void nmod_mpoly_randtest_bound(nmod_mpoly_t A, flint_rand_ptr state,
                     slong length, ulong exp_bound, const nmod_mpoly_ctx_t ctx);
 
-FLINT_DLL void nmod_mpoly_randtest_bits(nmod_mpoly_t A, flint_rand_t state,
+FLINT_DLL void nmod_mpoly_randtest_bits(nmod_mpoly_t A, flint_rand_ptr state,
                slong length, flint_bitcnt_t exp_bits, const nmod_mpoly_ctx_t ctx);
 
 FLINT_DLL ulong _nmod_mpoly_get_term_ui_fmpz(const nmod_mpoly_t poly,
@@ -1443,7 +1443,7 @@ FLINT_DLL void nmod_mpolyu_setform(nmod_mpolyu_t A, nmod_mpolyu_t B,
 
 FLINT_DLL int nmod_mpolyu_gcdm_zippel(nmod_mpolyu_t G, nmod_mpolyu_t Abar,
                        nmod_mpolyu_t Bbar, nmod_mpolyu_t A, nmod_mpolyu_t B,
-                                 nmod_mpoly_ctx_t ctx, flint_rand_t randstate);
+                                 nmod_mpoly_ctx_t ctx, flint_rand_ptr randstate);
 
 NMOD_MPOLY_INLINE mp_limb_t nmod_mpolyu_leadcoeff(
                                    nmod_mpolyu_t A, const nmod_mpoly_ctx_t ctx)
@@ -1696,11 +1696,11 @@ typedef enum {
 FLINT_DLL nmod_gcds_ret_t nmod_mpolyu_gcds_zippel(nmod_mpolyu_t G,
                            nmod_mpolyu_t A, nmod_mpolyu_t B, nmod_mpolyu_t f,
                                         slong var, const nmod_mpoly_ctx_t ctx,
-                                     flint_rand_t randstate, slong * degbound);
+                                     flint_rand_ptr randstate, slong * degbound);
 
 FLINT_DLL int nmod_mpolyu_gcdp_zippel(nmod_mpolyu_t G, nmod_mpolyu_t Abar,
              nmod_mpolyu_t Bbar, nmod_mpolyu_t A, nmod_mpolyu_t B, slong var,
-                           const nmod_mpoly_ctx_t ctx, flint_rand_t randstate);
+                           const nmod_mpoly_ctx_t ctx, flint_rand_ptr randstate);
 
 FLINT_DLL void nmod_mpoly_to_mpolyl_perm_deflate(
     nmod_mpoly_t A,

--- a/nmod_mpoly/ctx_init_rand.c
+++ b/nmod_mpoly/ctx_init_rand.c
@@ -11,7 +11,7 @@
 
 #include "nmod_mpoly.h"
 
-void nmod_mpoly_ctx_init_rand(nmod_mpoly_ctx_t ctx, flint_rand_t state,
+void nmod_mpoly_ctx_init_rand(nmod_mpoly_ctx_t ctx, flint_rand_ptr state,
                                             slong max_nvars, mp_limb_t modulus)
 {
     mpoly_ctx_init_rand(ctx->minfo, state, max_nvars);

--- a/nmod_mpoly/gcd_zippel.c
+++ b/nmod_mpoly/gcd_zippel.c
@@ -19,7 +19,7 @@ int nmod_mpolyu_gcdm_zippel_bivar(
     nmod_mpolyu_t A,
     nmod_mpolyu_t B,
     nmod_mpoly_ctx_t ctx,
-    flint_rand_t randstate)
+    flint_rand_ptr randstate)
 {
     slong var = 0;
     slong Alastdeg, Blastdeg;
@@ -222,7 +222,7 @@ int nmod_mpolyu_gcdm_zippel(
     nmod_mpolyu_t A,
     nmod_mpolyu_t B,
     nmod_mpoly_ctx_t ctx,
-    flint_rand_t randstate)
+    flint_rand_ptr randstate)
 {
     slong degbound;
     slong bound;

--- a/nmod_mpoly/mpolyu_gcdp_zippel.c
+++ b/nmod_mpoly/mpolyu_gcdp_zippel.c
@@ -186,7 +186,7 @@ cleanup:
 */
 nmod_gcds_ret_t nmod_mpolyu_gcds_zippel(nmod_mpolyu_t G,
                nmod_mpolyu_t A, nmod_mpolyu_t B,  nmod_mpolyu_t f, slong var,
-          const nmod_mpoly_ctx_t ctx, flint_rand_t randstate, slong * degbound)
+          const nmod_mpoly_ctx_t ctx, flint_rand_ptr randstate, slong * degbound)
 {
     int eval_points_tried;
     nmod_gcds_ret_t success;
@@ -866,7 +866,7 @@ int nmod_mpolyu_gcdp_zippel(
     nmod_mpolyu_t B,
     slong var,
     const nmod_mpoly_ctx_t ctx,
-    flint_rand_t randstate)
+    flint_rand_ptr randstate)
 {
     slong lastdeg;
     slong Alastdeg;

--- a/nmod_mpoly/randtest_bits.c
+++ b/nmod_mpoly/randtest_bits.c
@@ -11,7 +11,7 @@
 
 #include "nmod_mpoly.h"
 
-void nmod_mpoly_randtest_bits(nmod_mpoly_t A, flint_rand_t state,
+void nmod_mpoly_randtest_bits(nmod_mpoly_t A, flint_rand_ptr state,
                 slong length, flint_bitcnt_t exp_bits, const nmod_mpoly_ctx_t ctx)
 {
     mp_limb_t p = ctx->mod.n;

--- a/nmod_mpoly/randtest_bound.c
+++ b/nmod_mpoly/randtest_bound.c
@@ -11,7 +11,7 @@
 
 #include "nmod_mpoly.h"
 
-void nmod_mpoly_randtest_bound(nmod_mpoly_t A, flint_rand_t state,
+void nmod_mpoly_randtest_bound(nmod_mpoly_t A, flint_rand_ptr state,
                      slong length, ulong exp_bound, const nmod_mpoly_ctx_t ctx)
 {
     mp_limb_t p = ctx->mod.n;

--- a/nmod_mpoly/randtest_bounds.c
+++ b/nmod_mpoly/randtest_bounds.c
@@ -11,7 +11,7 @@
 
 #include "nmod_mpoly.h"
 
-void nmod_mpoly_randtest_bounds(nmod_mpoly_t A, flint_rand_t state,
+void nmod_mpoly_randtest_bounds(nmod_mpoly_t A, flint_rand_ptr state,
                   slong length, ulong * exp_bounds, const nmod_mpoly_ctx_t ctx)
 {
     mp_limb_t p = ctx->mod.n;

--- a/nmod_mpoly/sqrt_heap.c
+++ b/nmod_mpoly/sqrt_heap.c
@@ -15,7 +15,7 @@
 
 static int _is_proved_not_square_medprime(
     int count,
-    flint_rand_t state,
+    flint_rand_ptr state,
     const mp_limb_t * Acoeffs,
     const ulong * Aexps,
     slong Alen,
@@ -88,7 +88,7 @@ next_p:
 /* try to prove that A is not a square */
 static int _is_proved_not_square(
     int count,
-    flint_rand_t state,
+    flint_rand_ptr state,
     const mp_limb_t * Acoeffs,
     const ulong * Aexps,
     slong Alen,

--- a/nmod_mpoly/test/t-mpolyn_divides_threaded.c
+++ b/nmod_mpoly/test/t-mpolyn_divides_threaded.c
@@ -18,7 +18,7 @@ void _divides_check(
     slong ii,
     slong jj,
     const char * name,
-    flint_rand_t randstate)
+    flint_rand_ptr randstate)
 {
     int divides, ndivides;
     nmod_mpoly_ctx_t nctx;

--- a/nmod_mpoly/test/t-mpolyuu_divides.c
+++ b/nmod_mpoly/test/t-mpolyuu_divides.c
@@ -18,7 +18,7 @@ void univar_divides_check(
     slong ii,
     slong jj,
     const char * name,
-    flint_rand_t randstate)
+    flint_rand_ptr randstate)
 {
     int divides, udivides;
     nmod_mpoly_ctx_t uctx;

--- a/nmod_mpoly_factor.h
+++ b/nmod_mpoly_factor.h
@@ -301,37 +301,37 @@ FLINT_DLL int nmod_mpoly_factor_lcc_wang(nmod_mpoly_struct * lc_divs,
                                                    const nmod_mpoly_ctx_t ctx);
 
 FLINT_DLL int nmod_mpoly_factor_irred_smprime_zassenhaus(nmod_mpolyv_t fac,
-         const nmod_mpoly_t A, const nmod_mpoly_ctx_t ctx, flint_rand_t state);
+         const nmod_mpoly_t A, const nmod_mpoly_ctx_t ctx, flint_rand_ptr state);
 
 FLINT_DLL int nmod_mpoly_factor_irred_medprime_zassenhaus(nmod_mpolyv_t fac,
-         const nmod_mpoly_t A, const nmod_mpoly_ctx_t ctx, flint_rand_t state);
+         const nmod_mpoly_t A, const nmod_mpoly_ctx_t ctx, flint_rand_ptr state);
 
 FLINT_DLL int nmod_mpoly_factor_irred_lgprime_zassenhaus(nmod_mpolyv_t fac,
-         const nmod_mpoly_t A, const nmod_mpoly_ctx_t ctx, flint_rand_t state);
+         const nmod_mpoly_t A, const nmod_mpoly_ctx_t ctx, flint_rand_ptr state);
 
 FLINT_DLL int nmod_mpoly_factor_irred_smprime_wang(nmod_mpolyv_t fac,
        const nmod_mpoly_t A, const nmod_mpoly_factor_t lcAfac,
-       const nmod_mpoly_t lcA, const nmod_mpoly_ctx_t ctx, flint_rand_t state);
+       const nmod_mpoly_t lcA, const nmod_mpoly_ctx_t ctx, flint_rand_ptr state);
 
 FLINT_DLL int nmod_mpoly_factor_irred_medprime_wang(nmod_mpolyv_t Af,
        const nmod_mpoly_t A, const nmod_mpoly_factor_t lcAfac,
-       const nmod_mpoly_t lcA, const nmod_mpoly_ctx_t ctx, flint_rand_t state);
+       const nmod_mpoly_t lcA, const nmod_mpoly_ctx_t ctx, flint_rand_ptr state);
 
 FLINT_DLL int nmod_mpoly_factor_irred_lgprime_wang(nmod_mpolyv_t Af,
        const nmod_mpoly_t A, const nmod_mpoly_factor_t lcAfac,
-       const nmod_mpoly_t lcA, const nmod_mpoly_ctx_t ctx, flint_rand_t state);
+       const nmod_mpoly_t lcA, const nmod_mpoly_ctx_t ctx, flint_rand_ptr state);
 
 FLINT_DLL int nmod_mpoly_factor_irred_smprime_zippel(nmod_mpolyv_t fac,
        const nmod_mpoly_t A, const nmod_mpoly_factor_t lcAfac,
-       const nmod_mpoly_t lcA, const nmod_mpoly_ctx_t ctx, flint_rand_t state);
+       const nmod_mpoly_t lcA, const nmod_mpoly_ctx_t ctx, flint_rand_ptr state);
 
 FLINT_DLL int nmod_mpoly_factor_irred_medprime_zippel(nmod_mpolyv_t Af,
        const nmod_mpoly_t A, const nmod_mpoly_factor_t lcAfac,
-       const nmod_mpoly_t lcA, const nmod_mpoly_ctx_t ctx, flint_rand_t state);
+       const nmod_mpoly_t lcA, const nmod_mpoly_ctx_t ctx, flint_rand_ptr state);
 
 FLINT_DLL int nmod_mpoly_factor_irred_lgprime_zippel(nmod_mpolyv_t Af,
        const nmod_mpoly_t A, const nmod_mpoly_factor_t lcAfac,
-       const nmod_mpoly_t lcA, const nmod_mpoly_ctx_t ctx, flint_rand_t state);
+       const nmod_mpoly_t lcA, const nmod_mpoly_ctx_t ctx, flint_rand_ptr state);
 
 /*****************************************************************************/
 
@@ -418,7 +418,7 @@ FLINT_DLL int n_polyu3_mod_hlift(slong r, n_polyun_struct * BB,  n_polyu_t A,
 
 FLINT_DLL int nmod_mpoly_hlift_zippel(slong m, nmod_mpoly_struct * B, slong r,
             const mp_limb_t * alpha, const nmod_mpoly_t A, const slong * degs,
-                               const nmod_mpoly_ctx_t ctx, flint_rand_t state);
+                               const nmod_mpoly_ctx_t ctx, flint_rand_ptr state);
 
 FLINT_DLL int nmod_mpoly_factor_algo(nmod_mpoly_factor_t f,
           const nmod_mpoly_t A, const nmod_mpoly_ctx_t ctx, unsigned int algo);
@@ -450,11 +450,11 @@ FLINT_DLL void _nmod_mpoly_set_n_bpoly_var1_zero(nmod_mpoly_t A,
 
 FLINT_DLL int nmod_mpolyl_gcdp_zippel_smprime(nmod_mpoly_t G, nmod_mpoly_t Abar,
                 nmod_mpoly_t Bbar, nmod_mpoly_t A, nmod_mpoly_t B, slong var,
-                               const nmod_mpoly_ctx_t ctx, flint_rand_t state);
+                               const nmod_mpoly_ctx_t ctx, flint_rand_ptr state);
 
 FLINT_DLL int nmod_mpolyl_gcds_zippel(nmod_mpoly_t G, const ulong * Gmarks,
         slong Gmarkslen, nmod_mpoly_t A, nmod_mpoly_t B, slong *perm,
-        slong l, slong var, const nmod_mpoly_ctx_t ctx,  flint_rand_t state,
+        slong l, slong var, const nmod_mpoly_ctx_t ctx,  flint_rand_ptr state,
                           slong * Gdegbound, n_poly_t Amarks, n_poly_t Bmarks);
 
 /* zip helpers ***************************************************************/

--- a/nmod_mpoly_factor/gcd_zippel.c
+++ b/nmod_mpoly_factor/gcd_zippel.c
@@ -159,7 +159,7 @@ int nmod_mpolyl_gcds_zippel(
     slong l,
     slong var,
     const nmod_mpoly_ctx_t ctx,
-    flint_rand_t state,
+    flint_rand_ptr state,
     slong * Gdegbound,
     n_poly_t Amarks,    /* temps */
     n_poly_t Bmarks)
@@ -495,7 +495,7 @@ static int _do_bivar_or_univar(
     nmod_mpoly_t B,
     slong var,
     const nmod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     if (var == 1)
     {
@@ -582,7 +582,7 @@ int nmod_mpolyl_gcdp_zippel_smprime(
     nmod_mpoly_t B,
     slong var,
     const nmod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     flint_bitcnt_t bits = A->bits;
     slong i, j, N = mpoly_words_per_exp_sp(bits, ctx->minfo);

--- a/nmod_mpoly_factor/irred_lgprime.c
+++ b/nmod_mpoly_factor/irred_lgprime.c
@@ -127,7 +127,7 @@ int nmod_mpoly_factor_irred_lgprime_zassenhaus(
     nmod_mpolyv_t Af,
     const nmod_mpoly_t A,
     const nmod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int success;
     fq_nmod_mpolyv_t eAf;
@@ -226,7 +226,7 @@ int nmod_mpoly_factor_irred_lgprime_wang(
     const nmod_mpoly_factor_t lcAfac,
     const nmod_mpoly_t lcA,
     const nmod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int success;
     fq_nmod_mpoly_factor_t elcAfac;
@@ -290,7 +290,7 @@ int nmod_mpoly_factor_irred_lgprime_zippel(
     const nmod_mpoly_factor_t lcAfac,
     const nmod_mpoly_t lcA,
     const nmod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int success;
     fq_nmod_mpoly_factor_t elcAfac;

--- a/nmod_mpoly_factor/irred_medprime.c
+++ b/nmod_mpoly_factor/irred_medprime.c
@@ -104,7 +104,7 @@ int nmod_mpoly_factor_irred_medprime_zassenhaus(
     nmod_mpolyv_t Af,
     const nmod_mpoly_t A,
     const nmod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int success;
     fq_zech_mpolyv_t eAf;
@@ -212,7 +212,7 @@ int nmod_mpoly_factor_irred_medprime_wang(
     const nmod_mpoly_factor_t lcAfac,
     const nmod_mpoly_t lcA,
     const nmod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int success;
     const slong n = ctx->minfo->nvars - 1;
@@ -284,7 +284,7 @@ int nmod_mpoly_factor_irred_medprime_zippel(
     const nmod_mpoly_factor_t lcAfac,
     const nmod_mpoly_t lcA,
     const nmod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int success;
     const slong n = ctx->minfo->nvars - 1;

--- a/nmod_mpoly_factor/irred_smprime_wang.c
+++ b/nmod_mpoly_factor/irred_smprime_wang.c
@@ -22,7 +22,7 @@ int nmod_mpoly_factor_irred_smprime_wang(
     const nmod_mpoly_factor_t lcAfac,
     const nmod_mpoly_t lcA,
     const nmod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int success;
     int alphas_tries_remaining, alphabetas_tries_remaining, alphabetas_length;

--- a/nmod_mpoly_factor/irred_smprime_zassenhaus.c
+++ b/nmod_mpoly_factor/irred_smprime_zassenhaus.c
@@ -126,7 +126,7 @@ int nmod_mpoly_factor_irred_smprime_zassenhaus(
     nmod_mpolyv_t fac,
     const nmod_mpoly_t A,
     const nmod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int success;
     int tries_remaining = 10;

--- a/nmod_mpoly_factor/irred_smprime_zippel.c
+++ b/nmod_mpoly_factor/irred_smprime_zippel.c
@@ -22,7 +22,7 @@ int nmod_mpoly_factor_irred_smprime_zippel(
     const nmod_mpoly_factor_t lcAfac,
     const nmod_mpoly_t lcA,
     const nmod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     int success;
     int alphas_tries_remaining, alphabetas_tries_remaining, alphabetas_length;

--- a/nmod_mpoly_factor/mpoly_hlift_zippel.c
+++ b/nmod_mpoly_factor/mpoly_hlift_zippel.c
@@ -588,7 +588,7 @@ int nmod_mpoly_hlift_zippel(
     const nmod_mpoly_t A,
     const slong * degs,
     const nmod_mpoly_ctx_t ctx,
-    flint_rand_t state)
+    flint_rand_ptr state)
 {
     flint_bitcnt_t bits = A->bits;
     int success;

--- a/nmod_poly.h
+++ b/nmod_poly.h
@@ -343,35 +343,35 @@ int nmod_poly_is_gen(const nmod_poly_t poly)
 
 /* Randomisation  ************************************************************/
 
-FLINT_DLL void nmod_poly_randtest(nmod_poly_t poly, flint_rand_t state, slong len);
+FLINT_DLL void nmod_poly_randtest(nmod_poly_t poly, flint_rand_ptr state, slong len);
 
 NMOD_POLY_INLINE
-void nmod_poly_randtest_not_zero(nmod_poly_t poly, flint_rand_t state, slong len)
+void nmod_poly_randtest_not_zero(nmod_poly_t poly, flint_rand_ptr state, slong len)
 {
     do {
         nmod_poly_randtest(poly, state, len);
     } while (nmod_poly_is_zero(poly));
 }
       
-FLINT_DLL void nmod_poly_randtest_irreducible(nmod_poly_t poly, flint_rand_t state, slong len);
+FLINT_DLL void nmod_poly_randtest_irreducible(nmod_poly_t poly, flint_rand_ptr state, slong len);
 
-FLINT_DLL void nmod_poly_randtest_monic(nmod_poly_t poly, flint_rand_t state, slong len);
+FLINT_DLL void nmod_poly_randtest_monic(nmod_poly_t poly, flint_rand_ptr state, slong len);
 
-FLINT_DLL void nmod_poly_randtest_monic_irreducible(nmod_poly_t poly, flint_rand_t state, slong len);
+FLINT_DLL void nmod_poly_randtest_monic_irreducible(nmod_poly_t poly, flint_rand_ptr state, slong len);
 
-FLINT_DLL void nmod_poly_randtest_monic_primitive(nmod_poly_t poly, flint_rand_t state, slong len);
+FLINT_DLL void nmod_poly_randtest_monic_primitive(nmod_poly_t poly, flint_rand_ptr state, slong len);
 
-FLINT_DLL void nmod_poly_randtest_trinomial(nmod_poly_t poly, flint_rand_t state, slong len);
+FLINT_DLL void nmod_poly_randtest_trinomial(nmod_poly_t poly, flint_rand_ptr state, slong len);
 
-FLINT_DLL int nmod_poly_randtest_trinomial_irreducible(nmod_poly_t poly, flint_rand_t state,
+FLINT_DLL int nmod_poly_randtest_trinomial_irreducible(nmod_poly_t poly, flint_rand_ptr state,
                                          slong len, slong max_attempts);
 
-FLINT_DLL void nmod_poly_randtest_pentomial(nmod_poly_t poly, flint_rand_t state, slong len);
+FLINT_DLL void nmod_poly_randtest_pentomial(nmod_poly_t poly, flint_rand_ptr state, slong len);
 
-FLINT_DLL int nmod_poly_randtest_pentomial_irreducible(nmod_poly_t poly, flint_rand_t state,
+FLINT_DLL int nmod_poly_randtest_pentomial_irreducible(nmod_poly_t poly, flint_rand_ptr state,
                                          slong len, slong max_attempts);
 
-FLINT_DLL void nmod_poly_randtest_sparse_irreducible(nmod_poly_t poly, flint_rand_t state, slong len);
+FLINT_DLL void nmod_poly_randtest_sparse_irreducible(nmod_poly_t poly, flint_rand_ptr state, slong len);
 
 /* Getting and setting coefficients  *****************************************/
 
@@ -1373,7 +1373,7 @@ FLINT_DLL void _nmod_poly_product_roots_nmod_vec(mp_ptr poly,
 
 FLINT_DLL void _nmod_poly_split_rabin(nmod_poly_t a, nmod_poly_t b,
                            const nmod_poly_t f, nmod_poly_t t, nmod_poly_t t2,
-                                                       flint_rand_t randstate);
+                                                       flint_rand_ptr randstate);
 
 FLINT_DLL int nmod_poly_find_distinct_nonzero_roots(mp_limb_t * roots,
                                                           const nmod_poly_t P);

--- a/nmod_poly/find_distinct_nonzero_roots.c
+++ b/nmod_poly/find_distinct_nonzero_roots.c
@@ -19,7 +19,7 @@ void _nmod_poly_split_rabin(
     const nmod_poly_t f,
     nmod_poly_t t,
     nmod_poly_t t2,
-    flint_rand_t randstate)
+    flint_rand_ptr randstate)
 {
     FLINT_ASSERT(nmod_poly_degree(f) > 1);
 

--- a/nmod_poly/randtest.c
+++ b/nmod_poly/randtest.c
@@ -17,7 +17,7 @@
 #include "nmod_poly.h"
 
 void
-nmod_poly_randtest(nmod_poly_t poly, flint_rand_t state, slong len)
+nmod_poly_randtest(nmod_poly_t poly, flint_rand_ptr state, slong len)
 {
     nmod_poly_fit_length(poly, len);
     _nmod_vec_randtest(poly->coeffs, state, len, poly->mod);
@@ -26,7 +26,7 @@ nmod_poly_randtest(nmod_poly_t poly, flint_rand_t state, slong len)
 }
 
 void
-nmod_poly_randtest_monic(nmod_poly_t poly, flint_rand_t state, slong len)
+nmod_poly_randtest_monic(nmod_poly_t poly, flint_rand_ptr state, slong len)
 {
     nmod_poly_fit_length(poly, len);
     _nmod_vec_randtest(poly->coeffs, state, len - 1, poly->mod);
@@ -35,7 +35,7 @@ nmod_poly_randtest_monic(nmod_poly_t poly, flint_rand_t state, slong len)
 }
 
 static void
-nmod_poly_randtest_monic_sparse(nmod_poly_t poly, flint_rand_t state,
+nmod_poly_randtest_monic_sparse(nmod_poly_t poly, flint_rand_ptr state,
                                                       slong len, slong nonzero)
 {
     slong i;
@@ -50,7 +50,7 @@ nmod_poly_randtest_monic_sparse(nmod_poly_t poly, flint_rand_t state,
 }
 
 void
-nmod_poly_randtest_irreducible(nmod_poly_t poly, flint_rand_t state, slong len)
+nmod_poly_randtest_irreducible(nmod_poly_t poly, flint_rand_ptr state, slong len)
 {
     do {
         nmod_poly_randtest(poly, state, len);
@@ -58,7 +58,7 @@ nmod_poly_randtest_irreducible(nmod_poly_t poly, flint_rand_t state, slong len)
 }
 
 void
-nmod_poly_randtest_monic_irreducible(nmod_poly_t poly, flint_rand_t state, slong len)
+nmod_poly_randtest_monic_irreducible(nmod_poly_t poly, flint_rand_ptr state, slong len)
 {
     do {
         nmod_poly_randtest_monic(poly, state, len);
@@ -67,7 +67,7 @@ nmod_poly_randtest_monic_irreducible(nmod_poly_t poly, flint_rand_t state, slong
 
 static void
 nmod_poly_randtest_monic_irreducible_sparse(nmod_poly_t poly,
-                                              flint_rand_t state, slong len)
+                                              flint_rand_ptr state, slong len)
 {
     slong i = 0;
     slong terms = 3;
@@ -82,7 +82,7 @@ nmod_poly_randtest_monic_irreducible_sparse(nmod_poly_t poly,
 }
 
 void
-nmod_poly_randtest_trinomial(nmod_poly_t poly, flint_rand_t state, slong len)
+nmod_poly_randtest_trinomial(nmod_poly_t poly, flint_rand_ptr state, slong len)
 {
     ulong k;
     nmod_poly_fit_length(poly, len);
@@ -95,7 +95,7 @@ nmod_poly_randtest_trinomial(nmod_poly_t poly, flint_rand_t state, slong len)
 }
 
 void
-nmod_poly_randtest_pentomial(nmod_poly_t poly, flint_rand_t state, slong len)
+nmod_poly_randtest_pentomial(nmod_poly_t poly, flint_rand_ptr state, slong len)
 {
     nmod_poly_fit_length(poly, len);
     _nmod_vec_zero(poly->coeffs, len);
@@ -108,7 +108,7 @@ nmod_poly_randtest_pentomial(nmod_poly_t poly, flint_rand_t state, slong len)
 }
 
 int
-nmod_poly_randtest_trinomial_irreducible(nmod_poly_t poly, flint_rand_t state,
+nmod_poly_randtest_trinomial_irreducible(nmod_poly_t poly, flint_rand_ptr state,
                                          slong len, slong max_attempts)
 {
     slong i = 0;
@@ -127,7 +127,7 @@ nmod_poly_randtest_trinomial_irreducible(nmod_poly_t poly, flint_rand_t state,
 }
 
 int
-nmod_poly_randtest_pentomial_irreducible(nmod_poly_t poly, flint_rand_t state,
+nmod_poly_randtest_pentomial_irreducible(nmod_poly_t poly, flint_rand_ptr state,
                                          slong len, slong max_attempts)
 {
     slong i = 0;
@@ -146,7 +146,7 @@ nmod_poly_randtest_pentomial_irreducible(nmod_poly_t poly, flint_rand_t state,
 }
 
 void
-nmod_poly_randtest_sparse_irreducible(nmod_poly_t poly, flint_rand_t state, slong len)
+nmod_poly_randtest_sparse_irreducible(nmod_poly_t poly, flint_rand_ptr state, slong len)
 {
     if (len < 3)
     {

--- a/nmod_poly/randtest_monic_primitive.c
+++ b/nmod_poly/randtest_monic_primitive.c
@@ -13,7 +13,7 @@
 #include "fq_nmod.h"
 
 void
-nmod_poly_randtest_monic_primitive(nmod_poly_t poly, flint_rand_t state, slong len)
+nmod_poly_randtest_monic_primitive(nmod_poly_t poly, flint_rand_ptr state, slong len)
 {
     fq_nmod_ctx_t ctx;
     fq_nmod_t X;

--- a/nmod_poly_factor.h
+++ b/nmod_poly_factor.h
@@ -105,7 +105,7 @@ FLINT_DLL void nmod_poly_factor_equal_deg(nmod_poly_factor_t factors,
                                 const nmod_poly_t pol, slong d);
 
 FLINT_DLL int nmod_poly_factor_equal_deg_prob(nmod_poly_t factor,
-    flint_rand_t state, const nmod_poly_t pol, slong d);
+    flint_rand_ptr state, const nmod_poly_t pol, slong d);
 
 FLINT_DLL void nmod_poly_factor_distinct_deg(nmod_poly_factor_t res,
                                    const nmod_poly_t poly, slong * const *degs);

--- a/nmod_poly_factor.h
+++ b/nmod_poly_factor.h
@@ -156,7 +156,7 @@ FLINT_DLL void nmod_poly_roots(nmod_poly_factor_t r,
                                    const nmod_poly_t f, int with_multiplicity);
 
 FLINT_DLL int nmod_poly_roots_factored(nmod_poly_factor_t r,
-             const nmod_poly_t f, int with_multiplicity, const n_factor_t * n);
+             const nmod_poly_t f, int with_multiplicity, n_factor_srcptr n);
 
 /* Inlines *******************************************************************/
 

--- a/nmod_poly_factor/factor_berlekamp.c
+++ b/nmod_poly_factor/factor_berlekamp.c
@@ -56,7 +56,7 @@ nmod_mat_col_to_nmod_poly_shifted(nmod_poly_t poly, nmod_mat_t mat,
 
 static void
 __nmod_poly_factor_berlekamp(nmod_poly_factor_t factors,
-    flint_rand_t state, const nmod_poly_t f)
+    flint_rand_ptr state, const nmod_poly_t f)
 {
     const mp_limb_t p = nmod_poly_modulus(f);
     const slong n      = nmod_poly_degree(f);

--- a/nmod_poly_factor/factor_equal_deg_prob.c
+++ b/nmod_poly_factor/factor_equal_deg_prob.c
@@ -18,7 +18,7 @@
 
 int
 nmod_poly_factor_equal_deg_prob(nmod_poly_t factor,
-    flint_rand_t state, const nmod_poly_t pol, slong d)
+    flint_rand_ptr state, const nmod_poly_t pol, slong d)
 {
     nmod_poly_t a, b, c, polinv;
     mpz_t exp;

--- a/nmod_poly_factor/is_irreducible_rabin.c
+++ b/nmod_poly_factor/is_irreducible_rabin.c
@@ -69,13 +69,13 @@ nmod_poly_is_irreducible_rabin(const nmod_poly_t f)
             n_factor_t factors;
             slong i;
 
-            n_factor_init(&factors);
+            n_factor_init(factors);
 
-	        n_factor(&factors, n, 1);
+	        n_factor(factors, n, 1);
 
-            for (i = 0; i < factors.num; i++)
+            for (i = 0; i < factors->num; i++)
             {
-                nmod_poly_powpowmod(a, x, p, n/factors.p[i], f);
+                nmod_poly_powpowmod(a, x, p, n/factors->p[i], f);
                 nmod_poly_sub(a, a, x);
 
                 if (!nmod_poly_is_zero(a))

--- a/nmod_poly_factor/roots.c
+++ b/nmod_poly_factor/roots.c
@@ -24,7 +24,7 @@ static void _nmod_poly_push_roots(
     nmod_poly_t t,              /* temp */
     nmod_poly_t t2,             /* more temp */
     nmod_poly_struct * stack,   /* temp of size FLINT_BITS */
-    flint_rand_t randstate)
+    flint_rand_ptr randstate)
 {
     slong i, sp;
     nmod_poly_struct * a, * b;

--- a/nmod_poly_factor/roots_factored.c
+++ b/nmod_poly_factor/roots_factored.c
@@ -230,7 +230,7 @@ cleanup:
 
 
 int nmod_poly_roots_factored(nmod_poly_factor_t x0,
-            const nmod_poly_t f, int with_multiplicity, const n_factor_t * fac)
+            const nmod_poly_t f, int with_multiplicity, n_factor_srcptr fac)
 {
     int success = 1;
     slong i, j, k, new_length;

--- a/nmod_poly_factor/test/t-roots_factored.c
+++ b/nmod_poly_factor/test/t-roots_factored.c
@@ -22,7 +22,7 @@ void test_poly(
     nmod_poly_factor_t roots,
     const nmod_poly_t f,
     int want_mult,
-    const n_factor_t * n)
+    n_factor_srcptr n)
 {
     slong i, multiplicity;
     nmod_poly_t q, qt, r;
@@ -137,8 +137,8 @@ main(void)
 
         n = n_randtest_bits(state, n_randint(state, FLINT_BITS) + 1);
         n = FLINT_MAX(n, UWORD(2));
-        n_factor_init(&nfac);
-        n_factor(&nfac, n, 0);
+        n_factor_init(nfac);
+        n_factor(nfac, n, 0);
 
         nmod_poly_init(f, n);
         nmod_poly_factor_init(roots);
@@ -151,14 +151,14 @@ main(void)
             nmod_poly_set_coeff_ui(f, 2, n - 1);
             nmod_poly_set_coeff_ui(f, 0, a);
 
-            if (!nmod_poly_roots_factored(roots, f, 0, &nfac))
+            if (!nmod_poly_roots_factored(roots, f, 0, nfac))
             {
                 flint_printf("FAILED:\ncheck sqrt could be calculated\n");
                 fflush(stdout);
                 flint_abort();
             }
 
-            if (roots->num != n_sqrtmodn(&sqrt, a, &nfac))
+            if (roots->num != n_sqrtmodn(&sqrt, a, nfac))
             {
                 flint_printf("FAILED:\ncheck root count against n_sqrtmodn\n");
                 fflush(stdout);
@@ -168,8 +168,8 @@ main(void)
             if (sqrt)
                 flint_free(sqrt);
 
-            test_poly(roots, f, 0, &nfac);
-            test_poly(roots, f, 1, &nfac);
+            test_poly(roots, f, 0, nfac);
+            test_poly(roots, f, 1, nfac);
         }
 
         nmod_poly_clear(f);
@@ -186,8 +186,8 @@ main(void)
         p = n_randbits(state, n_randint(state, FLINT_BITS) + 1);
         p = FLINT_MAX(p, UWORD(2));
 
-        n_factor_init(&n);
-        n_factor(&n, p, 1);
+        n_factor_init(n);
+        n_factor(n, p, 1);
 
         nmod_poly_init(f, p);
         nmod_poly_factor_init(r);
@@ -211,9 +211,9 @@ main(void)
                 nmod_poly_clear(ff);
             }
 
-            test_poly(r, f, 0, &n);
+            test_poly(r, f, 0, n);
             if (r->num < 1000)
-                test_poly(r, f, 1, &n);
+                test_poly(r, f, 1, n);
         }
 
         nmod_poly_factor_clear(r);

--- a/nmod_poly_mat.h
+++ b/nmod_poly_mat.h
@@ -119,10 +119,10 @@ FLINT_DLL void nmod_poly_mat_one(nmod_poly_mat_t mat);
 
 /* Random matrices ***********************************************************/
 
-FLINT_DLL void nmod_poly_mat_randtest(nmod_poly_mat_t mat, flint_rand_t state,
+FLINT_DLL void nmod_poly_mat_randtest(nmod_poly_mat_t mat, flint_rand_ptr state,
                                 slong len);
 
-FLINT_DLL void nmod_poly_mat_randtest_sparse(nmod_poly_mat_t A, flint_rand_t state,
+FLINT_DLL void nmod_poly_mat_randtest_sparse(nmod_poly_mat_t A, flint_rand_ptr state,
                         slong len, float density);
 
 /* Windows and concatenation */

--- a/nmod_poly_mat/randtest.c
+++ b/nmod_poly_mat/randtest.c
@@ -15,7 +15,7 @@
 #include "nmod_poly_mat.h"
 
 void
-nmod_poly_mat_randtest(nmod_poly_mat_t A, flint_rand_t state, slong len)
+nmod_poly_mat_randtest(nmod_poly_mat_t A, flint_rand_ptr state, slong len)
 {
     slong i, j;
 

--- a/nmod_poly_mat/randtest_sparse.c
+++ b/nmod_poly_mat/randtest_sparse.c
@@ -15,7 +15,7 @@
 #include "ulong_extras.h"
 
 void
-nmod_poly_mat_randtest_sparse(nmod_poly_mat_t A, flint_rand_t state, slong len,
+nmod_poly_mat_randtest_sparse(nmod_poly_mat_t A, flint_rand_ptr state, slong len,
     float density)
 {
     slong i, j;

--- a/nmod_vec.h
+++ b/nmod_vec.h
@@ -50,7 +50,7 @@ void _nmod_vec_clear(mp_ptr vec)
    flint_free(vec);
 }
 
-FLINT_DLL void _nmod_vec_randtest(mp_ptr vec, flint_rand_t state, slong len, nmod_t mod);
+FLINT_DLL void _nmod_vec_randtest(mp_ptr vec, flint_rand_ptr state, slong len, nmod_t mod);
 
 NMOD_VEC_INLINE
 void _nmod_vec_zero(mp_ptr vec, slong len)

--- a/nmod_vec/discrete_log_pohlig_hellman.c
+++ b/nmod_vec/discrete_log_pohlig_hellman.c
@@ -73,12 +73,12 @@ double nmod_discrete_log_pohlig_hellman_precompute_prime(nmod_discrete_log_pohli
     /* just free everything and allocate again for now */
     nmod_discrete_log_pohlig_hellman_clear(L);
 
-    n_factor_init(&factors);
-    n_factor(&factors, p - 1, 1);
+    n_factor_init(factors);
+    n_factor(factors, p - 1, 1);
 
     nmod_init(&L->mod, p);
     L->entries = NULL;
-    L->num_factors = factors.num;
+    L->num_factors = factors->num;
     if (L->num_factors > 0)
     {
         L->entries = (nmod_discrete_log_pohlig_hellman_entry_struct*) flint_malloc(
@@ -91,8 +91,8 @@ double nmod_discrete_log_pohlig_hellman_precompute_prime(nmod_discrete_log_pohli
 
         Li = L->entries + i;
 
-        Li->exp = factors.exp[i];
-        Li->prime = factors.p[i];
+        Li->exp = factors->exp[i];
+        Li->prime = factors->p[i];
 
         fmpz_init(recp);
         fmpz_init(temp);

--- a/nmod_vec/randtest.c
+++ b/nmod_vec/randtest.c
@@ -15,7 +15,7 @@
 #include "ulong_extras.h"
 #include "nmod_vec.h"
 
-void _nmod_vec_randtest(mp_ptr vec, flint_rand_t state, slong len, nmod_t mod)
+void _nmod_vec_randtest(mp_ptr vec, flint_rand_ptr state, slong len, nmod_t mod)
 {
     slong i, sparseness;
 

--- a/padic.h
+++ b/padic.h
@@ -179,12 +179,12 @@ FLINT_DLL void padic_reduce(padic_t rop, const padic_ctx_t ctx);
 
 /* Randomisation *************************************************************/
 
-FLINT_DLL void padic_randtest(padic_t rop, flint_rand_t state, const padic_ctx_t ctx);
+FLINT_DLL void padic_randtest(padic_t rop, flint_rand_ptr state, const padic_ctx_t ctx);
 
-FLINT_DLL void padic_randtest_not_zero(padic_t rop, flint_rand_t state, 
+FLINT_DLL void padic_randtest_not_zero(padic_t rop, flint_rand_ptr state, 
                              const padic_ctx_t ctx);
 
-FLINT_DLL void padic_randtest_int(padic_t rop, flint_rand_t state, 
+FLINT_DLL void padic_randtest_int(padic_t rop, flint_rand_ptr state, 
                         const padic_ctx_t ctx);
 
 /* Assignments and conversions ***********************************************/

--- a/padic/randtest.c
+++ b/padic/randtest.c
@@ -13,7 +13,7 @@
 
 #define PADIC_RANDTEST_TRIES  10
 
-void padic_randtest(padic_t rop, flint_rand_t state, const padic_ctx_t ctx)
+void padic_randtest(padic_t rop, flint_rand_ptr state, const padic_ctx_t ctx)
 {
     const slong N = padic_prec(rop);
 
@@ -46,7 +46,7 @@ void padic_randtest(padic_t rop, flint_rand_t state, const padic_ctx_t ctx)
         fmpz_clear(pow);
 }
 
-void padic_randtest_not_zero(padic_t rop, flint_rand_t state, 
+void padic_randtest_not_zero(padic_t rop, flint_rand_ptr state, 
                              const padic_ctx_t ctx)
 {
     slong i;
@@ -63,7 +63,7 @@ void padic_randtest_not_zero(padic_t rop, flint_rand_t state,
     }
 }
 
-void padic_randtest_int(padic_t rop, flint_rand_t state, 
+void padic_randtest_int(padic_t rop, flint_rand_ptr state, 
                         const padic_ctx_t ctx)
 {
     const slong N = padic_prec(rop);

--- a/padic/test/t-log.c
+++ b/padic/test/t-log.c
@@ -17,7 +17,7 @@
     This is important as for negative N, exp(0) is 1, which is 0 mod p^N, 
     and then log(0) does not converge.
  */
-static slong __rand_prec(flint_rand_t state, slong i)
+static slong __rand_prec(flint_rand_ptr state, slong i)
 {
     slong N;
 

--- a/padic/test/t-log_balanced.c
+++ b/padic/test/t-log_balanced.c
@@ -17,7 +17,7 @@
     This is important as for negative N, exp(0) is 1, which is 0 mod p^N, 
     and then log(0) does not converge.
  */
-static slong __rand_prec(flint_rand_t state, slong i)
+static slong __rand_prec(flint_rand_ptr state, slong i)
 {
     slong N;
 

--- a/padic/test/t-log_rectangular.c
+++ b/padic/test/t-log_rectangular.c
@@ -17,7 +17,7 @@
     This is important as for negative N, exp(0) is 1, which is 0 mod p^N, 
     and then log(0) does not converge.
  */
-static slong __rand_prec(flint_rand_t state, slong i)
+static slong __rand_prec(flint_rand_ptr state, slong i)
 {
     slong N;
 

--- a/padic/test/t-log_satoh.c
+++ b/padic/test/t-log_satoh.c
@@ -17,7 +17,7 @@
     This is important as for negative N, exp(0) is 1, which is 0 mod p^N, 
     and then log(0) does not converge.
  */
-static slong __rand_prec(flint_rand_t state, slong i)
+static slong __rand_prec(flint_rand_ptr state, slong i)
 {
     slong N;
 

--- a/padic_mat.h
+++ b/padic_mat.h
@@ -240,7 +240,7 @@ int padic_mat_print_pretty(const padic_mat_t A, const padic_ctx_t ctx)
 
 /* Random matrix generation  *************************************************/
 
-FLINT_DLL void padic_mat_randtest(padic_mat_t mat, flint_rand_t state, 
+FLINT_DLL void padic_mat_randtest(padic_mat_t mat, flint_rand_ptr state, 
                         const padic_ctx_t ctx);
 
 /* Transpose *****************************************************************/

--- a/padic_mat/randtest.c
+++ b/padic_mat/randtest.c
@@ -12,7 +12,7 @@
 #include "fmpz_mat.h"
 #include "padic_mat.h"
 
-void padic_mat_randtest(padic_mat_t mat, flint_rand_t state, const padic_ctx_t ctx)
+void padic_mat_randtest(padic_mat_t mat, flint_rand_ptr state, const padic_ctx_t ctx)
 {
     if (!padic_mat_is_empty(mat))
     {

--- a/padic_poly.h
+++ b/padic_poly.h
@@ -155,13 +155,13 @@ PADIC_POLY_INLINE slong padic_poly_val(const padic_poly_t poly)
 
 /*  Randomisation  ***********************************************************/
 
-FLINT_DLL void padic_poly_randtest(padic_poly_t f, flint_rand_t state, 
+FLINT_DLL void padic_poly_randtest(padic_poly_t f, flint_rand_ptr state, 
                          slong len, const padic_ctx_t ctx);
 
-FLINT_DLL void padic_poly_randtest_not_zero(padic_poly_t f, flint_rand_t state,
+FLINT_DLL void padic_poly_randtest_not_zero(padic_poly_t f, flint_rand_ptr state,
                                   slong len, const padic_ctx_t ctx);
 
-FLINT_DLL void padic_poly_randtest_val(padic_poly_t f, flint_rand_t state, 
+FLINT_DLL void padic_poly_randtest_val(padic_poly_t f, flint_rand_ptr state, 
                              slong val, slong len, const padic_ctx_t ctx);
 
 /*  Assignment and basic manipulation  ***************************************/

--- a/padic_poly/randtest.c
+++ b/padic_poly/randtest.c
@@ -16,7 +16,7 @@
 #include "flint.h"
 #include "padic_poly.h"
 
-void padic_poly_randtest_val(padic_poly_t f, flint_rand_t state, 
+void padic_poly_randtest_val(padic_poly_t f, flint_rand_ptr state, 
                              slong val, slong len, const padic_ctx_t ctx)
 {
     const slong N = padic_poly_prec(f);
@@ -59,7 +59,7 @@ void padic_poly_randtest_val(padic_poly_t f, flint_rand_t state,
     }
 }
 
-void padic_poly_randtest(padic_poly_t f, flint_rand_t state, 
+void padic_poly_randtest(padic_poly_t f, flint_rand_ptr state, 
                          slong len, const padic_ctx_t ctx)
 {
     const slong N = padic_poly_prec(f);
@@ -87,7 +87,7 @@ void padic_poly_randtest(padic_poly_t f, flint_rand_t state,
     padic_poly_randtest_val(f, state, val, len, ctx);
 }
 
-void padic_poly_randtest_not_zero(padic_poly_t f, flint_rand_t state, 
+void padic_poly_randtest_not_zero(padic_poly_t f, flint_rand_ptr state, 
                                   slong len, const padic_ctx_t ctx)
 {
     slong i;

--- a/perm.h
+++ b/perm.h
@@ -142,7 +142,7 @@ _perm_compose(slong *res, const slong *vec1, const slong *vec2, slong n)
 
 /* Randomisation *************************************************************/
 
-FLINT_DLL int _perm_randtest(slong * vec, slong n, flint_rand_t state);
+FLINT_DLL int _perm_randtest(slong * vec, slong n, flint_rand_ptr state);
 
 /* Parity ********************************************************************/
 

--- a/perm/randtest.c
+++ b/perm/randtest.c
@@ -14,7 +14,7 @@
 #include "flint.h"
 #include "ulong_extras.h"
 
-int _perm_randtest(slong *vec, slong n, flint_rand_t state)
+int _perm_randtest(slong *vec, slong n, flint_rand_ptr state)
 {
     slong i, j, t;
 

--- a/qadic.h
+++ b/qadic.h
@@ -204,27 +204,27 @@ QADIC_INLINE void qadic_reduce(qadic_t x, const qadic_ctx_t ctx)
 /* Randomisation *************************************************************/
 
 QADIC_INLINE void 
-qadic_randtest(qadic_t x, flint_rand_t state, const qadic_ctx_t ctx)
+qadic_randtest(qadic_t x, flint_rand_ptr state, const qadic_ctx_t ctx)
 {
     padic_poly_randtest(x, state, qadic_ctx_degree(ctx), &ctx->pctx);
 }
 
 QADIC_INLINE void 
-qadic_randtest_not_zero(qadic_t x, flint_rand_t state, const qadic_ctx_t ctx)
+qadic_randtest_not_zero(qadic_t x, flint_rand_ptr state, const qadic_ctx_t ctx)
 {
     padic_poly_randtest_not_zero(x, state, qadic_ctx_degree(ctx), 
                                  &ctx->pctx);
 }
 
 QADIC_INLINE void 
-qadic_randtest_val(qadic_t x, flint_rand_t state, slong val, 
+qadic_randtest_val(qadic_t x, flint_rand_ptr state, slong val, 
                    const qadic_ctx_t ctx)
 {
     padic_poly_randtest_val(x, state, val, qadic_ctx_degree(ctx), &ctx->pctx);
 }
 
 QADIC_INLINE void 
-qadic_randtest_int(qadic_t x, flint_rand_t state, const qadic_ctx_t ctx)
+qadic_randtest_int(qadic_t x, flint_rand_ptr state, const qadic_ctx_t ctx)
 {
     const slong N = qadic_prec(x);
 

--- a/qsieve.h
+++ b/qsieve.h
@@ -423,7 +423,7 @@ FLINT_DLL uint64_t get_null_entry(uint64_t * nullrows, slong i, slong l);
 
 FLINT_DLL void reduce_matrix(qs_t qs_inf, slong *nrows, slong *ncols, la_col_t *cols);
 
-FLINT_DLL uint64_t * block_lanczos(flint_rand_t state, slong nrows,
+FLINT_DLL uint64_t * block_lanczos(flint_rand_ptr state, slong nrows,
 			slong dense_rows, slong ncols, la_col_t *B);
 
 FLINT_DLL void qsieve_square_root(fmpz_t X, fmpz_t Y, qs_t qs_inf,

--- a/qsieve/block_lanczos.c
+++ b/qsieve/block_lanczos.c
@@ -695,7 +695,7 @@ void combine_cols(slong ncols,
 }
 
 /*-----------------------------------------------------------------------*/
-uint64_t * block_lanczos(flint_rand_t state, slong nrows, 
+uint64_t * block_lanczos(flint_rand_ptr state, slong nrows, 
 			slong dense_rows, slong ncols, la_col_t *B) {
 	
 	/* Solve Bx = 0 for some nonzero x; the computed

--- a/qsieve/test/t-factor.c
+++ b/qsieve/test/t-factor.c
@@ -20,7 +20,7 @@
 #include "qsieve.h"
 #include "thread_support.h"
 
-void randprime(fmpz_t p, flint_rand_t state, slong bits)
+void randprime(fmpz_t p, flint_rand_ptr state, slong bits)
 {
     fmpz_randbits(p, state, bits);
  

--- a/todo.txt
+++ b/todo.txt
@@ -39,9 +39,6 @@ ulong_extras
 
 * add profile code for factor_trial, factor_one_line, factor_SQUFOF
 
-* [maybe] make n_factor_t an array of length 1 so it can be passed by reference
-  automatically, as per mpz_t's, etc
-
 * [enhancement] Implement a primality test which only requires factoring of
   n-1 up to n^1/3 or n^1/4
 

--- a/ulong_extras.h
+++ b/ulong_extras.h
@@ -39,7 +39,11 @@ typedef struct {
    int num;
    int exp[FLINT_MAX_FACTORS_IN_LIMB];
    ulong p[FLINT_MAX_FACTORS_IN_LIMB];
-} n_factor_t;
+} n_factor_struct;
+
+typedef n_factor_struct n_factor_t[1];
+typedef n_factor_struct * n_factor_ptr;
+typedef const n_factor_struct * n_factor_srcptr;
 
 #define FLINT_ODDPRIME_SMALL_CUTOFF 4096
 #define FLINT_NUM_PRIMES_SMALL 172
@@ -84,6 +88,8 @@ typedef struct
 n_primes_struct;
 
 typedef n_primes_struct n_primes_t[1];
+typedef n_primes_struct * n_primes_ptr;
+typedef const n_primes_struct * n_primes_srcptr;
 
 FLINT_DLL void n_primes_init(n_primes_t iter);
 
@@ -317,7 +323,7 @@ FLINT_DLL slong n_sqrtmod_2pow(ulong ** sqrt, ulong a, slong exp);
 FLINT_DLL slong n_sqrtmod_primepow(ulong ** sqrt, ulong a, 
                                               ulong p, slong exp);
 
-FLINT_DLL slong n_sqrtmodn(ulong ** sqrt, ulong a, n_factor_t * fac);
+FLINT_DLL slong n_sqrtmodn(ulong ** sqrt, ulong a, n_factor_ptr fac);
 
 FLINT_DLL ulong n_gcd(ulong x, ulong y);
 
@@ -412,23 +418,23 @@ FLINT_DLL int n_remove(ulong * n, ulong p);
 FLINT_DLL int n_remove2_precomp(ulong * n, ulong p, double ppre);
 
 ULONG_EXTRAS_INLINE
-void n_factor_init(n_factor_t * factors)
+void n_factor_init(n_factor_ptr factors)
 {
     factors->num = UWORD(0);
 }
 
-FLINT_DLL void n_factor_insert(n_factor_t * factors, ulong p, ulong exp);
+FLINT_DLL void n_factor_insert(n_factor_ptr factors, ulong p, ulong exp);
 
-FLINT_DLL ulong n_factor_trial_range(n_factor_t * factors, 
+FLINT_DLL ulong n_factor_trial_range(n_factor_ptr factors, 
                          ulong n, ulong start, ulong num_primes);
 
-FLINT_DLL ulong n_factor_trial_partial(n_factor_t * factors, ulong n, 
+FLINT_DLL ulong n_factor_trial_partial(n_factor_ptr factors, ulong n, 
                 ulong * prod, ulong num_primes, ulong limit);
 
-FLINT_DLL ulong n_factor_trial(n_factor_t * factors, 
+FLINT_DLL ulong n_factor_trial(n_factor_ptr factors, 
                                   ulong n, ulong num_primes);
 
-FLINT_DLL ulong n_factor_partial(n_factor_t * factors, 
+FLINT_DLL ulong n_factor_partial(n_factor_ptr factors, 
                            ulong n, ulong limit, int proved);
 
 FLINT_DLL ulong n_factor_power235(ulong *exp, ulong n);
@@ -439,7 +445,7 @@ FLINT_DLL ulong n_factor_lehman(ulong n);
 
 FLINT_DLL ulong n_factor_SQUFOF(ulong n, ulong iters);
 
-FLINT_DLL void n_factor(n_factor_t * factors, ulong n, int proved);
+FLINT_DLL void n_factor(n_factor_ptr factors, ulong n, int proved);
 
 FLINT_DLL ulong n_factor_pp1(ulong n, ulong B1, ulong c);
 
@@ -472,7 +478,7 @@ FLINT_DLL ulong n_factorial_mod2_preinv(ulong n, ulong p, ulong pinv);
 
 FLINT_DLL ulong n_factorial_fast_mod2_preinv(ulong n, ulong p, ulong pinv);
 
-FLINT_DLL ulong n_primitive_root_prime_prefactor(ulong p, n_factor_t * factors);
+FLINT_DLL ulong n_primitive_root_prime_prefactor(ulong p, n_factor_ptr factors);
 
 FLINT_DLL ulong n_primitive_root_prime(ulong p);
 

--- a/ulong_extras.h
+++ b/ulong_extras.h
@@ -153,23 +153,23 @@ ULONG_EXTRAS_INLINE int n_sub_checked(ulong * a, ulong b, ulong c)
 
 /*****************************************************************************/
 
-FLINT_DLL ulong n_randlimb(flint_rand_t state);
+FLINT_DLL ulong n_randlimb(flint_rand_ptr state);
 
-FLINT_DLL ulong n_randint(flint_rand_t state, ulong limit);
+FLINT_DLL ulong n_randint(flint_rand_ptr state, ulong limit);
 
-FLINT_DLL ulong n_urandint(flint_rand_t state, ulong limit);
+FLINT_DLL ulong n_urandint(flint_rand_ptr state, ulong limit);
 
-FLINT_DLL ulong n_randbits(flint_rand_t state, unsigned int bits);
+FLINT_DLL ulong n_randbits(flint_rand_ptr state, unsigned int bits);
 
-FLINT_DLL ulong n_randtest_bits(flint_rand_t state, int bits);
+FLINT_DLL ulong n_randtest_bits(flint_rand_ptr state, int bits);
 
-FLINT_DLL ulong n_randtest(flint_rand_t state);
+FLINT_DLL ulong n_randtest(flint_rand_ptr state);
 
-FLINT_DLL ulong n_randtest_not_zero(flint_rand_t state);
+FLINT_DLL ulong n_randtest_not_zero(flint_rand_ptr state);
 
-FLINT_DLL ulong n_randprime(flint_rand_t state, ulong bits, int proved);
+FLINT_DLL ulong n_randprime(flint_rand_ptr state, ulong bits, int proved);
 
-FLINT_DLL ulong n_randtest_prime(flint_rand_t state, int proved);
+FLINT_DLL ulong n_randtest_prime(flint_rand_ptr state, int proved);
 
 FLINT_DLL ulong n_pow(ulong n, ulong exp);
 
@@ -452,7 +452,7 @@ FLINT_DLL int n_factor_pollard_brent_single(ulong *factor, ulong n,
                                             ulong xi, ulong normbits,
                                             ulong max_iters);
 
-FLINT_DLL int n_factor_pollard_brent(ulong *factor, flint_rand_t state, 
+FLINT_DLL int n_factor_pollard_brent(ulong *factor, flint_rand_ptr state, 
                                      ulong n_in, ulong max_tries, 
                                      ulong max_iters);
 
@@ -527,7 +527,7 @@ FLINT_DLL int n_factor_ecm_stage_II(ulong *f, ulong B1, ulong B2,
                                     ulong P, ulong n, n_ecm_t n_ecm_inf);
 
 FLINT_DLL int n_factor_ecm(ulong *f, ulong curves, ulong B1,
-                           ulong B2, flint_rand_t state, ulong n);
+                           ulong B2, flint_rand_ptr state, ulong n);
 
 FLINT_DLL mp_limb_t n_mulmod_precomp_shoup(mp_limb_t w, mp_limb_t p);
 

--- a/ulong_extras/euler_phi.c
+++ b/ulong_extras/euler_phi.c
@@ -21,12 +21,12 @@ mp_limb_t n_euler_phi(mp_limb_t n)
     if (n < 2)
         return n;
 
-    n_factor_init(&fac);
-    n_factor(&fac, n, 1);
+    n_factor_init(fac);
+    n_factor(fac, n, 1);
 
     phi = UWORD(1);
-    for (i = 0; i < fac.num; i++)
-        phi *= (fac.p[i]-1) * n_pow(fac.p[i], fac.exp[i]-1);
+    for (i = 0; i < fac->num; i++)
+        phi *= (fac->p[i]-1) * n_pow(fac->p[i], fac->exp[i]-1);
 
     return phi;
 }

--- a/ulong_extras/factor.c
+++ b/ulong_extras/factor.c
@@ -23,7 +23,7 @@ static int is_prime(mp_limb_t n, int proved)
     return proved ? n_is_prime(n) : n_is_probabprime(n);
 }
 
-void n_factor(n_factor_t * factors, mp_limb_t n, int proved)
+void n_factor(n_factor_ptr factors, mp_limb_t n, int proved)
 {
    ulong factor_arr[FLINT_MAX_FACTORS_IN_LIMB];
    ulong exp_arr[FLINT_MAX_FACTORS_IN_LIMB];

--- a/ulong_extras/factor_ecm.c
+++ b/ulong_extras/factor_ecm.c
@@ -39,7 +39,7 @@ ulong n_ecm_primorial[] =
 
 int
 n_factor_ecm(mp_limb_t *f, mp_limb_t curves, mp_limb_t B1, mp_limb_t B2,
-             flint_rand_t state, mp_limb_t n)
+             flint_rand_ptr state, mp_limb_t n)
 {
     mp_limb_t P, num, maxD, mmin, mmax, mdiff, prod, maxj, sig;
     int i, j, ret;

--- a/ulong_extras/factor_insert.c
+++ b/ulong_extras/factor_insert.c
@@ -13,7 +13,7 @@
 #include "flint.h"
 #include "ulong_extras.h"
 
-void n_factor_insert(n_factor_t * factors, mp_limb_t p, ulong exp)
+void n_factor_insert(n_factor_ptr factors, mp_limb_t p, ulong exp)
 {
    ulong i;
    

--- a/ulong_extras/factor_lehman.c
+++ b/ulong_extras/factor_lehman.c
@@ -33,13 +33,13 @@ mp_limb_t n_factor_lehman(mp_limb_t n)
     cuberoot = (mp_limb_t) ceil(limit);
     bound = n_prime_pi(cuberoot);
 
-    n_factor_init(&factors);
-    if (n_factor_trial_range(&factors, n, 0, bound) != n)
-        return factors.p[0];
+    n_factor_init(factors);
+    if (n_factor_trial_range(factors, n, 0, bound) != n)
+        return factors->p[0];
 
-    if ((factors.p[0] = n_factor_one_line(n, FLINT_FACTOR_ONE_LINE_ITERS)))
-        if (factors.p[0] != n)
-            return factors.p[0];
+    if ((factors->p[0] = n_factor_one_line(n, FLINT_FACTOR_ONE_LINE_ITERS)))
+        if (factors->p[0] != n)
+            return factors->p[0];
 
     for (k = 1; k <= cuberoot + 1; k++)
     {

--- a/ulong_extras/factor_partial.c
+++ b/ulong_extras/factor_partial.c
@@ -23,7 +23,7 @@ int is_prime2(mp_limb_t n, int proved)
    else return n_is_probabprime(n);
 }
 
-mp_limb_t n_factor_partial(n_factor_t * factors, mp_limb_t n, mp_limb_t limit, int proved)
+mp_limb_t n_factor_partial(n_factor_ptr factors, mp_limb_t n, mp_limb_t limit, int proved)
 {
    ulong factor_arr[FLINT_MAX_FACTORS_IN_LIMB];
    ulong exp_arr[FLINT_MAX_FACTORS_IN_LIMB];

--- a/ulong_extras/factor_pollard_brent.c
+++ b/ulong_extras/factor_pollard_brent.c
@@ -122,7 +122,7 @@ n_factor_pollard_brent_single(mp_limb_t *factor, mp_limb_t n, mp_limb_t ninv,
 }
 
 int
-n_factor_pollard_brent(mp_limb_t *factor, flint_rand_t state, mp_limb_t n_in, 
+n_factor_pollard_brent(mp_limb_t *factor, flint_rand_ptr state, mp_limb_t n_in, 
                         mp_limb_t max_tries, mp_limb_t max_iters)
 {
     mp_limb_t normbits, a, x, n, ninv, max;

--- a/ulong_extras/factor_trial.c
+++ b/ulong_extras/factor_trial.c
@@ -13,7 +13,7 @@
 #include "flint.h"
 #include "ulong_extras.h"
 
-mp_limb_t n_factor_trial(n_factor_t * factors, mp_limb_t n, ulong num_primes)
+mp_limb_t n_factor_trial(n_factor_ptr factors, mp_limb_t n, ulong num_primes)
 {
     return n_factor_trial_range(factors, n, UWORD(0), num_primes);
 }

--- a/ulong_extras/factor_trial_partial.c
+++ b/ulong_extras/factor_trial_partial.c
@@ -13,7 +13,7 @@
 #include "flint.h"
 #include "ulong_extras.h"
 
-mp_limb_t n_factor_trial_partial(n_factor_t * factors, mp_limb_t n, mp_limb_t * prod, ulong num_primes, mp_limb_t limit)
+mp_limb_t n_factor_trial_partial(n_factor_ptr factors, mp_limb_t n, mp_limb_t * prod, ulong num_primes, mp_limb_t limit)
 {
    unsigned int exp;
    mp_limb_t p;

--- a/ulong_extras/factor_trial_range.c
+++ b/ulong_extras/factor_trial_range.c
@@ -13,7 +13,7 @@
 #include "flint.h"
 #include "ulong_extras.h"
 
-mp_limb_t n_factor_trial_range(n_factor_t * factors, mp_limb_t n, ulong start, ulong num_primes)
+mp_limb_t n_factor_trial_range(n_factor_ptr factors, mp_limb_t n, ulong start, ulong num_primes)
 {
    unsigned int exp;
    mp_limb_t p;

--- a/ulong_extras/is_prime_pocklington.c
+++ b/ulong_extras/is_prime_pocklington.c
@@ -46,7 +46,7 @@ n_is_prime_pocklington(mp_limb_t n, ulong iterations)
         return 0;
 
     n1 = n - 1;
-    n_factor_init(&factors);
+    n_factor_init(factors);
     limit = (mp_limb_t) pow((double)n1, 1.0/3);
 
     val = n_pow(limit, 3);
@@ -58,18 +58,18 @@ n_is_prime_pocklington(mp_limb_t n, ulong iterations)
     }
 
 
-    cofactor = n_factor_partial(&factors, n1, limit, 1);
+    cofactor = n_factor_partial(factors, n1, limit, 1);
 
     if (cofactor != 1)                      /* check that cofactor is coprime to factors found */
     {
-        for (i = 0; i < factors.num; i++)
+        for (i = 0; i < factors->num; i++)
         {
-            if (factors.p[i] > FLINT_FACTOR_TRIAL_PRIMES_PRIME)
+            if (factors->p[i] > FLINT_FACTOR_TRIAL_PRIMES_PRIME)
             {
-                while (cofactor >= factors.p[i] && (cofactor % factors.p[i]) == 0)
+                while (cofactor >= factors->p[i] && (cofactor % factors->p[i]) == 0)
                 {
-                    factors.exp[i]++;
-                    cofactor /= factors.p[i];
+                    factors->exp[i]++;
+                    cofactor /= factors->p[i];
                 }
             }
         }
@@ -87,15 +87,15 @@ n_is_prime_pocklington(mp_limb_t n, ulong iterations)
     }
     ninv = n_preinvert_limb(n);
     c = 1;
-    for (i = factors.num - 1; i >= 0; i--)
+    for (i = factors->num - 1; i >= 0; i--)
     {
-        mp_limb_t exp = n1 / factors.p[i];
+        mp_limb_t exp = n1 / factors->p[i];
         pass = 0;
 
         for (j = 2; j < iterations && pass == 0; j++)
         {
             b = n_powmod2_preinv(j, exp, n, ninv);
-            if (n_powmod2_ui_preinv(b, factors.p[i], n, ninv) != UWORD(1))
+            if (n_powmod2_ui_preinv(b, factors->p[i], n, ninv) != UWORD(1))
                 return 0;
 
             b = n_submod(b, UWORD(1), n);

--- a/ulong_extras/moebius_mu.c
+++ b/ulong_extras/moebius_mu.c
@@ -88,15 +88,15 @@ int n_moebius_mu(mp_limb_t n)
     if (n % 9 == 0 || n % 25 == 0)
         return 0;
 
-    n_factor_init(&fac);
-    n_factor(&fac, n, 1);
-    for (i = 0; i < fac.num; i++)
+    n_factor_init(fac);
+    n_factor(fac, n, 1);
+    for (i = 0; i < fac->num; i++)
     {
-        if (fac.exp[i] != 1)
+        if (fac->exp[i] != 1)
             return 0;
     }
 
-    if (fac.num % 2)
+    if (fac->num % 2)
         return -1;
     else
         return 1;

--- a/ulong_extras/primitive_root_prime.c
+++ b/ulong_extras/primitive_root_prime.c
@@ -14,7 +14,7 @@
 #include "flint.h"
 #include "ulong_extras.h"
 
-mp_limb_t n_primitive_root_prime_prefactor(mp_limb_t p, n_factor_t * factors)
+mp_limb_t n_primitive_root_prime_prefactor(mp_limb_t p, n_factor_ptr factors)
 {
     slong i;
     int found;
@@ -56,10 +56,10 @@ mp_limb_t n_primitive_root_prime(mp_limb_t p)
     mp_limb_t a;
     n_factor_t factors;
 
-    n_factor_init(&factors);
-    n_factor(&factors, p - 1, 1);
+    n_factor_init(factors);
+    n_factor(factors, p - 1, 1);
     
-    a = n_primitive_root_prime_prefactor(p, &factors);
+    a = n_primitive_root_prime_prefactor(p, factors);
 
     return a;
 }

--- a/ulong_extras/profile/p-factor.c
+++ b/ulong_extras/profile/p-factor.c
@@ -48,7 +48,7 @@ void sample(void * arg, ulong count)
    }
 }
 
-void fill_array(ulong * ret, flint_bitcnt_t bits, flint_rand_t state)
+void fill_array(ulong * ret, flint_bitcnt_t bits, flint_rand_ptr state)
 {
    ulong n;
    n_factor_t factors;

--- a/ulong_extras/profile/p-factor.c
+++ b/ulong_extras/profile/p-factor.c
@@ -58,9 +58,9 @@ void fill_array(ulong * ret, flint_bitcnt_t bits, flint_rand_ptr state)
    {
 	  do 
 	  {
-		 n_factor_init(&factors);
+		 n_factor_init(factors);
 	     n = n_randbits(state, bits);
-	  } while (n_is_probabprime(n) || (n_factor_trial(&factors, n, primes) != n));
+	  } while (n_is_probabprime(n) || (n_factor_trial(factors, n, primes) != n));
 	  ret[i] = n;
    }
       

--- a/ulong_extras/profile/p-factor_pp1.c
+++ b/ulong_extras/profile/p-factor_pp1.c
@@ -23,9 +23,9 @@ main(int argc, char** argv)
     
     for (i = 0; i < 1000; )
     {
-       n_factor_init(&fac);
+       n_factor_init(fac);
        n = n_randbits(state, bits + n_randint(state, FLINT_BITS - bits + 1));
-       cofactor = n_factor_trial(&fac, n, FLINT_FACTOR_TRIAL_PRIMES);
+       cofactor = n_factor_trial(fac, n, FLINT_FACTOR_TRIAL_PRIMES);
        if (FLINT_BIT_COUNT(cofactor) == bits && !n_is_prime(cofactor))
        {
           nums[i++] = n;
@@ -51,8 +51,8 @@ main(int argc, char** argv)
             {
                for (i = 0; i < 1000; i++)
 	       {
-	           n_factor_init(&fac);
-	           n_factor(&fac, nums[i], 0);
+	           n_factor_init(fac);
+	           n_factor(fac, nums[i], 0);
 	       }
 	    }
             prof_stop();

--- a/ulong_extras/profile/p-gcd.c
+++ b/ulong_extras/profile/p-gcd.c
@@ -41,7 +41,7 @@ void sample(void * arg, ulong count)
    }
 }
 
-void fill_array(ulong * ret, flint_bitcnt_t bits, flint_rand_t state)
+void fill_array(ulong * ret, flint_bitcnt_t bits, flint_rand_ptr state)
 {
    ulong n;
    ulong i;

--- a/ulong_extras/randbits.c
+++ b/ulong_extras/randbits.c
@@ -13,7 +13,7 @@
 #include "flint.h"
 #include "ulong_extras.h"
 
-mp_limb_t n_randbits(flint_rand_t state, unsigned int bits)
+mp_limb_t n_randbits(flint_rand_ptr state, unsigned int bits)
 {
    if (bits == 0) return UWORD(0);
    else return (UWORD(1) << (bits - 1)) | n_randint(state, l_shift(UWORD(1), bits));

--- a/ulong_extras/randint.c
+++ b/ulong_extras/randint.c
@@ -14,13 +14,13 @@
 #include "flint.h"
 #include "ulong_extras.h"
 
-ulong n_randint(flint_rand_t state, ulong limit) 
+ulong n_randint(flint_rand_ptr state, ulong limit) 
 {
     if (limit == UWORD(0)) return n_randlimb(state);
     else return n_randlimb(state) % limit;
 }
 
-mp_limb_t n_urandint(flint_rand_t state, mp_limb_t limit) 
+mp_limb_t n_urandint(flint_rand_ptr state, mp_limb_t limit) 
 {
     if ((limit & (limit - 1)) == 0)
     {

--- a/ulong_extras/randlimb.c
+++ b/ulong_extras/randlimb.c
@@ -15,7 +15,7 @@
 
 #if FLINT64
 
-mp_limb_t n_randlimb(flint_rand_t state) 
+mp_limb_t n_randlimb(flint_rand_ptr state) 
 {   
     state->__randval = (state->__randval*UWORD(13282407956253574709) + UWORD(286824421));
     state->__randval2 = (state->__randval2*UWORD(7557322358563246341) + UWORD(286824421));
@@ -25,7 +25,7 @@ mp_limb_t n_randlimb(flint_rand_t state)
 
 #else
 
-mp_limb_t n_randlimb(flint_rand_t state) 
+mp_limb_t n_randlimb(flint_rand_ptr state) 
 {   
     state->__randval = (state->__randval*UWORD(1543932465) +  UWORD(1626832771));
     state->__randval2 = (state->__randval2*UWORD(2495927737) +  UWORD(1626832771));

--- a/ulong_extras/randprime.c
+++ b/ulong_extras/randprime.c
@@ -20,7 +20,7 @@
 #include "ulong_extras.h"
 
 
-mp_limb_t n_randprime(flint_rand_t state, ulong bits, int proved)
+mp_limb_t n_randprime(flint_rand_ptr state, ulong bits, int proved)
 {
     mp_limb_t rand;
 
@@ -53,7 +53,7 @@ mp_limb_t n_randprime(flint_rand_t state, ulong bits, int proved)
     return rand;
 }
 
-mp_limb_t n_randtest_prime(flint_rand_t state, int proved)
+mp_limb_t n_randtest_prime(flint_rand_ptr state, int proved)
 {
     return n_randprime(state, 2 + n_randint(state, FLINT_BITS - 1), proved);
 }

--- a/ulong_extras/randtest.c
+++ b/ulong_extras/randtest.c
@@ -17,7 +17,7 @@
 #include "fmpz.h"
 #include "ulong_extras.h"
 
-mp_limb_t n_randtest_bits(flint_rand_t state, int bits)
+mp_limb_t n_randtest_bits(flint_rand_ptr state, int bits)
 {
     mp_limb_t m;
     mp_limb_t n;
@@ -61,12 +61,12 @@ mp_limb_t n_randtest_bits(flint_rand_t state, int bits)
     return n;
 }
 
-mp_limb_t n_randtest(flint_rand_t state)
+mp_limb_t n_randtest(flint_rand_ptr state)
 {
     return n_randtest_bits(state, n_randint(state, FLINT_BITS + 1));
 }
 
-mp_limb_t n_randtest_not_zero(flint_rand_t state)
+mp_limb_t n_randtest_not_zero(flint_rand_ptr state)
 {
     mp_limb_t n;
 

--- a/ulong_extras/sqrtmodn.c
+++ b/ulong_extras/sqrtmodn.c
@@ -18,7 +18,7 @@
 #include "ulong_extras.h"
 
 /* compute square roots of a modulo m given factorisation of m */
-slong n_sqrtmodn(mp_limb_t ** sqrt, mp_limb_t a, n_factor_t * fac) 
+slong n_sqrtmodn(mp_limb_t ** sqrt, mp_limb_t a, n_factor_ptr fac) 
 {
     mp_limb_t m = 1, minv = 1;
     slong i, j, num;

--- a/ulong_extras/test/t-factor.c
+++ b/ulong_extras/test/t-factor.c
@@ -30,15 +30,15 @@ int main(void)
         mp_limb_t n1, n2;
         n_factor_t factors;
 
-        n_factor_init(&factors);
+        n_factor_init(factors);
 
         n1 = n_randtest_not_zero(state);
-        n_factor(&factors, n1, 0);
+        n_factor(factors, n1, 0);
 
         n2 = UWORD(1);
-        for (j = 0; j < factors.num; j++)
+        for (j = 0; j < factors->num; j++)
         {
-            n2 *= n_pow(factors.p[j], factors.exp[j]);
+            n2 *= n_pow(factors->p[j], factors->exp[j]);
         }
 
         result = (n1 == n2);
@@ -55,15 +55,15 @@ int main(void)
         mp_limb_t n1, n2;
         n_factor_t factors;
 
-        n_factor_init(&factors);
+        n_factor_init(factors);
 
         n1 = UWORD(4253857039);
-        n_factor(&factors, n1, 0);
+        n_factor(factors, n1, 0);
 
         n2 = UWORD(1);
-        for (j = 0; j < factors.num; j++)
+        for (j = 0; j < factors->num; j++)
         {
-            n2 *= n_pow(factors.p[j], factors.exp[j]);
+            n2 *= n_pow(factors->p[j], factors->exp[j]);
         }
 
         result = (n1 == n2);

--- a/ulong_extras/test/t-factor_partial.c
+++ b/ulong_extras/test/t-factor_partial.c
@@ -29,16 +29,16 @@ int main(void)
       mp_limb_t n1, n2, prod, limit;
       n_factor_t factors;
 
-      n_factor_init(&factors);
+      n_factor_init(factors);
 
       n1 = n_randtest_not_zero(state);
       limit = n_sqrt(n1);
-      n2 = n_factor_partial(&factors, n1, limit, 0);
+      n2 = n_factor_partial(factors, n1, limit, 0);
       
       prod = 1;
-      for (j = 0; j < factors.num; j++)
+      for (j = 0; j < factors->num; j++)
       {
-         prod *= n_pow(factors.p[j], factors.exp[j]);
+         prod *= n_pow(factors->p[j], factors->exp[j]);
       }
 
       result = ((n1 == n2*prod) && ((prod > limit) || (n1 == 1)));

--- a/ulong_extras/test/t-factor_trial.c
+++ b/ulong_extras/test/t-factor_trial.c
@@ -29,14 +29,14 @@ int main(void)
       mp_limb_t n1, n2;
       n_factor_t factors;
 
-      n_factor_init(&factors);
+      n_factor_init(factors);
 
       n1 = n_randtest_not_zero(state);
-      n2 = n_factor_trial(&factors, n1, UWORD(10000));
+      n2 = n_factor_trial(factors, n1, UWORD(10000));
       
-      for (j = 0; j < factors.num; j++)
+      for (j = 0; j < factors->num; j++)
       {
-         n2 *= n_pow(factors.p[j], factors.exp[j]);
+         n2 *= n_pow(factors->p[j], factors->exp[j]);
       }
 
       result = (n1 == n2);

--- a/ulong_extras/test/t-factor_trial_partial.c
+++ b/ulong_extras/test/t-factor_trial_partial.c
@@ -29,11 +29,11 @@ int main(void)
       mp_limb_t n1, n2, prod, limit;
       n_factor_t factors;
 
-      n_factor_init(&factors);
+      n_factor_init(factors);
 
       n1 = n_randtest_not_zero(state);
       limit = n_sqrt(n1);
-      n2 = n_factor_trial_partial(&factors, n1, &prod, UWORD(10000), limit);
+      n2 = n_factor_trial_partial(factors, n1, &prod, UWORD(10000), limit);
       
       if (n1 != n2*prod)
       {
@@ -43,9 +43,9 @@ int main(void)
          flint_abort();
       }
 
-      for (j = 0; j < factors.num; j++)
+      for (j = 0; j < factors->num; j++)
       {
-         n2 *= n_pow(factors.p[j], factors.exp[j]);
+         n2 *= n_pow(factors->p[j], factors->exp[j]);
       }
 
       result = (n1 == n2);

--- a/ulong_extras/test/t-factor_trial_range.c
+++ b/ulong_extras/test/t-factor_trial_range.c
@@ -29,14 +29,14 @@ int main(void)
       mp_limb_t n1, n2;
       n_factor_t factors;
 
-      n_factor_init(&factors);
+      n_factor_init(factors);
 
       n1 = n_randtest_not_zero(state);
-      n2 = n_factor_trial_range(&factors, n1, UWORD(100), UWORD(10000));
+      n2 = n_factor_trial_range(factors, n1, UWORD(100), UWORD(10000));
       
-      for (j = 0; j < factors.num; j++)
+      for (j = 0; j < factors->num; j++)
       {
-         n2 *= n_pow(factors.p[j], factors.exp[j]);
+         n2 *= n_pow(factors->p[j], factors->exp[j]);
       }
 
       result = (n1 == n2);

--- a/ulong_extras/test/t-primitive_root_prime.c
+++ b/ulong_extras/test/t-primitive_root_prime.c
@@ -28,19 +28,19 @@ int main(void)
         mp_limb_t p, root;
         double pinv;
         
-        n_factor_init(&factors);
+        n_factor_init(factors);
         p = n_randtest_prime(state, 1);
         pinv = n_precompute_inverse(p);
-        n_factor(&factors, p - 1, 1);
+        n_factor(factors, p - 1, 1);
 
         root = n_primitive_root_prime(p);
         
-        for (j = 0; j < factors.num; j++)
+        for (j = 0; j < factors->num; j++)
         {
-            if (n_powmod_precomp(root, (p-1) / factors.p[j], p, pinv) == 1)
+            if (n_powmod_precomp(root, (p-1) / factors->p[j], p, pinv) == 1)
             {
                 flint_printf("FAIL:\n");
-                flint_printf("%wu ** (%wu / %wu) == 1 mod %wu\n", root, p-1, factors.p[j], p);
+                flint_printf("%wu ** (%wu / %wu) == 1 mod %wu\n", root, p-1, factors->p[j], p);
                 fflush(stdout);
                 flint_abort();
             }

--- a/ulong_extras/test/t-sqrtmodn.c
+++ b/ulong_extras/test/t-sqrtmodn.c
@@ -39,13 +39,13 @@ int main(void)
         if (n == 0) n = 1;
         b = n_randtest(state) % n;
         
-        n_factor_init(&fac);
-        n_factor(&fac, n, 0);
+        n_factor_init(fac);
+        n_factor(fac, n, 0);
 
         ninv = n_preinvert_limb(n);
         a = n_mulmod2_preinv(b, b, n, ninv);
 
-        num = n_sqrtmodn(&sqrt, a, &fac);
+        num = n_sqrtmodn(&sqrt, a, fac);
         
         btest = 0;
         for (i = 0; i < num; i++)
@@ -87,13 +87,13 @@ int main(void)
         bits = n_randint(state, 18) + 2;
         n = n_randtest_bits(state, bits);
         if (n == 2) n++;
-        n_factor_init(&fac);
-        n_factor(&fac, n, 0);
+        n_factor_init(fac);
+        n_factor(fac, n, 0);
 
         ninv = n_preinvert_limb(n);
         
         a = n_randtest(state) % n;
-        while (n_sqrtmodn(&sqrt, a, &fac))
+        while (n_sqrtmodn(&sqrt, a, fac))
         {
             if (n_mulmod2_preinv(sqrt[0], sqrt[0], n, ninv) != a)
             {


### PR DESCRIPTION
Very descriptive title. Basically I am trying to make pointer types for (almost) every type in FLINT such that #1079 can be solved.

I also aim to make the types in FLINT more coherent. Not only within the repository, but also with GMP. For examples within FLINT, we have `n_factor_t` which at the moment is not a one-element array, but a struct. Very confusing. Also, the types in `apcrl` is named different compared to all the other parts in FLINT.

I do not aim to simply change everything. I still think that the documentation should try to involve types such as `fmpz_t` instead of `fmpz_ptr` for the sake of not involving too many types in the documentation, but the actual declarations should have the pointer versions in order to not get warnings from GCC about overreadings; At least when things are on the form `const mystruct[1]`, but the other variants should change as well for the sake of coherency.

I know this has not really been discussed yet, but I think it is the way to go.

For specific namings schemes, please see the commit messages.