### PR TITLE
Remove col_hash_t from fmpz_mat.h

### DIFF
--- a/fmpz_mat.h
+++ b/fmpz_mat.h
@@ -47,13 +47,6 @@ typedef struct
 
 typedef fmpz_mat_struct fmpz_mat_t[1];
 
-/* used for column partitioning, used by van Hoeij poly factoring */
-typedef struct
-{
-   ulong col;
-   ulong hash;
-} col_hash_t;
-
 /* Element access  ********************************************************/
 
 FMPZ_MAT_INLINE


### PR DESCRIPTION
Only used in one function, thus declutter the namespace for users.