### PR TITLE
add factor_integer example program

### DIFF
--- a/examples/factor_integer.c
+++ b/examples/factor_integer.c
@@ -1,0 +1,114 @@
+/*
+    Copyright (C) 2022 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <gmp.h>
+#include "flint.h"
+#include "fmpz.h"
+#include "fmpz_factor.h"
+#include "fmpz_mpoly.h"
+#include "profiler.h"
+
+int
+main(int argc, char * argv[])
+{
+    fmpz_t n;
+    fmpz_factor_t fac;
+    slong i;
+    int num_threads = 1;
+    int timing = 0;
+
+    if (argc < 2)
+    {
+        flint_printf("usage: factor_integer [-threads t] [-timing] n\n");
+        flint_printf("n can be given as an expression (no spaces)\n");
+        return 1;
+    }
+
+    fmpz_init(n);
+
+    for (i = 1; i < argc; i++)
+    {
+        if (!strcmp(argv[i], "-threads"))
+        {
+            num_threads = atoi(argv[i+1]);
+            flint_set_num_threads(num_threads);
+            i++;
+        }
+        else if (!strcmp(argv[i], "-timing"))
+        {
+            timing = 1;
+        }
+        else
+        {
+            /* allow input like 2^64+1 */
+            /* we don't have an expression parser for fmpz yet, so use
+               fmpz_mpoly with 0 variables  */
+            {
+                fmpz_mpoly_ctx_t mctx;
+                fmpz_mpoly_t f;
+
+                fmpz_mpoly_ctx_init(mctx, 0, ORD_LEX);
+                fmpz_mpoly_init(f, mctx);
+
+                if (fmpz_mpoly_set_str_pretty(f, argv[i], NULL, mctx) != 0)
+                {
+                    flint_printf("unable to parse integer\n");
+                    return 1;
+                }
+
+                fmpz_mpoly_get_fmpz(n, f, mctx);
+
+                fmpz_mpoly_clear(f, mctx);
+                fmpz_mpoly_ctx_clear(mctx);
+            }
+        }
+    }
+
+    fmpz_factor_init(fac);
+
+    if (timing)
+    {
+        TIMEIT_START
+        fmpz_factor(fac, n);
+        TIMEIT_STOP
+        SHOW_MEMORY_USAGE
+    }
+    else
+    {
+        fmpz_factor(fac, n);
+    }
+
+    fmpz_print(n);
+    flint_printf(" =\n");
+    if (fac->sign != 1 || fac->num == 0)
+    {
+        flint_printf("%d", fac->sign);
+        if (fac->num > 0)
+            flint_printf(" * ");
+    }
+    for (i = 0; i < fac->num; i++)
+    {
+        fmpz_print(fac->p + i);
+        if (fac->exp[i] >= 2)
+            flint_printf("^%lu", fac->exp[i]);
+        if (i < fac->num - 1)
+            flint_printf(" * ");
+    }
+    flint_printf("\n");
+
+    fmpz_factor_clear(fac);
+    fmpz_clear(n);
+
+    flint_cleanup_master();
+    return 0;
+}

--- a/examples/factor_polynomial.c
+++ b/examples/factor_polynomial.c
@@ -1,0 +1,100 @@
+/*
+    Copyright (C) 2022 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <gmp.h>
+#include "flint.h"
+#include "fmpz.h"
+#include "fmpz_mpoly.h"
+#include "fmpz_mpoly_factor.h"
+#include "profiler.h"
+
+int
+main(int argc, char * argv[])
+{
+    fmpz_mpoly_t f;
+    fmpz_mpoly_ctx_t mctx;
+    fmpz_mpoly_factor_t fac;
+    slong i;
+    int num_threads = 1;
+    int timing = 0;
+    int suppress = 0;
+    const char * vars[] = { "x", "y", "z" };
+
+    if (argc < 2)
+    {
+        flint_printf("usage: factor_polynomial [-threads t] [-timing] [-suppress] expr\n");
+        flint_printf("example: build/examples/factor_polynomial -timing \"(1+x+2*y+3*z)^3+1\"\n");
+        return 1;
+    }
+
+    fmpz_mpoly_ctx_init(mctx, 3, ORD_LEX);
+    fmpz_mpoly_init(f, mctx);
+    fmpz_mpoly_factor_init(fac, mctx);
+
+    for (i = 1; i < argc; i++)
+    {
+        if (!strcmp(argv[i], "-threads"))
+        {
+            num_threads = atoi(argv[i+1]);
+            flint_set_num_threads(num_threads);
+            i++;
+        }
+        else if (!strcmp(argv[i], "-timing"))
+        {
+            timing = 1;
+        }
+        else if (!strcmp(argv[i], "-suppress"))
+        {
+            suppress = 1;
+        }
+        else
+        {
+            if (fmpz_mpoly_set_str_pretty(f, argv[i], vars, mctx) != 0)
+            {
+                flint_printf("unable to parse polynomial\n");
+                return 1;
+            }
+        }
+    }
+
+    if (timing)
+    {
+        TIMEIT_START
+        fmpz_mpoly_factor(fac, f, mctx);
+        TIMEIT_STOP
+        SHOW_MEMORY_USAGE
+    }
+    else
+    {
+        fmpz_mpoly_factor(fac, f, mctx);
+    }
+
+    if (!suppress)
+    {
+        fmpz_mpoly_print_pretty(f, vars, mctx);
+        flint_printf(" =\n");
+        fmpz_mpoly_factor_print_pretty(fac, vars, mctx);
+        flint_printf("\n");
+    }
+    else
+    {
+        flint_printf("%wd irreducible factors\n", fac->num);
+    }
+
+    fmpz_mpoly_factor_clear(fac, mctx);
+    fmpz_mpoly_clear(f, mctx);
+    fmpz_mpoly_ctx_clear(mctx);
+
+    flint_cleanup_master();
+    return 0;
+}


### PR DESCRIPTION
The `examples` directory is quite neglected. This adds a program demonstrating that Flint can factor integers (typically something people look for in a number theory library).

    fredrik@mordor:~/src/flint2$ build/examples/factor_integer -threads 8 -timing 10^65+5
    cpu/wall(s): 4.756 1.221
    virt/peak/res/peak(MB): 538.10 560.48 22.43 37.82
    100000000000000000000000000000000000000000000000000000000000000005 =
    3 * 5 * 19 * 587 * 1495746017710260639140088379 * 399631012640915970972514028712641
