### PR TITLE
Fix bug in test code for GCC 12

### DIFF
--- a/test/t-sdiv_qrnnd.c
+++ b/test/t-sdiv_qrnnd.c
@@ -33,7 +33,7 @@ int main(void)
         {
             d = n_randtest_not_zero(state);
             nh = n_randtest(state);
-        } while ((FLINT_ABS(nh) >= FLINT_ABS(d)/2) || (nh == WORD_MIN));
+        } while ((nh == WORD_MIN) || (FLINT_ABS(nh) >= FLINT_ABS(d)/2));
 
         nl = n_randtest(state);
 


### PR DESCRIPTION
Weird bug in GCC 12, but swapping the argument for a logical or seems to make a difference. I have sent them an email about getting an account for claiming this bug. Until this is fixed, let's write it like this.