### PR TITLE
lll: always want mpfr but want it with more bits

### DIFF
--- a/fmpz_lll/is_reduced.c
+++ b/fmpz_lll/is_reduced.c
@@ -13,26 +13,13 @@
 
 #include "fmpz_lll.h"
 
-static int
-want_mpfr(const fmpz_mat_t A)
-{
-    slong bits;
-
-    bits = fmpz_mat_max_bits(A);
-    bits = FLINT_ABS(bits);
-
-    /* highest double exponent is 1023; use mpfr when products in
-       is_reduced_d could possibly have overflowed */
-    return bits > 512 - 32;
-}
-
 int
 fmpz_lll_is_reduced(const fmpz_mat_t B, const fmpz_lll_t fl, flint_bitcnt_t prec)
 {
     if (fmpz_lll_is_reduced_d(B, fl))
         return 1;
 
-    if (want_mpfr(B) && fmpz_lll_is_reduced_mpfr(B, fl, prec))
+    if (fmpz_lll_is_reduced_mpfr(B, fl, prec))
         return 1;
 
     return (fl->rt == Z_BASIS) ?

--- a/fmpz_lll/is_reduced_with_removal.c
+++ b/fmpz_lll/is_reduced_with_removal.c
@@ -13,21 +13,6 @@
 
 #include "fmpz_lll.h"
 
-static int
-want_mpfr(const fmpz_mat_t A, const fmpz_t b)
-{
-    slong bits, bits2;
-
-    bits = fmpz_mat_max_bits(A);
-    bits = FLINT_ABS(bits);
-    bits2 = fmpz_bits(b);
-    bits = FLINT_MAX(bits, bits2);
-
-    /* highest double exponent is 1023; use mpfr when products in
-       is_reduced_d could possibly have overflowed */
-    return bits > 512 - 32;
-}
-
 int
 fmpz_lll_is_reduced_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
                                  const fmpz_t gs_B, int newd, flint_bitcnt_t prec)
@@ -38,8 +23,7 @@ fmpz_lll_is_reduced_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
     if (fmpz_lll_is_reduced_d_with_removal(B, fl, gs_B, newd))
         return 1;
 
-    if (want_mpfr(B, gs_B) &&
-        fmpz_lll_is_reduced_mpfr_with_removal(B, fl, gs_B, newd, prec))
+    if (fmpz_lll_is_reduced_mpfr_with_removal(B, fl, gs_B, newd, prec))
         return 1;
 
     return (fl->rt == Z_BASIS) ?

--- a/fmpz_lll/wrapper_with_removal.c
+++ b/fmpz_lll/wrapper_with_removal.c
@@ -19,15 +19,14 @@ fmpz_lll_wrapper_with_removal(fmpz_mat_t B, fmpz_mat_t U, const fmpz_t gs_B,
 {
     int res = fmpz_lll_d_with_removal(B, U, gs_B, fl);
 
-    if ((res == -1)
-        || (!fmpz_lll_is_reduced_with_removal(B, fl, gs_B, res, D_BITS)))
+    if ((res == -1) ||
+        (!fmpz_lll_is_reduced_with_removal(B, fl, gs_B, res, 120)))
     {
         if (fl->rt == Z_BASIS && fl->gt == APPROX)
         {
             res = fmpz_lll_d_heuristic_with_removal(B, U, gs_B, fl);
-            if ((res == -1)
-                ||
-                (!fmpz_lll_is_reduced_with_removal(B, fl, gs_B, res, D_BITS)))
+            if ((res == -1) ||
+                (!fmpz_lll_is_reduced_with_removal(B, fl, gs_B, res, 120)))
             {
                 res = fmpz_lll_mpf_with_removal(B, U, gs_B, fl);
             }

--- a/fmpz_lll/wrapper_with_removal_knapsack.c
+++ b/fmpz_lll/wrapper_with_removal_knapsack.c
@@ -19,15 +19,14 @@ fmpz_lll_wrapper_with_removal_knapsack(fmpz_mat_t B, fmpz_mat_t U,
 {
     int res = fmpz_lll_d_with_removal_knapsack(B, U, gs_B, fl);
 
-    if ((res == -1)
-        || (!fmpz_lll_is_reduced_with_removal(B, fl, gs_B, res, D_BITS)))
+    if ((res == -1) ||
+        (!fmpz_lll_is_reduced_with_removal(B, fl, gs_B, res, 120)))
     {
         if (fl->rt == Z_BASIS && fl->gt == APPROX)
         {
             res = fmpz_lll_d_heuristic_with_removal(B, U, gs_B, fl);
-            if ((res == -1)
-                ||
-                (!fmpz_lll_is_reduced_with_removal(B, fl, gs_B, res, D_BITS)))
+            if ((res == -1) ||
+                (!fmpz_lll_is_reduced_with_removal(B, fl, gs_B, res, 120)))
             {
                 res = fmpz_lll_mpf_with_removal(B, U, gs_B, fl);
             }

--- a/fmpz_poly_factor/test/t-factor.c
+++ b/fmpz_poly_factor/test/t-factor.c
@@ -48,8 +48,7 @@ void factor_poly(const char * file_str, const char * name)
    gettimeofday(&stop, NULL);
    ms = (stop.tv_sec - start.tv_sec)*1000 + (stop.tv_usec - start.tv_usec) / 1000;
 
-   flint_printf("%s has %wd factors\n", name, fac->num);
-   flint_printf("Time to factor %s: %ld ms\n\n", name, ms);
+   flint_printf("%s has %wd factors: %ld ms\n", name, fac->num, ms);
 
    fmpz_poly_factor_clear(fac);
    fclose(file);
@@ -72,26 +71,30 @@ main(void)
     fflush(stdout);
 
 #if TEST_HARD
-    factor_poly("/home/wbhart/.julia/v0.5/Nemo/deps/flint2/fmpz_poly_factor/test/P1_flint", "P1");
-    factor_poly("/home/wbhart/.julia/v0.5/Nemo/deps/flint2/fmpz_poly_factor/test/P2_flint", "P2");
-    factor_poly("/home/wbhart/.julia/v0.5/Nemo/deps/flint2/fmpz_poly_factor/test/P3_flint", "P3");
-    factor_poly("/home/wbhart/.julia/v0.5/Nemo/deps/flint2/fmpz_poly_factor/test/P4_flint", "P4");
-    factor_poly("/home/wbhart/.julia/v0.5/Nemo/deps/flint2/fmpz_poly_factor/test/P5_flint", "P5");
-    factor_poly("/home/wbhart/.julia/v0.5/Nemo/deps/flint2/fmpz_poly_factor/test/P6_flint", "P6");
-    factor_poly("/home/wbhart/.julia/v0.5/Nemo/deps/flint2/fmpz_poly_factor/test/P7_flint", "P7");
-    factor_poly("/home/wbhart/.julia/v0.5/Nemo/deps/flint2/fmpz_poly_factor/test/P8_flint", "P8");
-    factor_poly("/home/wbhart/.julia/v0.5/Nemo/deps/flint2/fmpz_poly_factor/test/M12_5_flint", "M12_5");
-    factor_poly("/home/wbhart/.julia/v0.5/Nemo/deps/flint2/fmpz_poly_factor/test/M12_6_flint", "M12_6");
-    factor_poly("/home/wbhart/.julia/v0.5/Nemo/deps/flint2/fmpz_poly_factor/test/T1_flint", "T1");
-    factor_poly("/home/wbhart/.julia/v0.5/Nemo/deps/flint2/fmpz_poly_factor/test/T2_flint", "T2");
-    factor_poly("/home/wbhart/.julia/v0.5/Nemo/deps/flint2/fmpz_poly_factor/test/T3_flint", "T3");
-    factor_poly("/home/wbhart/.julia/v0.5/Nemo/deps/flint2/fmpz_poly_factor/test/H1_flint", "H1");
-    factor_poly("/home/wbhart/.julia/v0.5/Nemo/deps/flint2/fmpz_poly_factor/test/S7_flint", "S7");
-    factor_poly("/home/wbhart/.julia/v0.5/Nemo/deps/flint2/fmpz_poly_factor/test/S8_flint", "S8");
-    factor_poly("/home/wbhart/.julia/v0.5/Nemo/deps/flint2/fmpz_poly_factor/test/C1_flint", "C1");
-    factor_poly("/home/wbhart/.julia/v0.5/Nemo/deps/flint2/fmpz_poly_factor/test/S9_flint", "S9");
-    factor_poly("/home/wbhart/.julia/v0.5/Nemo/deps/flint2/fmpz_poly_factor/test/S10_flint", "S10");
-    factor_poly("/home/wbhart/.julia/v0.5/Nemo/deps/flint2/fmpz_poly_factor/test/H2_flint", "H2");
+#define MY_DIR "/home/wbhart/.julia/v0.5/Nemo/deps/flint2/fmpz_poly_factor/test/"
+    flint_printf("\n");
+    factor_poly(MY_DIR"P1_flint", "P1");
+    factor_poly(MY_DIR"P2_flint", "P2");
+    factor_poly(MY_DIR"P3_flint", "P3");
+    factor_poly(MY_DIR"P4_flint", "P4");
+    factor_poly(MY_DIR"P5_flint", "P5");
+    factor_poly(MY_DIR"P6_flint", "P6");
+    factor_poly(MY_DIR"P7_flint", "P7");
+    factor_poly(MY_DIR"P8_flint", "P8");
+    factor_poly(MY_DIR"M12_5_flint", "M12_5");
+    factor_poly(MY_DIR"M12_6_flint", "M12_6");
+    factor_poly(MY_DIR"T1_flint", "T1");
+    factor_poly(MY_DIR"T2_flint", "T2");
+    factor_poly(MY_DIR"T3_flint", "T3");
+    factor_poly(MY_DIR"H1_flint", "H1");
+    factor_poly(MY_DIR"S7_flint", "S7");
+    factor_poly(MY_DIR"S8_flint", "S8");
+    factor_poly(MY_DIR"C1_flint", "C1");
+/*
+    factor_poly(MY_DIR"S9_flint", "S9");
+    factor_poly(MY_DIR"S10_flint", "S10");
+    factor_poly(MY_DIR"H2_flint", "H2");
+*/
 #endif
 
     for (i = 0; i < tmul * flint_test_multiplier(); i++)


### PR DESCRIPTION
just a possible suggestion
@thofma, can you run all of your lll examples again?
The effect on the factoring benchmarks is generally a slow down:
```

                    |   new   |   old   |
P1 has 36 factors:      10 ms    10 ms
P2 has 12 factors:      19 ms    19 ms
P3 has 16 factors:      37 ms    37 ms
P4 has 2 factors:      352 ms   350 ms
P5 has 1 factors:       11 ms    11 ms
P6 has 6 factors:       17 ms    17 ms
P7 has 1 factors:      559 ms    408 ms
P8 has 1 factors:      199 ms    192 ms
M12_5 has 1 factors:   651 ms    599 ms
M12_6 has 2 factors:  8412 ms   8740 ms
T1 has 2 factors:      159 ms    160 ms
T2 has 2 factors:      171 ms    172 ms
T3 has 4 factors:     5443 ms   5805 ms
H1 has 28 factors:    2598 ms   2073 ms
S7 has 1 factors:      181 ms    155 ms
S8 has 1 factors:     2262 ms   2319 ms
C1 has 32 factors:     734 ms    397 ms
```