### PR TITLE
Declude mpfr

### DIFF
--- a/.build_dependencies
+++ b/.build_dependencies
@@ -61,7 +61,7 @@ echo \
 ##################################################"
 
 echo "Downloading..."
-wget https://www.mpfr.org/mpfr-4.0.0/mpfr-4.0.0.tar.bz2 > out.log 2>&1
+wget https://www.mpfr.org/mpfr-current/mpfr-4.1.0.tar.bz2 > out.log 2>&1
 if [ $? = 0 ]; then
     echo "Successfully downloaded."
     echo ""
@@ -71,8 +71,8 @@ else
     exit 1
 fi
 
-tar -xf mpfr-4.0.0.tar.bz2
-cd mpfr-4.0.0
+tar -xf mpfr-4.1.0.tar.bz2
+cd mpfr-4.1.0
 
 echo "Configuring..."
 ./configure --with-gmp=${LOCAL} --prefix=${LOCAL} --enable-shared \

--- a/arith.h
+++ b/arith.h
@@ -19,7 +19,6 @@
 #endif
 
 #include <gmp.h>
-#include <mpfr.h>
 #include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
@@ -34,7 +33,9 @@
 
 /* MPFR extras ***************************************************************/
 
+#ifdef __MPFR_H
 FLINT_DLL void mpfr_zeta_inv_euler_product(mpfr_t res, ulong s, int char_4);
+#endif
 
 /* Various arithmetic functions **********************************************/
 
@@ -221,7 +222,9 @@ FLINT_DLL extern const unsigned int partitions_lookup[128];
 
 FLINT_DLL void arith_number_of_partitions_nmod_vec(mp_ptr res, slong len, nmod_t mod);
 FLINT_DLL void arith_number_of_partitions_vec(fmpz * res, slong len);
+#ifdef __MPFR_H
 FLINT_DLL void arith_number_of_partitions_mpfr(mpfr_t x, ulong n);
+#endif
 FLINT_DLL void arith_number_of_partitions(fmpz_t x, ulong n);
 
 /* Number of sums of squares representations *********************************/

--- a/arith.h
+++ b/arith.h
@@ -19,6 +19,7 @@
 #endif
 
 #include <gmp.h>
+#include "mpfr.h"
 #include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
@@ -33,9 +34,7 @@
 
 /* MPFR extras ***************************************************************/
 
-#ifdef __MPFR_H
 FLINT_DLL void mpfr_zeta_inv_euler_product(mpfr_t res, ulong s, int char_4);
-#endif
 
 /* Various arithmetic functions **********************************************/
 
@@ -222,9 +221,7 @@ FLINT_DLL extern const unsigned int partitions_lookup[128];
 
 FLINT_DLL void arith_number_of_partitions_nmod_vec(mp_ptr res, slong len, nmod_t mod);
 FLINT_DLL void arith_number_of_partitions_vec(fmpz * res, slong len);
-#ifdef __MPFR_H
 FLINT_DLL void arith_number_of_partitions_mpfr(mpfr_t x, ulong n);
-#endif
 FLINT_DLL void arith_number_of_partitions(fmpz_t x, ulong n);
 
 /* Number of sums of squares representations *********************************/

--- a/arith/bernoulli_number_zeta.c
+++ b/arith/bernoulli_number_zeta.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "mpfr.h"
 #include "arith.h"
 
 void _arith_bernoulli_number_zeta(fmpz_t num, fmpz_t den, ulong n)

--- a/arith/cyclotomic_cos_polynomial.c
+++ b/arith/cyclotomic_cos_polynomial.c
@@ -10,6 +10,7 @@
 */
 
 #include <math.h>
+#include "mpfr.h"
 #include "arith.h"
 
 #define MAX_32BIT 58

--- a/arith/euler_number_zeta.c
+++ b/arith/euler_number_zeta.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "mpfr.h"
 #include "arith.h"
 
 void _arith_euler_number_zeta(fmpz_t res, ulong n)

--- a/arith/number_of_partitions.c
+++ b/arith/number_of_partitions.c
@@ -10,6 +10,7 @@
 */
 
 #include <math.h>
+#include "mpfr.h"
 #include "arith.h"
 
 /* This nice round number precisely fits on 32 bits */

--- a/arith/number_of_partitions_mpfr.c
+++ b/arith/number_of_partitions_mpfr.c
@@ -10,6 +10,7 @@
 */
 
 #include <math.h>
+#include "mpfr.h"
 #include "arith.h"
 
 #define DOUBLE_PREC 53

--- a/arith/zeta_inv_euler_product.c
+++ b/arith/zeta_inv_euler_product.c
@@ -10,6 +10,7 @@
 */
 
 #include <math.h>
+#include "mpfr.h"
 #include "arith.h"
 
 void mpfr_zeta_inv_euler_product(mpfr_t res, ulong s, int char_4)

--- a/doc/source/fmpq.rst
+++ b/doc/source/fmpq.rst
@@ -214,6 +214,9 @@ Conversion
     in direction ``rnd``. Returns the sign of the rounding,
     according to MPFR conventions.
 
+    **Note:** Requires that ``mpfr.h`` has been included before any FLINT
+    header is included.
+
 .. function:: char * _fmpq_get_str(char * str, int b, const fmpz_t num, const fmpz_t den)
               char * fmpq_get_str(char * str, int b, const fmpq_t x)
 

--- a/doc/source/fmpz.rst
+++ b/doc/source/fmpz.rst
@@ -231,6 +231,9 @@ Conversion
     Sets the value of `x` from `f`, rounded toward the given
     direction ``rnd``.
 
+    **Note:** Requires that ``mpfr.h`` has been included before any FLINT
+    header is included.
+
 .. function:: double fmpz_get_d_2exp(slong * exp, const fmpz_t f)
 
     Returns `f` as a normalized ``double`` along with a `2`-exponent 

--- a/doc/source/mpfr_vec.rst
+++ b/doc/source/mpfr_vec.rst
@@ -8,12 +8,12 @@ Memory management
 --------------------------------------------------------------------------------
 
 
-.. function:: flint_mpfr * _mpfr_vec_init(slong len, flint_bitcnt_t prec)
+.. function:: mpfr_ptr _mpfr_vec_init(slong len, flint_bitcnt_t prec)
 
     Returns a vector of the given length of initialised ``mpfr``'s 
     with the given exact precision.
  
-.. function:: void _mpfr_vec_clear(flint_mpfr * vec, slong len)
+.. function:: void _mpfr_vec_clear(mpfr_ptr vec, slong len)
 
     Clears the given vector.
 
@@ -22,30 +22,30 @@ Arithmetic
 --------------------------------------------------------------------------------
 
 
-.. function:: void _mpfr_vec_zero(flint_mpfr * vec, slong len)
+.. function:: void _mpfr_vec_zero(mpfr_ptr vec, slong len)
 
     Zeros the vector ``(vec, len)``.
 
-.. function:: void _mpfr_vec_set(flint_mpfr * vec1, const flint_mpfr * vec2, slong len)
+.. function:: void _mpfr_vec_set(mpfr_ptr vec1, mpfr_srcptr vec2, slong len)
 
     Copies the vector ``vec2`` of the given length into ``vec1``. 
     No check is made to ensure ``vec1`` and ``vec2`` are different.
 
-.. function:: void _mpfr_vec_add(flint_mpfr * res, const flint_mpfr * vec1, const flint_mpfr * vec2, slong len)
+.. function:: void _mpfr_vec_add(mpfr_ptr res, mpfr_srcptr vec1, mpfr_srcptr vec2, slong len)
 
     Adds the given vectors of the given length together and stores the 
     result in ``res``.
 
-.. function:: void _mpfr_vec_scalar_mul_mpfr(flint_mpfr * res, const flint_mpfr * vec, slong len, mpfr_t c)
+.. function:: void _mpfr_vec_scalar_mul_mpfr(mpfr_ptr res, mpfr_srcptr vec, slong len, mpfr_t c)
 
     Multiplies the vector with given length by the scalar `c` and 
     sets ``res`` to the result.
 
-.. function:: void _mpfr_vec_scalar_mul_2exp(flint_mpfr * res, const flint_mpfr * vec, slong len, flint_bitcnt_t exp)
+.. function:: void _mpfr_vec_scalar_mul_2exp(mpfr_ptr res, mpfr_srcptr vec, slong len, flint_bitcnt_t exp)
 
     Multiplies the given vector of the given length by ``2^exp``.
 
-.. function:: void _mpfr_vec_scalar_product(mpfr_t res, const flint_mpfr * vec1, const flint_mpfr * vec2, slong len)
+.. function:: void _mpfr_vec_scalar_product(mpfr_t res, mpfr_srcptr vec1, mpfr_srcptr vec2, slong len)
 
    Sets ``res`` to the scalar product of ``(vec1, len)`` with 
     ``(vec2, len)``. Assumes ``len > 0``.

--- a/flint.h
+++ b/flint.h
@@ -18,7 +18,6 @@
 #include <sys/param.h> /* for BSD define */
 #endif
 #include <gmp.h>
-#include <mpfr.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h> /* for alloca on FreeBSD */
@@ -62,15 +61,8 @@
                          __FLINT_VERSION_MINOR * 100 + \
                          __FLINT_VERSION_PATCHLEVEL)
 
-/*
-   Check mpir and mpfr version numbers
-*/
 #if __GNU_MP_VERSION < 5
 #error GMP 5.0.0 or MPIR 2.6.0 or later are required
-#endif
-
-#if MPFR_VERSION_MAJOR < 3
-#error MPFR 3.0.0 or later is required
 #endif
 
 /*
@@ -268,11 +260,6 @@ void flint_rand_free(flint_rand_s * state)
 #define FLINT_TEST_CLEANUP(xxx) \
    flint_randclear(xxx); \
    flint_cleanup_master();
-
-/*
-  We define this here as there is no mpfr.h
- */
-typedef __mpfr_struct flint_mpfr;
 
 #if FLINT_WANT_ASSERT
 #define FLINT_ASSERT(param) assert(param)

--- a/fmpq.h
+++ b/fmpq.h
@@ -25,7 +25,6 @@
 #undef ulong
 
 #include <gmp.h>
-#include <mpfr.h>
 #define ulong mp_limb_t
 #include "flint.h"
 #include "fmpz.h"
@@ -188,7 +187,9 @@ FMPQ_INLINE void fmpq_get_mpq(mpq_t dest, const fmpq_t src)
 
 FLINT_DLL double fmpq_get_d(const fmpq_t a);
 
+#ifdef __MPFR_H
 FLINT_DLL int fmpq_get_mpfr(mpfr_t r, const fmpq_t x, mpfr_rnd_t rnd);
+#endif
 
 FLINT_DLL void fmpq_get_mpz_frac(mpz_t a, mpz_t b, fmpq_t c);
 

--- a/fmpq/get_mpfr.c
+++ b/fmpq/get_mpfr.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "mpfr.h"
 #include "fmpq.h"
 
 int

--- a/fmpz.h
+++ b/fmpz.h
@@ -334,7 +334,9 @@ FLINT_DLL void fmpz_get_mpf(mpf_t x, const fmpz_t f);
 
 FLINT_DLL void fmpz_set_mpf(fmpz_t f, const mpf_t x);
 
+#ifdef __MPFR_H
 FLINT_DLL void fmpz_get_mpfr(mpfr_t x, const fmpz_t f, mpfr_rnd_t rnd);
+#endif
 
 FLINT_DLL int fmpz_get_mpn(mp_ptr *n, fmpz_t n_in);
 

--- a/fmpz/get_mpfr.c
+++ b/fmpz/get_mpfr.c
@@ -14,10 +14,10 @@
 #include <stdint.h> /* to enable mpfr_set_sj in mpfr.h */
 #endif
 #include <gmp.h>
+#include <mpfr.h>
 #if defined( _WIN64) && defined( _MSC_MPIR_VERSION ) && __MPIR_RELEASE >= 20700
 #  if defined( _MSC_VER ) && _MSC_VER >= 1600
 #    include <stdint.h>
-#    include <mpfr.h>
 #    define mpfr_set_si mpfr_set_sj
 #  endif
 #endif

--- a/fmpz/test/t-get_mpfr.c
+++ b/fmpz/test/t-get_mpfr.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <gmp.h>
+#include "mpfr.h"
 #include "flint.h"
 #include "ulong_extras.h"
 #include "fmpz.h"

--- a/fmpz_lll/is_reduced_mpfr.c
+++ b/fmpz_lll/is_reduced_mpfr.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "mpfr.h"
 #include "fmpz_lll.h"
 #include "mpfr_vec.h"
 #include "mpfr_mat.h"

--- a/fmpz_lll/is_reduced_mpfr.c
+++ b/fmpz_lll/is_reduced_mpfr.c
@@ -24,7 +24,7 @@ fmpz_lll_is_reduced_mpfr(const fmpz_mat_t B, const fmpz_lll_t fl,
         slong i, j, k, m, n;
         mpfr_mat_t A, Q, R, V, Wu, Wd, bound, bound2, bound3, boundt, mm, rm,
             mn, rn, absR;
-        flint_mpfr *du, *dd;
+        mpfr_ptr du, dd;
         mpfr_t s, norm, ti, tj, tmp;
 
         if (B->r == 0 || B->r == 1)
@@ -509,7 +509,7 @@ fmpz_lll_is_reduced_mpfr(const fmpz_mat_t B, const fmpz_lll_t fl,
         slong i, j, k, m, n;
         mpfr_mat_t A, R, V, Wu, Wd, bound, bound2, bound3, boundt, mm, rm,
             mn, rn, absR;
-        flint_mpfr *du, *dd;
+        mpfr_ptr du, dd;
         mpfr_t s, norm, ti, tj, tmp;
 
         if (B->r == 0 || B->r == 1)

--- a/fmpz_lll/is_reduced_mpfr_with_removal.c
+++ b/fmpz_lll/is_reduced_mpfr_with_removal.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "mpfr.h"
 #include "fmpz_lll.h"
 #include "mpfr_vec.h"
 #include "mpfr_mat.h"

--- a/fmpz_lll/is_reduced_mpfr_with_removal.c
+++ b/fmpz_lll/is_reduced_mpfr_with_removal.c
@@ -25,7 +25,7 @@ fmpz_lll_is_reduced_mpfr_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
         slong i, j, k, m, n;
         mpfr_mat_t A, Q, R, V, Wu, Wd, bound, bound2, bound3, boundt, mm, rm,
             mn, rn, absR;
-        flint_mpfr *du, *dd;
+        mpfr_ptr du, dd;
         mpfr_t s, norm, ti, tj, tmp, mpfr_gs_B;
 
         if (B->r == 0 || B->r == 1)
@@ -530,7 +530,7 @@ fmpz_lll_is_reduced_mpfr_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
         slong i, j, k, m, n;
         mpfr_mat_t A, R, V, Wu, Wd, bound, bound2, bound3, boundt, mm, rm,
             mn, rn, absR;
-        flint_mpfr *du, *dd;
+        mpfr_ptr du, dd;
         mpfr_t s, norm, ti, tj, tmp, mpfr_gs_B;
 
         if (B->r == 0 || B->r == 1)

--- a/fmpz_poly/test/t-evaluate_horner_d_2exp.c
+++ b/fmpz_poly/test/t-evaluate_horner_d_2exp.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <gmp.h>
+#include "mpfr.h"
 #include "flint.h"
 #include "fmpz.h"
 #include "fmpz_poly.h"

--- a/memory_manager.c
+++ b/memory_manager.c
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "flint.h"
+#include "mpfr.h"
 #include "thread_pool.h"
 
 #if FLINT_USES_GC

--- a/mpf_mat/test/t-init_clear.c
+++ b/mpf_mat/test/t-init_clear.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <gmp.h>
+#include "mpfr.h"
 #include "flint.h"
 #include "mpf_mat.h"
 #include "ulong_extras.h"

--- a/mpf_vec/test/t-init_clear.c
+++ b/mpf_vec/test/t-init_clear.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <gmp.h>
+#include "mpfr.h"
 #include "flint.h"
 #include "mpf_vec.h"
 #include "ulong_extras.h"

--- a/mpfr_mat.h
+++ b/mpfr_mat.h
@@ -18,7 +18,7 @@
 #define MPFR_MAT_INLINE static __inline__
 #endif
 
-#include <gmp.h>
+#include "flint.h"
 #include <mpfr.h> 
 
 #ifdef __cplusplus

--- a/mpfr_vec.h
+++ b/mpfr_vec.h
@@ -18,12 +18,18 @@
 #define MPFR_VEC_INLINE static __inline__
 #endif
 
-#include <gmp.h>
+#include "flint.h"
 #include <mpfr.h> 
+
+#if MPFR_VERSION_MAJOR < 3
+#error MPFR 3.0.0 or later is required
+#endif
 
 #ifdef __cplusplus
  extern "C" {
 #endif
+
+typedef __mpfr_struct flint_mpfr;
 
 FLINT_DLL flint_mpfr * _mpfr_vec_init(slong length, flint_bitcnt_t prec);
 

--- a/mpfr_vec.h
+++ b/mpfr_vec.h
@@ -29,36 +29,31 @@
  extern "C" {
 #endif
 
-typedef __mpfr_struct flint_mpfr;
+/* Soon to be deprecated */
+#define flint_mpfr __mpfr_struct
 
-FLINT_DLL flint_mpfr * _mpfr_vec_init(slong length, flint_bitcnt_t prec);
+FLINT_DLL mpfr_ptr _mpfr_vec_init(slong length, flint_bitcnt_t prec);
 
-FLINT_DLL void _mpfr_vec_clear(flint_mpfr * vec, slong length);
+FLINT_DLL void _mpfr_vec_clear(mpfr_ptr vec, slong length);
 
-FLINT_DLL void _mpfr_vec_randtest(flint_mpfr * f, flint_rand_t state, slong len);
+FLINT_DLL void _mpfr_vec_randtest(mpfr_ptr f, flint_rand_t state, slong len);
 
-FLINT_DLL void _mpfr_vec_zero(flint_mpfr * vec, slong length);
+FLINT_DLL void _mpfr_vec_zero(mpfr_ptr vec, slong length);
 
-FLINT_DLL void _mpfr_vec_set(flint_mpfr * vec1, const flint_mpfr * vec2, slong length);
+FLINT_DLL void _mpfr_vec_set(mpfr_ptr vec1, mpfr_srcptr vec2, slong length);
 
-FLINT_DLL int _mpfr_vec_equal(const flint_mpfr * vec1, const flint_mpfr * vec2, slong len);
+FLINT_DLL int _mpfr_vec_equal(mpfr_srcptr vec1, mpfr_srcptr vec2, slong len);
 
-FLINT_DLL void _mpfr_vec_add(flint_mpfr * res, const flint_mpfr * vec1, const flint_mpfr * vec2, slong length);
+FLINT_DLL void _mpfr_vec_add(mpfr_ptr res, mpfr_srcptr vec1, mpfr_srcptr vec2, slong length);
 
-FLINT_DLL void _mpfr_vec_scalar_mul_2exp(flint_mpfr * res, const flint_mpfr * vec, slong length, flint_bitcnt_t exp);
+FLINT_DLL void _mpfr_vec_scalar_mul_2exp(mpfr_ptr res, mpfr_srcptr vec, slong length, flint_bitcnt_t exp);
 
-FLINT_DLL void _mpfr_vec_scalar_mul_mpfr(flint_mpfr * res, const flint_mpfr * vec, slong length, mpfr_t c);
+FLINT_DLL void _mpfr_vec_scalar_mul_mpfr(mpfr_ptr res, mpfr_srcptr vec, slong length, mpfr_t c);
 
-FLINT_DLL void _mpfr_vec_scalar_product(mpfr_t res, const flint_mpfr * vec1, const flint_mpfr * vec2, slong length);
+FLINT_DLL void _mpfr_vec_scalar_product(mpfr_t res, mpfr_srcptr vec1, mpfr_srcptr vec2, slong length);
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif
-
-
-
-
-
-

--- a/mpfr_vec/add.c
+++ b/mpfr_vec/add.c
@@ -16,7 +16,7 @@
 #include "mpfr_vec.h"
 
 void
-_mpfr_vec_add(flint_mpfr * res, const flint_mpfr * vec1, const flint_mpfr * vec2, slong length)
+_mpfr_vec_add(mpfr_ptr res, mpfr_srcptr vec1, mpfr_srcptr vec2, slong length)
 {
     slong i;
     for (i = 0; i < length; i++)

--- a/mpfr_vec/clear.c
+++ b/mpfr_vec/clear.c
@@ -16,7 +16,7 @@
 #include "mpfr_vec.h"
 
 void
-_mpfr_vec_clear(flint_mpfr * vec, slong length)
+_mpfr_vec_clear(mpfr_ptr vec, slong length)
 {
     slong i;
     for (i = 0; i < length; i++)

--- a/mpfr_vec/equal.c
+++ b/mpfr_vec/equal.c
@@ -14,7 +14,7 @@
 #include "mpfr_vec.h"
 
 int
-_mpfr_vec_equal(const flint_mpfr * vec1, const flint_mpfr * vec2, slong len)
+_mpfr_vec_equal(mpfr_srcptr vec1, mpfr_srcptr vec2, slong len)
 {
     slong i;
     if (vec1 == vec2)

--- a/mpfr_vec/init.c
+++ b/mpfr_vec/init.c
@@ -15,7 +15,7 @@
 #include "flint.h"
 #include "mpfr_vec.h"
 
-flint_mpfr *
+mpfr_ptr
 _mpfr_vec_init(slong length, flint_bitcnt_t prec)
 {
     slong i;

--- a/mpfr_vec/randtest.c
+++ b/mpfr_vec/randtest.c
@@ -13,7 +13,7 @@
 #include "mpfr_vec.h"
 
 void
-_mpfr_vec_randtest(flint_mpfr * f, flint_rand_t state, slong len)
+_mpfr_vec_randtest(mpfr_ptr f, flint_rand_t state, slong len)
 {
     slong i;
 

--- a/mpfr_vec/scalar_mul_2exp.c
+++ b/mpfr_vec/scalar_mul_2exp.c
@@ -16,7 +16,7 @@
 #include "mpfr_vec.h"
 
 void
-_mpfr_vec_scalar_mul_2exp(flint_mpfr * res, const flint_mpfr * vec, slong length, flint_bitcnt_t exp)
+_mpfr_vec_scalar_mul_2exp(mpfr_ptr res, mpfr_srcptr vec, slong length, flint_bitcnt_t exp)
 {
     slong i;
     for (i = 0; i < length; i++)

--- a/mpfr_vec/scalar_mul_mpfr.c
+++ b/mpfr_vec/scalar_mul_mpfr.c
@@ -16,7 +16,7 @@
 #include "mpfr_vec.h"
 
 void
-_mpfr_vec_scalar_mul_mpfr(flint_mpfr * res, const flint_mpfr * vec, slong length, mpfr_t c)
+_mpfr_vec_scalar_mul_mpfr(mpfr_ptr res, mpfr_srcptr vec, slong length, mpfr_t c)
 {
     slong i;
     for (i = 0; i < length; i++)

--- a/mpfr_vec/scalar_product.c
+++ b/mpfr_vec/scalar_product.c
@@ -16,8 +16,8 @@
 #include "mpfr_vec.h"
 
 void
-_mpfr_vec_scalar_product(mpfr_t res, const flint_mpfr * vec1,
-                         const flint_mpfr * vec2, slong length)
+_mpfr_vec_scalar_product(mpfr_t res, mpfr_srcptr vec1,
+                         mpfr_srcptr vec2, slong length)
 {
     slong i;
     mpfr_t tmp;

--- a/mpfr_vec/set.c
+++ b/mpfr_vec/set.c
@@ -16,7 +16,7 @@
 #include "mpfr_vec.h"
 
 void
-_mpfr_vec_set(flint_mpfr * vec1, const flint_mpfr * vec2, slong length)
+_mpfr_vec_set(mpfr_ptr vec1, mpfr_srcptr vec2, slong length)
 {
     slong i;
     for (i = 0; i < length; i++)

--- a/mpfr_vec/test/t-set_equal.c
+++ b/mpfr_vec/test/t-set_equal.c
@@ -31,7 +31,7 @@ main(void)
     /* Check aliasing of a and b */
     for (i = 0; i < 1000 * flint_test_multiplier(); i++)
     {
-        flint_mpfr *a;
+        mpfr_ptr a;
         slong len = n_randint(state, 100);
 
         a = _mpfr_vec_init(len, 200);
@@ -53,7 +53,7 @@ main(void)
     /* Compare copied vectors */
     for (i = 0; i < 1000 * flint_test_multiplier(); i++)
     {
-        flint_mpfr *a, *b;
+        mpfr_ptr a, b;
         slong len = n_randint(state, 100);
 
         a = _mpfr_vec_init(len, 200);
@@ -77,7 +77,7 @@ main(void)
     /* Compare unequal vectors */
     for (i = 0; i < 1000 * flint_test_multiplier(); i++)
     {
-        flint_mpfr *a, *b;
+        mpfr_ptr a, b;
         slong len = n_randint(state, 100) + 1;
         slong coeff;
 

--- a/mpfr_vec/zero.c
+++ b/mpfr_vec/zero.c
@@ -16,7 +16,7 @@
 #include "mpfr_vec.h"
 
 void
-_mpfr_vec_zero(flint_mpfr * vec, slong length)
+_mpfr_vec_zero(mpfr_ptr vec, slong length)
 {
     slong i;
     for (i = 0; i < length; i++)


### PR DESCRIPTION
I defined `flint_mpfr` as a macro as I think it should be deprecated within a couple of versions.

Edit: Users now have to include `mpfr.h` **before** including FLINT in order to get such functionality. The exceptions here are `mpfr_[vec/mat].h` which includes these by default.