### PR TITLE
Clean fmpz crt

### DIFF
--- a/fmpz.h
+++ b/fmpz.h
@@ -880,38 +880,48 @@ fmpz_multi_crt_precomp_p      gone
 fmpz_multi_crt                => fmpz_multi_CRT now with sign option
 fmpz_multi_crt_clear          => fmpz_multi_CRT_clear
 */
-typedef fmpz_multi_CRT_struct fmpz_multi_crt_struct;
-typedef fmpz_multi_CRT_t fmpz_multi_crt_t;
 
-FLINT_DLL void fmpz_multi_crt_init(fmpz_multi_crt_t CRT);
+#define fmpz_multi_crt_struct fmpz_multi_CRT_struct
+#define fmpz_multi_crt_t fmpz_multi_CRT_t
 
-FLINT_DLL int fmpz_multi_crt_precompute(fmpz_multi_crt_t CRT,
+#define fmpz_multi_crt_init fmpz_deprecated_multi_crt_init
+#define fmpz_multi_crt_precompute fmpz_deprecated_multi_crt_precompute
+#define fmpz_multi_crt_precompute_p fmpz_deprecated_multi_crt_precompute_p
+#define fmpz_multi_crt_precomp fmpz_deprecated_multi_crt_precomp
+#define fmpz_multi_crt_precomp_p fmpz_deprecated_multi_crt_precomp_p
+#define fmpz_multi_crt fmpz_deprecated_multi_crt
+#define fmpz_multi_crt_clear fmpz_deprecated_multi_crt_clear
+#define _fmpz_multi_crt_local_size _fmpz_deprecated_multi_crt_local_size
+#define _fmpz_multi_crt_run _fmpz_deprecated_multi_crt_run
+#define _fmpz_multi_crt_run_p _fmpz_deprecated_multi_crt_run_p
+
+FLINT_DLL void fmpz_deprecated_multi_crt_init(fmpz_multi_crt_t CRT);
+
+FLINT_DLL int fmpz_deprecated_multi_crt_precompute(fmpz_multi_crt_t CRT,
                                                const fmpz * moduli, slong len);
 
-FLINT_DLL int fmpz_multi_crt_precompute_p(fmpz_multi_crt_t CRT,
+FLINT_DLL int fmpz_deprecated_multi_crt_precompute_p(fmpz_multi_crt_t CRT,
                                        const fmpz * const * moduli, slong len);
 
-FLINT_DLL void fmpz_multi_crt_precomp(fmpz_t output, const fmpz_multi_crt_t P,
+FLINT_DLL void fmpz_deprecated_multi_crt_precomp(fmpz_t output, const fmpz_multi_crt_t P,
                                                           const fmpz * inputs);
 
-FLINT_DLL void fmpz_multi_crt_precomp_p(fmpz_t output,
+FLINT_DLL void fmpz_deprecated_multi_crt_precomp_p(fmpz_t output,
                         const fmpz_multi_crt_t P, const fmpz * const * inputs);
 
-FLINT_DLL int fmpz_multi_crt(fmpz_t output, const fmpz * moduli,
+FLINT_DLL int fmpz_deprecated_multi_crt(fmpz_t output, const fmpz * moduli,
                                                const fmpz * values, slong len);
 
-FLINT_DLL void fmpz_multi_crt_clear(fmpz_multi_crt_t P);
+FLINT_DLL void fmpz_deprecated_multi_crt_clear(fmpz_multi_crt_t P);
 
-FMPZ_INLINE slong _fmpz_multi_crt_local_size(const fmpz_multi_crt_t CRT)
-{
-    return CRT->localsize;
-}
+FLINT_DLL slong _fmpz_deprecated_multi_crt_local_size(const fmpz_multi_crt_t CRT);
 
-FLINT_DLL void _fmpz_multi_crt_run(fmpz * outputs, const fmpz_multi_crt_t CRT,
+FLINT_DLL void _fmpz_deprecated_multi_crt_run(fmpz * outputs, const fmpz_multi_crt_t CRT,
                                                           const fmpz * inputs);
 
-FLINT_DLL void _fmpz_multi_crt_run_p(fmpz * outputs,
+FLINT_DLL void _fmpz_deprecated_multi_crt_run_p(fmpz * outputs,
                       const fmpz_multi_crt_t CRT, const fmpz * const * inputs);
+
 
 /* multi mod *****************************************************************/
 

--- a/fmpz/comb_init.c
+++ b/fmpz/comb_init.c
@@ -30,7 +30,7 @@
 #define FMPZ_MOD_UI_CUTOFF 75
 
 /* minimal number of basecase chunks in which to partition */
-#define FMPZ_CRT_UI_MULTIPLE_CUTOFF 8
+#define FMPZ_CRT_UI_MULTIPLE_CUTOFF 4
 #define FMPZ_MOD_UI_MULTIPLE_CUTOFF 4
 
 

--- a/fmpz/deprecated.c
+++ b/fmpz/deprecated.c
@@ -11,19 +11,17 @@
 
 #include "fmpz.h"
 
-/* deprecated functions *****************************************************/
-
-void fmpz_multi_crt_init(fmpz_multi_crt_t P)
+void fmpz_deprecated_multi_crt_init(fmpz_multi_crt_t P)
 {
     fmpz_multi_CRT_init(P);
 }
 
-void fmpz_multi_crt_clear(fmpz_multi_crt_t P)
+void fmpz_deprecated_multi_crt_clear(fmpz_multi_crt_t P)
 {
     fmpz_multi_CRT_clear(P);
 }
 
-int fmpz_multi_crt_precompute(
+int fmpz_deprecated_multi_crt_precompute(
     fmpz_multi_crt_t P,
     const fmpz * moduli,
     slong len)
@@ -31,7 +29,7 @@ int fmpz_multi_crt_precompute(
     return fmpz_multi_CRT_precompute(P, moduli, len);
 }
 
-int fmpz_multi_crt_precompute_p(
+int fmpz_deprecated_multi_crt_precompute_p(
     fmpz_multi_crt_t P,
     const fmpz * const * moduli,
     slong len)
@@ -50,7 +48,7 @@ int fmpz_multi_crt_precompute_p(
     return success;
 }
 
-void fmpz_multi_crt_precomp(
+void fmpz_deprecated_multi_crt_precomp(
     fmpz_t output,
     const fmpz_multi_crt_t P,
     const fmpz * inputs)
@@ -58,7 +56,7 @@ void fmpz_multi_crt_precomp(
     fmpz_multi_CRT_precomp(output, P, inputs, 1);
 }
 
-void fmpz_multi_crt_precomp_p(
+void fmpz_deprecated_multi_crt_precomp_p(
     fmpz_t output,
     const fmpz_multi_crt_t P,
     const fmpz * const * inputs)
@@ -74,7 +72,7 @@ void fmpz_multi_crt_precomp_p(
     flint_free(ins);
 }
 
-int fmpz_multi_crt(
+int fmpz_deprecated_multi_crt(
     fmpz_t output,
     const fmpz * moduli,
     const fmpz * values,
@@ -83,7 +81,7 @@ int fmpz_multi_crt(
     return fmpz_multi_CRT(output, moduli, values, len, 1);
 }
 
-void _fmpz_multi_crt_run(
+void _fmpz_deprecated_multi_crt_run(
     fmpz * outputs,
     const fmpz_multi_crt_t P,
     const fmpz * inputs)
@@ -91,7 +89,12 @@ void _fmpz_multi_crt_run(
     _fmpz_multi_CRT_precomp(outputs, P, inputs, 1);
 }
 
-void _fmpz_multi_crt_run_p(
+slong _fmpz_deprecated_multi_crt_local_size(const fmpz_multi_crt_t CRT)
+{
+    return CRT->localsize;
+}
+
+void _fmpz_deprecated_multi_crt_run_p(
     fmpz * outputs,
     const fmpz_multi_crt_t P,
     const fmpz * const * inputs)

--- a/fmpz/multi_CRT.c
+++ b/fmpz/multi_CRT.c
@@ -21,7 +21,7 @@ int fmpz_multi_CRT(
 {
     int success;
     slong i;
-    fmpz_multi_crt_t P;
+    fmpz_multi_CRT_t P;
     fmpz * out;
     TMP_INIT;
 

--- a/fmpz/multi_CRT_precomp.c
+++ b/fmpz/multi_CRT_precomp.c
@@ -85,7 +85,7 @@ doit:
 
 void fmpz_multi_CRT_precomp(
     fmpz_t output,
-    const fmpz_multi_crt_t P,
+    const fmpz_multi_CRT_t P,
     const fmpz * inputs,
     int sign)
 {

--- a/fmpz/profile/p-crt.c
+++ b/fmpz/profile/p-crt.c
@@ -1,0 +1,189 @@
+#include "flint/fmpz.h"
+#include "flint/profiler.h"
+
+void
+_fmpz_crt_combine(fmpz_t r1r2, fmpz_t m1m2, const fmpz_t r1, const fmpz_t m1, const fmpz_t r2, const fmpz_t m2)
+{
+    fmpz_invmod(m1m2, m1, m2);
+    fmpz_mul(m1m2, m1m2, m1);
+    fmpz_sub(r1r2, r2, r1);
+    fmpz_mul(r1r2, r1r2, m1m2);
+    fmpz_add(r1r2, r1r2, r1);
+    fmpz_mul(m1m2, m1, m2);
+    fmpz_mod(r1r2, r1r2, m1m2);
+}
+
+void
+_fmpz_crt_combine_uiui(fmpz_t r1r2, fmpz_t m1m2, ulong r1, ulong m1, ulong r2, ulong m2)
+{
+    mp_limb_t M[2];
+
+    /*
+        M = m1 * m2
+        c = invmod(m1, m2) * m1
+        r1r2 = ((r2 - r1) * c + r1) mod M
+        m1m2 = M
+    */
+
+    /* M = m1 * m2 */
+    umul_ppmm(M[1], M[0], m1, m2);
+
+    if (M[1] == 0)
+    {
+        mp_limb_t c, v;
+
+        c = n_invmod(m1, m2) * m1;
+
+        if (r2 >= r1)
+            v = n_mulmod2(r2 - r1, c, M[0]);
+        else
+            v = n_mulmod2(n_negmod(r1 - r2, M[0]), c, M[0]);
+
+        v = n_addmod(v, r1, M[0]);
+
+        fmpz_set_ui(r1r2, v);
+        fmpz_set_ui(m1m2, M[0]);
+    }
+    else
+    {
+        mp_limb_t c[2], t[4], q[3], r[3];
+
+        umul_ppmm(c[1], c[0], n_invmod(m1, m2), m1);
+
+        if (r2 >= r1)
+        {
+            t[2] = mpn_mul_1(t, c, 2, r2 - r1);
+
+            mpn_add_1(t, t, 3, r1);
+            mpn_tdiv_qr(q, r, 0, t, 3, M, 2);
+        }
+        else
+        {
+            sub_ddmmss(r[1], r[0], M[1], M[0], 0, r1 - r2);
+            mpn_mul_n(t, c, r, 2);
+            mpn_add_1(t, t, 4, r1);
+            mpn_tdiv_qr(q, r, 0, t, 4, M, 2);
+        }
+
+        fmpz_set_uiui(r1r2, r[1], r[0]);
+        fmpz_set_uiui(m1m2, M[1], M[0]);
+    }
+}
+
+void
+tree_crt(fmpz_t r, fmpz_t m, mp_srcptr residues, mp_srcptr primes, slong len)
+{
+    if (len == 0)
+    {
+        fmpz_zero(r);
+        fmpz_one(m);
+    }
+    else if (len == 1)
+    {
+        fmpz_set_ui(r, residues[0]);
+        fmpz_set_ui(m, primes[0]);
+    }
+    else if (len == 2)
+    {
+        _fmpz_crt_combine_uiui(r, m, residues[0], primes[0], residues[1], primes[1]);
+    }
+    else
+    {
+        fmpz_t r1, m1, r2, m2;
+
+        fmpz_init(r1);
+        fmpz_init(m1);
+        fmpz_init(r2);
+        fmpz_init(m2);
+
+        tree_crt(r1, m1, residues, primes, len / 2);
+        tree_crt(r2, m2, residues + len / 2, primes + len / 2, len - len / 2);
+        _fmpz_crt_combine(r, m, r1, m1, r2, m2);
+
+        fmpz_clear(r1);
+        fmpz_clear(m1);
+        fmpz_clear(r2);
+        fmpz_clear(m2);
+    }
+}
+
+void
+fmpz_print1(const fmpz_t n)
+{
+//    printf("%lu", fmpz_fdiv_ui(n, 1000000000)); printf("\n");
+}
+
+void
+benchmark(slong num_primes, slong prime_bits)
+{
+    flint_rand_t state;
+    fmpz_comb_temp_t temp;
+    fmpz_comb_t comb;
+    mp_ptr primes, residues;
+    fmpz_t res;
+    slong k;
+
+    flint_randinit(state);
+    primes = flint_malloc(num_primes * sizeof(mp_limb_t));
+    residues = flint_malloc(num_primes * sizeof(mp_limb_t));
+    fmpz_init(res);
+
+    primes[0] = n_nextprime(UWORD(1) << (prime_bits - 1), 0);
+    for (k = 1; k < num_primes; k++)
+        primes[k] = n_nextprime(primes[k-1], 0);
+
+    for (k = 0; k < num_primes; k++)
+        residues[k] = n_randint(state, primes[k]);
+
+    printf("simple tree:   ");
+    TIMEIT_START
+    fmpz_t tmp;
+    fmpz_init(tmp);
+    tree_crt(res, tmp, residues, primes, num_primes);
+    fmpz_clear(tmp);
+    TIMEIT_STOP
+    fmpz_print1(res);
+
+    printf("multi CRT:     ");
+    TIMEIT_START
+    fmpz_comb_init(comb, primes, num_primes);
+    fmpz_comb_temp_init(temp, comb);
+    fmpz_multi_CRT_ui(res, residues, comb, temp, 0);
+    fmpz_comb_clear(comb);
+    fmpz_comb_temp_clear(temp);
+    TIMEIT_STOP
+    fmpz_print1(res);
+
+    printf("multi precomp: ");
+    fmpz_comb_init(comb, primes, num_primes);
+    fmpz_comb_temp_init(temp, comb);
+    TIMEIT_START
+    fmpz_multi_CRT_ui(res, residues, comb, temp, 0);
+    TIMEIT_STOP
+    fmpz_comb_clear(comb);
+    fmpz_comb_temp_clear(temp);
+    fmpz_print1(res);
+
+    flint_free(primes);
+    flint_free(residues);
+    fmpz_clear(res);
+}
+
+int main()
+{
+    slong len, bits;
+
+    bits = 5;
+    for (len = 1; len <= 4000; len = FLINT_MAX(len * 1.5, len + 1))
+    {
+        printf("bits = %ld, len = %ld\n", bits, len);
+        benchmark(len, bits);
+    }
+
+    bits = 64;
+    for (len = 1; len <= 4000; len = FLINT_MAX(len * 1.5, len + 1))
+    {
+        printf("bits = %ld, len = %ld\n", bits, len);
+        benchmark(len, bits);
+    }
+}


### PR DESCRIPTION
resolves #1035 the cutoff of 8 was used for runtime performance, but caused bad init performance
resolves #956 the names of the old functions in the library now have "deprecated" in them and the deprecated functions are now macros
