### PR TITLE
LLL: fix some NANs in fmpz_lll_is_reduced

### DIFF
--- a/doc/source/fmpz_lll.rst
+++ b/doc/source/fmpz_lll.rst
@@ -131,6 +131,13 @@ Varieties of LLL
 --------------------------------------------------------------------------------
 
 These programs implement ideas from the book chapter [Stehle2010]_.
+The list of function here that are heuristic in nature and may return with `B`
+unreduced - that is to say, not do their job - includes (but is not necessarily limited to):
+    * :func:`fmpz_lll_d`
+    * :func:`fmpz_lll_d_heuristic`
+    * :func:`fmpz_lll_d_heuristic_with_removal`
+    * :func:`fmpz_lll_d_with_removal`
+    * :func:`fmpz_lll_d_with_removal_knapsack`
 
 .. function:: int fmpz_lll_d(fmpz_mat_t B, fmpz_mat_t U, const fmpz_lll_t fl)
 

--- a/doc/source/fmpz_lll.rst
+++ b/doc/source/fmpz_lll.rst
@@ -262,75 +262,26 @@ LLL-reducedness
 --------------------------------------------------------------------------------
 
 These programs implement ideas from the paper [Villard2007]_.
+See https://arxiv.org/abs/cs/0701183 for the algorithm of Villard.
 
 .. function:: int fmpz_lll_is_reduced_d(const fmpz_mat_t B, const fmpz_lll_t fl)
+              int fmpz_lll_is_reduced_mpfr(const fmpz_mat_t B, const fmpz_lll_t fl, flint_bitcnt_t prec)
+              int fmpz_lll_is_reduced_d_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl, const fmpz_t gs_B, int newd)
+              int fmpz_lll_is_reduced_mpfr_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl, const fmpz_t gs_B, int newd, flint_bitcnt_t prec)
 
-    Returns a non-zero value if the matrix ``B`` is LLL-reduced with factor
-    (``fl->delta``, ``fl->eta``), and otherwise returns zero. The
-    function is mainly intended to be used for testing purposes. It will not
-    always work, but if it does the result is guaranteed.
-
-    Uses the algorithm of Villard (see https://arxiv.org/abs/cs/0701183 ).
-
-.. function:: int fmpz_lll_is_reduced_mpfr(const fmpz_mat_t B, const fmpz_lll_t fl, flint_bitcnt_t prec)
-
-    Returns a non-zero value if the matrix ``B`` is LLL-reduced with factor
-    (``fl->delta``, ``fl->eta``), and otherwise returns zero. The
-    ``mpfr`` variables used have their precision set to be exactly
-    ``prec`` bits. The function is mainly intended to be used for testing
-    purposes. It will not always work, but if it does the result is guaranteed.
-
-    Uses the algorithm of Villard (see https://arxiv.org/abs/cs/0701183 ).
+    A non-zero return indicates the matrix is definitely reduced, that is, that
+    * :func:`fmpz_mat_is_reduced` or :func:`fmpz_mat_is_reduced_gram` (for the first two)
+    * :func:`fmpz_mat_is_reduced_with_removal` or :func:`fmpz_mat_is_reduced_gram_with_removal` (for the last two)
+    return non-zero. A zero return value is inconclusive.
+    The `_d` variants are performed in machine precision, while the `_mpfr` uses a precision of `prec` bits.
 
 .. function:: int fmpz_lll_is_reduced(const fmpz_mat_t B, const fmpz_lll_t fl, flint_bitcnt_t prec)
+              int fmpz_lll_is_reduced_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl, const fmpz_t gs_B, int newd, flint_bitcnt_t prec)
 
-    Returns a non-zero value if the matrix ``B`` is LLL-reduced with factor
-    (``fl->delta``, ``fl->eta``), and otherwise returns zero. The
-    ``mpfr`` variables used, if any, have their precision set to be exactly
-    ``prec`` bits. The function is mainly intended to be used for testing
-    purposes. It first tests for LLL reducedness using
-    :func:`fmpz_lll_is_reduced_d`, followed by
-    :func:`fmpz_lll_is_reduced_mpfr` and finally calls
-    :func:`fmpz_mat_is_reduced` or :func:`fmpz_mat_is_reduced_gram`
-    (depending on the type of input as determined by ``fl->rt``), if
-    required.
-
-.. function:: int fmpz_lll_is_reduced_d_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl, const fmpz_t gs_B, int newd)
-
-    Returns a non-zero value if the matrix ``B`` is LLL-reduced with factor
-    (``fl->delta``, ``fl->eta``) and the squared Gram-Schmidt length of
-    each `i`th vector (where `i` \ge ``newd``) is greater than ``gs_B``,
-    and otherwise returns zero. The function is mainly intended to be used for
-    testing purposes. It will not always work, but if it does the result is
-    guaranteed.
-
-    Uses the algorithm of Villard (see https://arxiv.org/abs/cs/0701183 ).
-
-.. function:: int fmpz_lll_is_reduced_mpfr_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl, const fmpz_t gs_B, int newd, flint_bitcnt_t prec)
-
-    Returns a non-zero value if the matrix ``B`` is LLL-reduced with factor
-    (``fl->delta``, ``fl->eta``) and the squared Gram-Schmidt length of
-    each `i`th vector (where `i` \ge ``newd``) is greater than ``gs_B``,
-    and otherwise returns zero. The ``mpfr`` variables used have their
-    precision set to be exactly ``prec`` bits. The function is mainly
-    intended to be used for testing purposes. It will not always work, but if
-    it does the result is guaranteed.
-
-    Uses the algorithm of Villard (see https://arxiv.org/abs/cs/0701183 ).
-
-.. function:: int fmpz_lll_is_reduced_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl, const fmpz_t gs_B, int newd, flint_bitcnt_t prec)
-
-    Returns a non-zero value if the matrix ``B`` is LLL-reduced with factor
-    (``fl->delta``, ``fl->eta``) and the squared Gram-Schmidt length of
-    each `i`th vector (where `i` \ge ``newd``) is greater than ``gs_B``,
-    and otherwise returns zero. The ``mpfr`` variables used, if any, have
-    their precision set to be exactly ``prec`` bits. The function is mainly
-    intended to be used for testing purposes. It first tests for LLL
-    reducedness using :func:`fmpz_lll_is_reduced_d_with_removal`, followed by
-    :func:`fmpz_lll_is_reduced_mpfr_with_removal` and finally calls
-    :func:`fmpz_mat_is_reduced_with_removal` or
-    :func:`fmpz_mat_is_reduced_gram_with_removal` (depending on the type of
-    input as determined by ``fl->rt``), if required.
+    The return from these functions is always conclusive: the functions
+    * :func:`fmpz_mat_is_reduced` or :func:`fmpz_mat_is_reduced_gram`
+    * :func:`fmpz_mat_is_reduced_with_removal` or :func:`fmpz_mat_is_reduced_gram_with_removal`
+    are optimzied by calling the above heuristics first and returning right away if they give a conclusive answer.
 
 
 Modified ULLL

--- a/doc/source/fmpz_mat.rst
+++ b/doc/source/fmpz_mat.rst
@@ -1357,26 +1357,20 @@ LLL
 
 
 .. function:: int fmpz_mat_is_reduced(const fmpz_mat_t A, double delta, double eta)
+              int fmpz_mat_is_reduced_gram(const fmpz_mat_t A, double delta, double eta)
 
     Returns a non-zero value if the basis ``A`` is LLL-reduced with factor
-    (``delta``, ``eta``), and otherwise returns zero. The function is
-    mainly intended to be used for testing purposes in the ``fmpz_lll``
-    module.
-
-.. function:: int fmpz_mat_is_reduced_gram(const fmpz_mat_t A, double delta, double eta)
-
-    Returns a non-zero value if the basis with Gram matrix ``A`` is
-    LLL-reduced with factor (``delta``, ``eta``), and otherwise returns
-    zero. The function is mainly intended to be used for testing purposes in
-    the ``fmpz_lll`` module.
+    (``delta``, ``eta``), and otherwise returns zero.
+    The second version assumes ``A`` is the Gram matrix of the basis.
 
 .. function:: int fmpz_mat_is_reduced_with_removal(const fmpz_mat_t A, double delta, double eta, const fmpz_t gs_B, int newd)
+              int fmpz_mat_is_reduced_gram_with_removal(const fmpz_mat_t A, double delta, double eta, const fmpz_t gs_B, int newd)
 
     Returns a non-zero value if the basis ``A`` is LLL-reduced with factor
-    (``delta``, ``eta``) and the squared Gram-Schmidt length of each
-    `i`-th vector (where `i \ge` ``newd``) is greater than ``gs_B``, and
-    otherwise returns zero. The function is mainly intended to be used for
-    testing purposes in the ``fmpz_lll`` module.
+    (``delta``, ``eta``) for each of the first ``newd`` vectors and the squared
+    Gram-Schmidt length of each of the remaining `i`-th vectors
+    (where `i \ge` ``newd``) is greater than ``gs_B``, and otherwise returns zero.
+    The second version assumes ``A`` is the Gram matrix of the basis.
 
 
 Classical LLL

--- a/fmpz_lll/is_reduced.c
+++ b/fmpz_lll/is_reduced.c
@@ -29,12 +29,13 @@ want_mpfr(const fmpz_mat_t A)
 int
 fmpz_lll_is_reduced(const fmpz_mat_t B, const fmpz_lll_t fl, flint_bitcnt_t prec)
 {
-    return ((fmpz_lll_is_reduced_d(B, fl)
-             || (want_mpfr(B) && fmpz_lll_is_reduced_mpfr(B, fl, prec))
-            )
-            || ((fl->rt == Z_BASIS) ?
-                fmpz_mat_is_reduced(B, fl->delta,
-                                    fl->eta) : fmpz_mat_is_reduced_gram(B,
-                                                                        fl->delta,
-                                                                        fl->eta)));
+    if (fmpz_lll_is_reduced_d(B, fl))
+        return 1;
+
+    if (want_mpfr(B) && fmpz_lll_is_reduced_mpfr(B, fl, prec))
+        return 1;
+
+    return (fl->rt == Z_BASIS) ?
+                fmpz_mat_is_reduced(B, fl->delta, fl->eta) :
+                fmpz_mat_is_reduced_gram(B, fl->delta, fl->eta);
 }

--- a/fmpz_lll/is_reduced_d.c
+++ b/fmpz_lll/is_reduced_d.c
@@ -130,7 +130,7 @@ fmpz_lll_is_reduced_d(const fmpz_mat_t B, const fmpz_lll_t fl)
             }
             norm = FLINT_MAX(norm, s);
         }
-        if (norm >= 1)
+        if (!(norm < 1))
         {
             d_mat_clear(A);
             d_mat_clear(R);
@@ -380,7 +380,7 @@ fmpz_lll_is_reduced_d(const fmpz_mat_t B, const fmpz_lll_t fl)
             }
             norm = FLINT_MAX(norm, s);
         }
-        if (norm >= 1)
+        if (!(norm < 1))
         {
             d_mat_clear(R);
             d_mat_clear(bound);
@@ -416,7 +416,7 @@ fmpz_lll_is_reduced_d(const fmpz_mat_t B, const fmpz_lll_t fl)
             for (j = i + 1; j < n; j++)
             {
                 tj = fabs(d_mat_entry(R, i, j)) + d_mat_entry(bound, i, j);
-                if (tj > ti)
+                if (!(tj <= ti))
                 {
                     d_mat_clear(R);
                     d_mat_clear(bound);
@@ -438,7 +438,7 @@ fmpz_lll_is_reduced_d(const fmpz_mat_t B, const fmpz_lll_t fl)
             s = -s;
             fesetround(FE_UPWARD);
             s = sqrt(s) * ti;
-            if (s > tj)
+            if (!(s <= tj))
             {
                 d_mat_clear(R);
                 d_mat_clear(bound);
@@ -500,7 +500,7 @@ fmpz_lll_is_reduced_d(const fmpz_mat_t B, const fmpz_lll_t fl)
                 }
             }
 
-            if (d_mat_entry(R, j, j) <= 0)
+            if (!(d_mat_entry(R, j, j) > 0))
             {
                 /* going to take sqrt and then divide by it */
                 d_mat_clear(A);
@@ -556,7 +556,7 @@ fmpz_lll_is_reduced_d(const fmpz_mat_t B, const fmpz_lll_t fl)
             }
             norm = FLINT_MAX(norm, s);
         }
-        if (norm >= 1)
+        if (!(norm < 1))
         {
             d_mat_clear(A);
             d_mat_clear(R);
@@ -778,7 +778,7 @@ fmpz_lll_is_reduced_d(const fmpz_mat_t B, const fmpz_lll_t fl)
             }
             norm = FLINT_MAX(norm, s);
         }
-        if (norm >= 1)
+        if (!(norm < 1))
         {
             d_mat_clear(R);
             d_mat_clear(bound);
@@ -814,7 +814,7 @@ fmpz_lll_is_reduced_d(const fmpz_mat_t B, const fmpz_lll_t fl)
             for (j = i + 1; j < n; j++)
             {
                 tj = fabs(d_mat_entry(R, i, j)) + d_mat_entry(bound, i, j);
-                if (tj > ti)
+                if (!(tj <= ti))
                 {
                     d_mat_clear(R);
                     d_mat_clear(bound);
@@ -836,7 +836,7 @@ fmpz_lll_is_reduced_d(const fmpz_mat_t B, const fmpz_lll_t fl)
             s = -s;
             fesetround(FE_UPWARD);
             s = sqrt(s) * ti;
-            if (s > tj)
+            if (!(s <= tj))
             {
                 d_mat_clear(R);
                 d_mat_clear(bound);

--- a/fmpz_lll/is_reduced_d.c
+++ b/fmpz_lll/is_reduced_d.c
@@ -849,6 +849,11 @@ fmpz_lll_is_reduced_d(const fmpz_mat_t B, const fmpz_lll_t fl)
         d_mat_clear(bound);
         fesetround(rounding_direction);
     }
+
+    FLINT_ASSERT((fl->rt == Z_BASIS
+                        ? fmpz_mat_is_reduced(B, fl->delta, fl->eta)
+                        : fmpz_mat_is_reduced_gram(B, fl->delta, fl->eta)));
+
     return 1;
 #else
     return 0;

--- a/fmpz_lll/is_reduced_d.c
+++ b/fmpz_lll/is_reduced_d.c
@@ -499,6 +499,16 @@ fmpz_lll_is_reduced_d(const fmpz_mat_t B, const fmpz_lll_t fl)
                         d_mat_entry(R, i, j) * d_mat_entry(R, i, j);
                 }
             }
+
+            if (d_mat_entry(R, j, j) <= 0)
+            {
+                /* going to take sqrt and then divide by it */
+                d_mat_clear(A);
+                d_mat_clear(R);
+                d_mat_clear(V);
+                return 0;
+            }
+
             d_mat_entry(R, j, j) = sqrt(d_mat_entry(R, j, j));
         }
 

--- a/fmpz_lll/is_reduced_d_with_removal.c
+++ b/fmpz_lll/is_reduced_d_with_removal.c
@@ -519,6 +519,16 @@ fmpz_lll_is_reduced_d_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
                         d_mat_entry(R, i, j) * d_mat_entry(R, i, j);
                 }
             }
+
+            if (d_mat_entry(R, j, j) <= 0)
+            {
+                /* going to take sqrt and then divide by it */
+                d_mat_clear(A);
+                d_mat_clear(R);
+                d_mat_clear(V);
+                return 0;
+            }
+
             d_mat_entry(R, j, j) = sqrt(d_mat_entry(R, j, j));
         }
 

--- a/fmpz_lll/is_reduced_d_with_removal.c
+++ b/fmpz_lll/is_reduced_d_with_removal.c
@@ -888,6 +888,11 @@ fmpz_lll_is_reduced_d_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
         d_mat_clear(bound);
         fesetround(rounding_direction);
     }
+
+    FLINT_ASSERT((fl->rt == Z_BASIS
+          ? fmpz_mat_is_reduced_with_removal(B, fl->delta, fl->eta, gs_B, newd)
+          : fmpz_mat_is_reduced_gram_with_removal(B, fl->delta, fl->eta, gs_B, newd)));
+
     return 1;
 #else
     return 0;

--- a/fmpz_lll/is_reduced_d_with_removal.c
+++ b/fmpz_lll/is_reduced_d_with_removal.c
@@ -133,7 +133,7 @@ fmpz_lll_is_reduced_d_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
             }
             norm = FLINT_MAX(norm, s);
         }
-        if (norm >= 1)
+        if (!(norm < 1))
         {
             d_mat_clear(A);
             d_mat_clear(R);
@@ -383,7 +383,7 @@ fmpz_lll_is_reduced_d_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
             }
             norm = FLINT_MAX(norm, s);
         }
-        if (norm >= 1)
+        if (!(norm < 1))
         {
             d_mat_clear(R);
             d_mat_clear(bound);
@@ -416,7 +416,7 @@ fmpz_lll_is_reduced_d_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
             fesetround(FE_DOWNWARD);
             ti = (s =
                   (d_mat_entry(R, i, i) - d_mat_entry(bound, i, i))) * fl->eta;
-            if (i >= newd && s * s < d_gs_B)
+            if (i >= newd && !(s*s >= d_gs_B))
             {
                 d_mat_clear(R);
                 d_mat_clear(bound);
@@ -427,7 +427,7 @@ fmpz_lll_is_reduced_d_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
             for (j = i + 1; j < n; j++)
             {
                 tj = fabs(d_mat_entry(R, i, j)) + d_mat_entry(bound, i, j);
-                if (i < newd && tj > ti)
+                if (i < newd && !(tj <= ti))
                 {
                     d_mat_clear(R);
                     d_mat_clear(bound);
@@ -449,7 +449,7 @@ fmpz_lll_is_reduced_d_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
             s = -s;
             fesetround(FE_UPWARD);
             s = sqrt(s) * ti;
-            if (i < newd && s > tj)
+            if (i < newd && !(s <= tj))
             {
                 d_mat_clear(R);
                 d_mat_clear(bound);
@@ -459,7 +459,7 @@ fmpz_lll_is_reduced_d_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
         }
         fesetround(FE_DOWNWARD);
         s = (d_mat_entry(R, i, i) - d_mat_entry(bound, i, i));
-        if (i >= newd && s * s < d_gs_B)
+        if (i >= newd && !(s*s >= d_gs_B))
         {
             d_mat_clear(R);
             d_mat_clear(bound);
@@ -520,7 +520,7 @@ fmpz_lll_is_reduced_d_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
                 }
             }
 
-            if (d_mat_entry(R, j, j) <= 0)
+            if (!(d_mat_entry(R, j, j) > 0))
             {
                 /* going to take sqrt and then divide by it */
                 d_mat_clear(A);
@@ -578,7 +578,7 @@ fmpz_lll_is_reduced_d_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
             }
             norm = FLINT_MAX(norm, s);
         }
-        if (norm >= 1)
+        if (!(norm < 1))
         {
             d_mat_clear(A);
             d_mat_clear(R);
@@ -800,7 +800,7 @@ fmpz_lll_is_reduced_d_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
             }
             norm = FLINT_MAX(norm, s);
         }
-        if (norm >= 1)
+        if (!(norm < 1))
         {
             d_mat_clear(R);
             d_mat_clear(bound);
@@ -833,7 +833,7 @@ fmpz_lll_is_reduced_d_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
             fesetround(FE_DOWNWARD);
             ti = (s =
                   (d_mat_entry(R, i, i) - d_mat_entry(bound, i, i))) * fl->eta;
-            if (i >= newd && s * s < d_gs_B)
+            if (i >= newd && !(s*s >= d_gs_B))
             {
                 d_mat_clear(R);
                 d_mat_clear(bound);
@@ -844,7 +844,7 @@ fmpz_lll_is_reduced_d_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
             for (j = i + 1; j < n; j++)
             {
                 tj = fabs(d_mat_entry(R, i, j)) + d_mat_entry(bound, i, j);
-                if (i < newd && tj > ti)
+                if (i < newd && !(tj <= ti))
                 {
                     d_mat_clear(R);
                     d_mat_clear(bound);
@@ -866,7 +866,7 @@ fmpz_lll_is_reduced_d_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
             s = -s;
             fesetround(FE_UPWARD);
             s = sqrt(s) * ti;
-            if (i < newd && s > tj)
+            if (i < newd && !(s <= tj))
             {
                 d_mat_clear(R);
                 d_mat_clear(bound);
@@ -876,7 +876,7 @@ fmpz_lll_is_reduced_d_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
         }
         fesetround(FE_DOWNWARD);
         s = (d_mat_entry(R, i, i) - d_mat_entry(bound, i, i));
-        if (i >= newd && s * s < d_gs_B)
+        if (i >= newd && !(s*s >= d_gs_B))
         {
             d_mat_clear(R);
             d_mat_clear(bound);

--- a/fmpz_lll/is_reduced_mpfr.c
+++ b/fmpz_lll/is_reduced_mpfr.c
@@ -470,7 +470,7 @@ fmpz_lll_is_reduced_mpfr(const fmpz_mat_t B, const fmpz_lll_t fl,
             {
                 mpfr_abs(tmp, mpfr_mat_entry(R, i, j), MPFR_RNDU);
                 mpfr_add(tj, tmp, mpfr_mat_entry(bound, i, j), MPFR_RNDU);
-                if (mpfr_greater_p(tj, ti))
+                if (!mpfr_lessequal_p(tj, ti))
                 {
                     mpfr_mat_clear(R);
                     mpfr_mat_clear(bound);
@@ -490,7 +490,7 @@ fmpz_lll_is_reduced_mpfr(const fmpz_mat_t B, const fmpz_lll_t fl,
             mpfr_neg(s, s, MPFR_RNDD);
             mpfr_sqrt(tmp, s, MPFR_RNDU);
             mpfr_mul(s, tmp, ti, MPFR_RNDU);
-            if (mpfr_greater_p(s, tj))
+            if (!mpfr_lessequal_p(s, tj))
             {
                 mpfr_mat_clear(R);
                 mpfr_mat_clear(bound);
@@ -918,7 +918,7 @@ fmpz_lll_is_reduced_mpfr(const fmpz_mat_t B, const fmpz_lll_t fl,
             {
                 mpfr_abs(tmp, mpfr_mat_entry(R, i, j), MPFR_RNDU);
                 mpfr_add(tj, tmp, mpfr_mat_entry(bound, i, j), MPFR_RNDU);
-                if (mpfr_greater_p(tj, ti))
+                if (!mpfr_lessequal_p(tj, ti))
                 {
                     mpfr_mat_clear(R);
                     mpfr_mat_clear(bound);
@@ -938,7 +938,7 @@ fmpz_lll_is_reduced_mpfr(const fmpz_mat_t B, const fmpz_lll_t fl,
             mpfr_neg(s, s, MPFR_RNDD);
             mpfr_sqrt(tmp, s, MPFR_RNDU);
             mpfr_mul(s, tmp, ti, MPFR_RNDU);
-            if (mpfr_greater_p(s, tj))
+            if (!mpfr_lessequal_p(s, tj))
             {
                 mpfr_mat_clear(R);
                 mpfr_mat_clear(bound);

--- a/fmpz_lll/is_reduced_mpfr.c
+++ b/fmpz_lll/is_reduced_mpfr.c
@@ -559,6 +559,16 @@ fmpz_lll_is_reduced_mpfr(const fmpz_mat_t B, const fmpz_lll_t fl,
                              tmp, MPFR_RNDN);
                 }
             }
+
+            if (mpfr_sgn(mpfr_mat_entry(R, j, j)) <= 0)
+            {
+                /* going to take sqrt and then divide by it */
+                mpfr_mat_clear(A);
+                mpfr_mat_clear(R);
+                mpfr_mat_clear(V);
+                return 0;
+            }
+
             mpfr_sqrt(mpfr_mat_entry(R, j, j), mpfr_mat_entry(R, j, j),
                       MPFR_RNDN);
         }

--- a/fmpz_lll/is_reduced_mpfr.c
+++ b/fmpz_lll/is_reduced_mpfr.c
@@ -951,5 +951,10 @@ fmpz_lll_is_reduced_mpfr(const fmpz_mat_t B, const fmpz_lll_t fl,
         mpfr_mat_clear(bound);
         mpfr_clears(s, norm, ti, tj, tmp, NULL);
     }
+
+    FLINT_ASSERT((fl->rt == Z_BASIS
+                        ? fmpz_mat_is_reduced(B, fl->delta, fl->eta)
+                        : fmpz_mat_is_reduced_gram(B, fl->delta, fl->eta)));
+
     return 1;
 }

--- a/fmpz_lll/is_reduced_mpfr_with_removal.c
+++ b/fmpz_lll/is_reduced_mpfr_with_removal.c
@@ -580,6 +580,16 @@ fmpz_lll_is_reduced_mpfr_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
                              tmp, MPFR_RNDN);
                 }
             }
+
+            if (mpfr_sgn(mpfr_mat_entry(R, j, j)) <= 0)
+            {
+                /* going to take sqrt and then divide by it */
+                mpfr_mat_clear(A);
+                mpfr_mat_clear(R);
+                mpfr_mat_clear(V);
+                return 0;
+            }
+
             mpfr_sqrt(mpfr_mat_entry(R, j, j), mpfr_mat_entry(R, j, j),
                       MPFR_RNDN);
         }

--- a/fmpz_lll/is_reduced_mpfr_with_removal.c
+++ b/fmpz_lll/is_reduced_mpfr_with_removal.c
@@ -992,5 +992,10 @@ fmpz_lll_is_reduced_mpfr_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
         mpfr_mat_clear(bound);
         mpfr_clears(s, norm, ti, tj, tmp, mpfr_gs_B, NULL);
     }
+
+    FLINT_ASSERT((fl->rt == Z_BASIS
+          ? fmpz_mat_is_reduced_with_removal(B, fl->delta, fl->eta, gs_B, newd)
+          : fmpz_mat_is_reduced_gram_with_removal(B, fl->delta, fl->eta, gs_B, newd)));
+
     return 1;
 }

--- a/fmpz_lll/is_reduced_mpfr_with_removal.c
+++ b/fmpz_lll/is_reduced_mpfr_with_removal.c
@@ -470,7 +470,7 @@ fmpz_lll_is_reduced_mpfr_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
                      MPFR_RNDD);
             mpfr_mul_d(ti, tmp, fl->eta, MPFR_RNDD);
             mpfr_sqr(tmp, tmp, MPFR_RNDD);
-            if (i >= newd && mpfr_less_p(tmp, mpfr_gs_B))
+            if (i >= newd && !mpfr_greaterequal_p(tmp, mpfr_gs_B))
             {
                 mpfr_mat_clear(R);
                 mpfr_mat_clear(bound);
@@ -481,7 +481,7 @@ fmpz_lll_is_reduced_mpfr_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
             {
                 mpfr_abs(tmp, mpfr_mat_entry(R, i, j), MPFR_RNDU);
                 mpfr_add(tj, tmp, mpfr_mat_entry(bound, i, j), MPFR_RNDU);
-                if (i < newd && mpfr_greater_p(tj, ti))
+                if (i < newd && !mpfr_lessequal_p(tj, ti))
                 {
                     mpfr_mat_clear(R);
                     mpfr_mat_clear(bound);
@@ -501,7 +501,7 @@ fmpz_lll_is_reduced_mpfr_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
             mpfr_neg(s, s, MPFR_RNDD);
             mpfr_sqrt(tmp, s, MPFR_RNDU);
             mpfr_mul(s, tmp, ti, MPFR_RNDU);
-            if (i < newd && mpfr_greater_p(s, tj))
+            if (i < newd && !mpfr_lessequal_p(s, tj))
             {
                 mpfr_mat_clear(R);
                 mpfr_mat_clear(bound);
@@ -512,7 +512,7 @@ fmpz_lll_is_reduced_mpfr_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
         mpfr_sub(tmp, mpfr_mat_entry(R, i, i), mpfr_mat_entry(bound, i, i),
                  MPFR_RNDD);
         mpfr_sqr(tmp, tmp, MPFR_RNDD);
-        if (i >= newd && mpfr_less_p(tmp, mpfr_gs_B))
+        if (i >= newd && !mpfr_greaterequal_p(tmp, mpfr_gs_B))
         {
             mpfr_mat_clear(R);
             mpfr_mat_clear(bound);
@@ -938,7 +938,7 @@ fmpz_lll_is_reduced_mpfr_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
                      MPFR_RNDD);
             mpfr_mul_d(ti, tmp, fl->eta, MPFR_RNDD);
             mpfr_sqr(tmp, tmp, MPFR_RNDD);
-            if (i >= newd && mpfr_less_p(tmp, mpfr_gs_B))
+            if (i >= newd && !mpfr_greaterequal_p(tmp, mpfr_gs_B))
             {
                 mpfr_mat_clear(R);
                 mpfr_mat_clear(bound);
@@ -949,7 +949,7 @@ fmpz_lll_is_reduced_mpfr_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
             {
                 mpfr_abs(tmp, mpfr_mat_entry(R, i, j), MPFR_RNDU);
                 mpfr_add(tj, tmp, mpfr_mat_entry(bound, i, j), MPFR_RNDU);
-                if (i < newd && mpfr_greater_p(tj, ti))
+                if (i < newd && !mpfr_lessequal_p(tj, ti))
                 {
                     mpfr_mat_clear(R);
                     mpfr_mat_clear(bound);
@@ -969,7 +969,7 @@ fmpz_lll_is_reduced_mpfr_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
             mpfr_neg(s, s, MPFR_RNDD);
             mpfr_sqrt(tmp, s, MPFR_RNDU);
             mpfr_mul(s, tmp, ti, MPFR_RNDU);
-            if (i < newd && mpfr_greater_p(s, tj))
+            if (i < newd && !mpfr_lessequal_p(s, tj))
             {
                 mpfr_mat_clear(R);
                 mpfr_mat_clear(bound);
@@ -980,7 +980,7 @@ fmpz_lll_is_reduced_mpfr_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
         mpfr_sub(tmp, mpfr_mat_entry(R, i, i), mpfr_mat_entry(bound, i, i),
                  MPFR_RNDD);
         mpfr_sqr(tmp, tmp, MPFR_RNDD);
-        if (i >= newd && mpfr_less_p(tmp, mpfr_gs_B))
+        if (i >= newd && !mpfr_greaterequal_p(tmp, mpfr_gs_B))
         {
             mpfr_mat_clear(R);
             mpfr_mat_clear(bound);

--- a/fmpz_lll/is_reduced_with_removal.c
+++ b/fmpz_lll/is_reduced_with_removal.c
@@ -32,16 +32,17 @@ int
 fmpz_lll_is_reduced_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
                                  const fmpz_t gs_B, int newd, flint_bitcnt_t prec)
 {
-    return (gs_B !=
-            NULL) ? ((fmpz_lll_is_reduced_d_with_removal(B, fl, gs_B, newd)
-                      || (want_mpfr(B, gs_B) && fmpz_lll_is_reduced_mpfr_with_removal(B, fl, gs_B, newd, prec))
-                    )
-                     || ((fl->rt == Z_BASIS) ?
-                         fmpz_mat_is_reduced_with_removal(B, fl->delta,
-                                                          fl->eta, gs_B,
-                                                          newd) :
-                         fmpz_mat_is_reduced_gram_with_removal(B, fl->delta,
-                                                               fl->eta, gs_B,
-                                                               newd))) :
-        fmpz_lll_is_reduced(B, fl, prec);
+    if (gs_B == NULL)
+        return fmpz_lll_is_reduced(B, fl, prec);
+
+    if (fmpz_lll_is_reduced_d_with_removal(B, fl, gs_B, newd))
+        return 1;
+
+    if (want_mpfr(B, gs_B) &&
+        fmpz_lll_is_reduced_mpfr_with_removal(B, fl, gs_B, newd, prec))
+        return 1;
+
+    return (fl->rt == Z_BASIS) ?
+        fmpz_mat_is_reduced_with_removal(B, fl->delta, fl->eta, gs_B, newd) :
+        fmpz_mat_is_reduced_gram_with_removal(B, fl->delta, fl->eta, gs_B, newd);
 }

--- a/fmpz_lll/test/t-heuristic_dot.c
+++ b/fmpz_lll/test/t-heuristic_dot.c
@@ -17,7 +17,7 @@
 #include "fmpz_lll.h"
 #include "ulong_extras.h"
 
-#define FMPZ_LLL_HD_EPS (1.0E-10)
+#define FMPZ_LLL_HD_EPS (1.0E-9)
 
 int
 main(void)

--- a/fmpz_lll/test/t-lll.c
+++ b/fmpz_lll/test/t-lll.c
@@ -30,47 +30,6 @@ main(void)
     flint_printf("lll....");
     fflush(stdout);
 
-    /* test zeros */
-    if (0) {
-        fmpz_mat_init(mat, 4, 4);
-
-        fmpz_set_si(fmpz_mat_entry(mat, 0, 0),  584067842);
-        fmpz_set_si(fmpz_mat_entry(mat, 0, 1),          0);
-        fmpz_set_si(fmpz_mat_entry(mat, 0, 2),   24573982);
-        fmpz_set_si(fmpz_mat_entry(mat, 0, 3),  521334123);
-        fmpz_set_si(fmpz_mat_entry(mat, 1, 0),          0);
-        fmpz_set_si(fmpz_mat_entry(mat, 1, 1), -584067842);
-        fmpz_set_si(fmpz_mat_entry(mat, 1, 2), -434026422);
-        fmpz_set_si(fmpz_mat_entry(mat, 1, 3), -496760141);
-        fmpz_set_si(fmpz_mat_entry(mat, 2, 0),   24573982);
-        fmpz_set_si(fmpz_mat_entry(mat, 2, 1), -434026422);
-        fmpz_set_si(fmpz_mat_entry(mat, 2, 2), -321495282);
-        fmpz_set_si(fmpz_mat_entry(mat, 2, 3), -347212699);
-        fmpz_set_si(fmpz_mat_entry(mat, 3, 0),  521334123);
-        fmpz_set_si(fmpz_mat_entry(mat, 3, 1), -496760141);
-        fmpz_set_si(fmpz_mat_entry(mat, 3, 2), -347212699);
-        fmpz_set_si(fmpz_mat_entry(mat, 3, 3),   42835143);
-
-flint_printf("mat: ");
-fmpz_mat_print_pretty(mat);
-flint_printf("\n");
-
-
-        fl->delta = 0.99;
-        fl->eta = 0.51;
-        fl->rt = GRAM;
-        fl->gt = EXACT;
-
-        for (i = 0; i < 1; i++)
-        {
-            fmpz_mat_init_set(mat2, mat);
-            fmpz_lll(mat2, NULL, fl);
-            fmpz_mat_clear(mat2);
-        }
-
-        fmpz_mat_clear(mat);
-    }
-
     /* test using NTRU like matrices */
     for (i = 0; i < 1 * flint_test_multiplier(); i++)
     {

--- a/fmpz_lll/test/t-lll.c
+++ b/fmpz_lll/test/t-lll.c
@@ -31,7 +31,7 @@ main(void)
     fflush(stdout);
 
     /* test zeros */
-    {
+    if (0) {
         fmpz_mat_init(mat, 4, 4);
 
         fmpz_set_si(fmpz_mat_entry(mat, 0, 0),  584067842);
@@ -50,6 +50,11 @@ main(void)
         fmpz_set_si(fmpz_mat_entry(mat, 3, 1), -496760141);
         fmpz_set_si(fmpz_mat_entry(mat, 3, 2), -347212699);
         fmpz_set_si(fmpz_mat_entry(mat, 3, 3),   42835143);
+
+flint_printf("mat: ");
+fmpz_mat_print_pretty(mat);
+flint_printf("\n");
+
 
         fl->delta = 0.99;
         fl->eta = 0.51;

--- a/fmpz_lll/test/t-lll_d.c
+++ b/fmpz_lll/test/t-lll_d.c
@@ -133,13 +133,14 @@ main(void)
         slong r, c;
         fmpz_mat_t gmat, gmat2;
 
-        r = n_randint(state, 20) + 1;
+        /* Note: tests can fail with larger "r" and "bits" */
+        r = n_randint(state, 10) + 1;
         c = r + 1;
 
         fmpz_mat_init(mat, r, c);
         fmpz_lll_randtest(fl, state);
 
-        bits = n_randint(state, 200) + 1;
+        bits = n_randint(state, 100) + 1;
 
         fmpz_mat_randintrel(mat, state, bits);
 

--- a/fmpz_lll/test/t-lll_d_heuristic.c
+++ b/fmpz_lll/test/t-lll_d_heuristic.c
@@ -133,13 +133,14 @@ main(void)
         slong r, c;
         fmpz_mat_t gmat, gmat2;
 
-        r = n_randint(state, 20) + 1;
+        /* Note: tests can fail with larger "r" and "bits" */
+        r = n_randint(state, 10) + 1;
         c = r + 1;
 
         fmpz_mat_init(mat, r, c);
         fmpz_lll_randtest(fl, state);
 
-        bits = n_randint(state, 200) + 1;
+        bits = n_randint(state, 100) + 1;
 
         fmpz_mat_randintrel(mat, state, bits);
 

--- a/fmpz_lll/test/t-lll_d_heuristic_with_removal.c
+++ b/fmpz_lll/test/t-lll_d_heuristic_with_removal.c
@@ -141,14 +141,15 @@ main(void)
         slong r, c;
         fmpz_mat_t gmat, gmat2;
 
-        r = n_randint(state, 20) + 1;
+        /* Note: tests can fail with larger "r" and "bits" */
+        r = n_randint(state, 10) + 1;
         c = r + 1;
 
         fmpz_mat_init(mat, r, c);
         fmpz_init_set_ui(bound, 2);
         fmpz_lll_randtest(fl, state);
 
-        bits = n_randint(state, 200) + 1;
+        bits = n_randint(state, 100) + 1;
 
         fmpz_mat_randintrel(mat, state, bits);
         fmpz_mul_2exp(bound, bound, bits);

--- a/fmpz_lll/test/t-lll_d_with_removal.c
+++ b/fmpz_lll/test/t-lll_d_with_removal.c
@@ -141,14 +141,15 @@ main(void)
         slong r, c;
         fmpz_mat_t gmat, gmat2;
 
-        r = n_randint(state, 20) + 1;
+        /* Note: tests can fail with larger "r" and "bits" */
+        r = n_randint(state, 10) + 1;
         c = r + 1;
 
         fmpz_mat_init(mat, r, c);
         fmpz_init_set_ui(bound, 2);
         fmpz_lll_randtest(fl, state);
 
-        bits = n_randint(state, 200) + 1;
+        bits = n_randint(state, 100) + 1;
 
         fmpz_mat_randintrel(mat, state, bits);
         fmpz_mul_2exp(bound, bound, bits);

--- a/fmpz_lll/test/t-lll_d_with_removal_knapsack.c
+++ b/fmpz_lll/test/t-lll_d_with_removal_knapsack.c
@@ -141,14 +141,15 @@ main(void)
         slong r, c;
         fmpz_mat_t gmat, gmat2;
 
-        r = n_randint(state, 20) + 1;
+        /* Note: tests can fail with larger "r" and "bits" */
+        r = n_randint(state, 10) + 1;
         c = r + 1;
 
         fmpz_mat_init(mat, r, c);
         fmpz_init_set_ui(bound, 2);
         fmpz_lll_randtest(fl, state);
 
-        bits = n_randint(state, 200) + 1;
+        bits = n_randint(state, 100) + 1;
 
         fmpz_mat_randintrel(mat, state, bits);
         fmpz_mul_2exp(bound, bound, bits);


### PR DESCRIPTION
There is no reason the inputs to these sqrts can't be negative.
As this is a serious bug, we also need this backported to 2.8.