### PR TITLE
Add flint_mpn_mul et al.; use in fmpz_mul, fmpz_addmul and other places 

### DIFF
--- a/doc/source/mpn_extras.rst
+++ b/doc/source/mpn_extras.rst
@@ -34,6 +34,30 @@ Utility functions
 Multiplication
 --------------------------------------------------------------------------------
 
+.. function:: mp_limb_t flint_mpn_mul(mp_ptr z, mp_srcptr x, mp_size_t xn, mp_srcptr y, mp_size_t yn)
+
+    Sets ``(z, xn+yn)`` to the product of ``(x, xn)`` and ``(y, yn)``
+    and returns the top limb of the result.
+    We require `xn \ge yn \ge 1`
+    and that ``z`` is not aliased with either input operand.
+    This function uses FFT multiplication if the operands are large enough
+    and otherwise calls ``mpn_mul``.
+
+.. function:: void flint_mpn_mul_n(mp_ptr z, mp_srcptr x, mp_srcptr y, mp_size_t n)
+
+    Sets ``z`` to the product of ``(x, n)`` and ``(y, n)``.
+    We require `n \ge 1`
+    and that ``z`` is not aliased with either input operand.
+    This function uses FFT multiplication if the operands are large enough
+    and otherwise calls ``mpn_mul_n``.
+
+.. function:: void flint_mpn_sqr(mp_ptr z, mp_srcptr x, mp_size_t n)
+
+    Sets ``z`` to the square of ``(x, n)``.
+    We require `n \ge 1`
+    and that ``z`` is not aliased with either input operand.
+    This function uses FFT multiplication if the operands are large enough
+    and otherwise calls ``mpn_sqr``.
 
 .. function:: mp_size_t flint_mpn_fmms1(mp_ptr y, mp_limb_t a1, mp_srcptr x1, mp_limb_t a2, mp_srcptr x2, mp_size_t n)
 

--- a/fmpz/addmul.c
+++ b/fmpz/addmul.c
@@ -21,7 +21,7 @@
             _mpz_realloc(z, nlimbs); \
     } while (0)
 
-/* Will not get called with x or y small */
+/* Will not get called with x or y small. */
 void
 _flint_mpz_addmul_large(mpz_ptr z, mpz_srcptr x, mpz_srcptr y, int negate)
 {
@@ -76,7 +76,11 @@ _flint_mpz_addmul_large(mpz_ptr z, mpz_srcptr x, mpz_srcptr y, int negate)
     if (zn == 0)
     {
         /* Cannot have aliasing here, because x and y are not
-           small and therefore not 0. */
+           small and therefore not 0. We can therefore resize z
+           or write to zd without invalidating the inputs. */
+        FLINT_ASSERT(xn >= 2 || xd[0] > COEFF_MAX);
+        FLINT_ASSERT(yn >= 2 || yd[0] > COEFF_MAX);
+
         MPZ_FIT_SIZE(z, tn + 1);
         zd = z->_mp_d;
         zn = tn;

--- a/fmpz/addmul.c
+++ b/fmpz/addmul.c
@@ -13,6 +13,145 @@
 #include "flint.h"
 #include "ulong_extras.h"
 #include "fmpz.h"
+#include "mpn_extras.h"
+
+#define MPZ_FIT_SIZE(z, nlimbs) \
+    do { \
+        if (z->_mp_alloc < nlimbs) \
+            _mpz_realloc(z, nlimbs); \
+    } while (0)
+
+/* Will not get called with x or y small */
+void
+_flint_mpz_addmul_large(mpz_ptr z, mpz_srcptr x, mpz_srcptr y, int negate)
+{
+    mp_size_t xn, yn, tn, zn, zn_signed, zn_new, x_sgn, y_sgn, sgn, alloc;
+    mp_srcptr xd, yd;
+    mp_ptr zd;
+    mp_ptr td;
+    mp_limb_t top;
+    TMP_INIT;
+
+    xn = x->_mp_size;
+    yn = y->_mp_size;
+    x_sgn = xn;
+    y_sgn = yn;
+    xn = FLINT_ABS(xn);
+    yn = FLINT_ABS(yn);
+
+    if (xn < yn)
+    {
+        mpz_srcptr t;
+        mp_size_t tn;
+
+        t = x; x = y; y = t;
+        tn = xn; xn = yn; yn = tn;
+        tn = x_sgn; x_sgn = y_sgn; y_sgn = tn;
+    }
+
+    if (negate)
+        y_sgn = -y_sgn;
+
+    xd = x->_mp_d;
+    yd = y->_mp_d;
+
+    /* todo: could inline code for (zn <= 5) + (xn <= 2) x (yn <= 2) */
+
+    if (yn == 1)
+    {
+        if (y_sgn >= 0)
+            flint_mpz_addmul_ui(z, x, yd[0]);
+        else
+            flint_mpz_submul_ui(z, x, yd[0]);
+        return;
+    }
+
+    sgn = x_sgn ^ y_sgn;
+
+    zn_signed = z->_mp_size;
+    zn = FLINT_ABS(zn_signed);
+    sgn ^= zn_signed;
+    tn = xn + yn;
+
+    if (zn == 0)
+    {
+        /* Cannot have aliasing here, because x and y are not
+           small and therefore not 0. */
+        MPZ_FIT_SIZE(z, tn + 1);
+        zd = z->_mp_d;
+        zn = tn;
+
+        if (x == y)
+        {
+            flint_mpn_sqr(zd, xd, xn);
+            top = zd[zn - 1];
+        }
+        else
+        {
+            top = flint_mpn_mul(zd, xd, xn, yd, yn);
+        }
+
+        zn -= (top == 0);
+        z->_mp_size = (sgn >= 0) ? zn : -zn;
+        return;
+    }
+
+    TMP_START;
+    td = TMP_ALLOC(tn * sizeof(mp_limb_t));
+
+    if (x == y)
+    {
+        flint_mpn_sqr(td, xd, xn);
+        top = td[tn - 1];
+    }
+    else
+    {
+        top = flint_mpn_mul(td, xd, xn, yd, yn);
+    }
+
+    tn -= (top == 0);
+    alloc = FLINT_MAX(tn, zn) + 1;
+    MPZ_FIT_SIZE(z, alloc);
+    zd = z->_mp_d;
+
+    if (sgn >= 0)
+    {
+        if (zn >= tn)
+        {
+            top = mpn_add(zd, zd, zn, td, tn);
+            zn_new = zn;
+        }
+        else
+        {
+            top = mpn_add(zd, td, tn, zd, zn);
+            zn_new = tn;
+        }
+
+        zd[zn_new] = top;
+        zn_new += (top != 0);
+    }
+    else
+    {
+        if (zn > tn || (zn == tn && mpn_cmp(zd, td, zn) >= 0))
+        {
+            mpn_sub(zd, zd, zn, td, tn);
+            zn_new = zn;
+        }
+        else
+        {
+            mpn_sub(zd, td, tn, zd, zn);
+            zn_new = tn;
+            zn_signed = -zn_signed;
+        }
+
+        while (zn_new >= 1 && zd[zn_new - 1] == 0)
+            zn_new--;
+    }
+
+    z->_mp_size = (zn_signed >= 0) ? zn_new : -zn_new;
+
+    TMP_END;
+}
 
 void fmpz_addmul(fmpz_t f, const fmpz_t g, const fmpz_t h)
 {
@@ -35,10 +174,20 @@ void fmpz_addmul(fmpz_t f, const fmpz_t g, const fmpz_t h)
 		if (c2 < WORD(0)) fmpz_submul_ui(f, g, -c2);
 		else fmpz_addmul_ui(f, g, c2);
 		return;
-	} 
+	}
+
+    if (0)
+    {
+        fmpz_t t;
+        fmpz_init(t);
+        fmpz_mul(t, g, h);
+        fmpz_add(f, f, t);
+        fmpz_clear(t);
+        return;
+    }
 
 	/* both g and h are large */
     mf = _fmpz_promote_val(f);
-    mpz_addmul(mf, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
+    _flint_mpz_addmul_large(mf, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2), 0);
     _fmpz_demote_val(f);  /* cancellation may have occurred	*/
 }

--- a/fmpz/addmul.c
+++ b/fmpz/addmul.c
@@ -176,16 +176,6 @@ void fmpz_addmul(fmpz_t f, const fmpz_t g, const fmpz_t h)
 		return;
 	}
 
-    if (0)
-    {
-        fmpz_t t;
-        fmpz_init(t);
-        fmpz_mul(t, g, h);
-        fmpz_add(f, f, t);
-        fmpz_clear(t);
-        return;
-    }
-
 	/* both g and h are large */
     mf = _fmpz_promote_val(f);
     _flint_mpz_addmul_large(mf, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2), 0);

--- a/fmpz/mul.c
+++ b/fmpz/mul.c
@@ -1,6 +1,7 @@
 /*
     Copyright (C) 2009 William Hart
     Copyright (C) 2021 Albin Ahlbäck
+    Copyright (C) 2022 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -13,7 +14,149 @@
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"
+#include "fft.h"
 #include "fmpz.h"
+
+#define MPZ_FIT_SIZE(z, nlimbs) \
+    do { \
+        if (z->_mp_alloc < nlimbs) \
+            _mpz_realloc(z, nlimbs); \
+    } while (0)
+
+
+/* this can only be called from fmpz_mul, and assumes
+   x and y are not small */
+static void
+flint_mpz_mul(mpz_ptr z, mpz_srcptr x, mpz_srcptr y)
+{
+    mp_size_t xn, yn, zn, sgn;
+    mp_srcptr xd, yd;
+    mp_ptr zd;
+    mp_limb_t top;
+    TMP_INIT;
+
+    xn = x->_mp_size;
+    yn = y->_mp_size;
+    sgn = xn ^ yn;
+
+    xn = FLINT_ABS(xn);
+    yn = FLINT_ABS(yn);
+
+    if (xn < yn)
+    {
+        mpz_srcptr t;
+        mp_size_t tn;
+
+        t = x;
+        x = y;
+        y = t;
+
+        tn = xn;
+        xn = yn;
+        yn = tn;
+    }
+
+    xd = x->_mp_d;
+    yd = y->_mp_d;
+
+    if (xn == yn)
+    {
+        if (xn == 2)
+        {
+            mp_limb_t r3, r2, r1, r0;
+            flint_mpn_mul_2x2(r3, r2, r1, r0, xd[1], xd[0], yd[1], yd[0]);
+            zn = 4 - (r3 == 0);
+            MPZ_FIT_SIZE(z, zn);
+            zd = z->_mp_d;
+            zd[0] = r0;
+            zd[1] = r1;
+            zd[2] = r2;
+            if (r3 != 0)
+                zd[3] = r3;
+            z->_mp_size = (sgn >= 0) ? zn : -zn;
+            return;
+        }
+
+        if (xn == 1)
+        {
+            mp_limb_t hi, lo;
+            umul_ppmm(hi, lo,  xd[0], yd[0]);
+            MPZ_FIT_SIZE(z, 2);
+            zd = z->_mp_d;
+            zd[0] = lo;
+            zd[1] = hi;
+            /* result cannot be 1 limb */
+            z->_mp_size = (sgn >= 0) ? 2 : -2;
+            return;
+        }
+    }
+
+    /* Unlikely case since operands up to FLINT_BITS-2 bits get
+       caught in the fmpz fast path, but we should still optimize
+       for this, especially since we don't need to handle aliasing. */
+    if (yn == 1)
+    {
+        zn = xn + yn;
+        MPZ_FIT_SIZE(z, zn);
+        zd = z->_mp_d;
+
+        if (xn == 2)
+        {
+            mp_limb_t r2, r1, r0;
+            flint_mpn_mul_2x1(r2, r1, r0, xd[1], xd[0], yd[0]);
+            zd[0] = r0;
+            zd[1] = r1;
+            zd[2] = top = r2;
+        }
+        else
+        {
+            zd = z->_mp_d;
+            xd = x->_mp_d;
+            yd = y->_mp_d;
+            top = zd[xn] = mpn_mul_1(zd, xd, xn, yd[0]);
+        }
+
+        zn -= (top == 0);
+        z->_mp_size = (sgn >= 0) ? zn : -zn;
+        return;
+    }
+
+    TMP_START;
+
+    zn = xn + yn;
+    zd = z->_mp_d;
+
+    if (zd == xd)
+    {
+        mp_ptr tmp = TMP_ALLOC(xn * sizeof(mp_limb_t));
+        flint_mpn_copyi(tmp, xd, xn);
+        xd = tmp;
+    }
+    else if (zd == yd)
+    {
+        mp_ptr tmp = TMP_ALLOC(yn * sizeof(mp_limb_t));
+        flint_mpn_copyi(tmp, yd, yn);
+        yd = tmp;
+    }
+
+    MPZ_FIT_SIZE(z, zn);
+    zd = z->_mp_d;
+
+    if (x == y)
+    {
+        flint_mpn_sqr(zd, xd, xn);
+        top = zd[zn - 1];
+    }
+    else
+    {
+        top = flint_mpn_mul(zd, xd, xn, yd, yn);
+    }
+
+    zn -= (top == 0);
+    z->_mp_size = (sgn >= 0) ? zn : -zn;
+
+    TMP_END;
+}
 
 void
 fmpz_mul(fmpz_t f, const fmpz_t g, const fmpz_t h)
@@ -64,5 +207,5 @@ fmpz_mul(fmpz_t f, const fmpz_t g, const fmpz_t h)
     if (!COEFF_IS_MPZ(c2))
         flint_mpz_mul_si(mf, COEFF_TO_PTR(c1), c2);
     else
-        mpz_mul(mf, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
+        flint_mpz_mul(mf, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
 }

--- a/fmpz/profile/p-aors_ui.c
+++ b/fmpz/profile/p-aors_ui.c
@@ -12,8 +12,337 @@
 #include <gmp.h>
 #include "profiler.h"
 #include "fmpz.h"
+#include "fmpz_vec.h"
 
-#define ntests 10
+#define ntests 30
+
+#define OLD_ALBIN 1
+
+#if OLD_ALBIN
+
+static void
+_fmpz_add_mpn_1(fmpz_t f, const mp_limb_t * glimbs, mp_size_t gsz, mp_limb_t x);
+
+static void
+_fmpz_sub_mpn_1(fmpz_t f, const mp_limb_t * glimbs, mp_size_t gsz, mp_limb_t x);
+
+void
+fmpz_add_ui_old(fmpz_t f, const fmpz_t g, ulong x)
+{
+    __mpz_struct * mf;
+    slong g1 = *g;
+    slong f1 = *f;
+
+    if (!COEFF_IS_MPZ(g1))  /* g is small */
+    {
+        mp_size_t sz = 2;
+        if (g1 >= 0)
+        {
+            {   /* add with jump if carry */
+                ulong tmp = g1;
+                g1 += x;
+                if (((ulong) g1) < tmp)
+                    goto carry;
+            }
+            if (((ulong) g1) <= COEFF_MAX)
+            {
+                if (COEFF_IS_MPZ(f1))
+                    _fmpz_clear_mpz(f1);
+                *f = g1;
+                return;
+            }
+nocarry:    sz = 1; /* No carry, but result does not fit in small fmpz */
+carry:      if (COEFF_IS_MPZ(f1))
+                mf = COEFF_TO_PTR(f1);
+            else
+            {
+                mf = _fmpz_new_mpz();
+                *f = PTR_TO_COEFF(mf);
+            }
+            mf->_mp_size = sz;
+            mf->_mp_d[0] = g1;
+            mf->_mp_d[1] = 1; /* Set carry (not used if sz = 1) */
+        }
+        else /* g < 0 */
+        {
+            g1 += x;
+            if (((slong) x) >= 0 && g1 <= COEFF_MAX)
+            {
+                /* If x > 0 does not have its top bit set
+                 * and COEFF_MIN <= g < 0, we can interpret x + g as a slong.
+                 * So if the result in g1 is smaller than COEFF_MAX, it is a
+                 * small fmpz. */
+                if (COEFF_IS_MPZ(f1))
+                    _fmpz_clear_mpz(f1);
+                *f = g1;
+                return;
+            }
+            else
+            {
+                /* 1) If top bit is set in x, the result is going to be positive
+                 *    but will be larger than COEFF_MAX since
+                 *
+                 *          x + g  >=  (2^63) - (2^62 - 1)  =  2^62 + 1.
+                 *
+                 *    However, it will be contained in one limb since g < 0.
+                 *
+                 * 2) If top bit is not set, then result is larger than
+                 *    COEFF_MAX, and so it cannot be a small fmpz. However, it
+                 *    must fit in one limb since
+                 *
+                 *          x + g  <=  (2^63 - 1) + (-1)  =  2^63 - 2,
+                 *
+                 *    which is contained in one limb. */
+
+                goto nocarry;
+            }
+        }
+    }
+    else
+    {
+        __mpz_struct * mg = COEFF_TO_PTR(g1);
+        mp_size_t gsz = mg->_mp_size;
+        mp_limb_t * glimbs = mg->_mp_d;
+
+        if (gsz > 0)
+            _fmpz_add_mpn_1(f, glimbs, gsz, x);
+        else
+            _fmpz_sub_mpn_1(f, glimbs, gsz, x);
+    }
+}
+
+/* "Add" two number with same sign. Decide sign from g. */
+static void
+_fmpz_add_mpn_1(fmpz_t f, const mp_limb_t * glimbs, mp_size_t gsz, mp_limb_t x)
+{
+    __mpz_struct * mf;
+    mp_limb_t * flimbs;
+    mp_size_t gabssz = FLINT_ABS(gsz);
+
+    /* Promote f as it is guaranteed to be large */
+    if (COEFF_IS_MPZ(*f))
+        mf = COEFF_TO_PTR(*f);
+    else
+    {
+        mf = _fmpz_new_mpz();
+        *f = PTR_TO_COEFF(mf);
+    }
+    flimbs = mf->_mp_d;
+
+    if (mf->_mp_alloc < (gabssz + 1)) /* Ensure result fits */
+    {
+        mp_limb_t * tmp = flimbs;
+        flimbs = _mpz_realloc(mf, gabssz + 1);
+
+        /* If f and g are aliased, then we need to change glimbs as well. */
+        if (tmp == glimbs)
+            glimbs = flimbs;
+    }
+
+    /* Use GMP to calculate result */
+    flimbs[gabssz] = mpn_add_1(flimbs, glimbs, gabssz, x);
+
+    /* flimbs[gabssz] is the carry from mpn_add_1,
+     * and so gabssz + flimbs[gabssz] is valid to determine the size of f */
+    mf->_mp_size = gabssz + flimbs[gabssz];
+    if (gsz < 0)
+    {
+        /* g and x has same sign. If g is negative, we negate the result */
+        mf->_mp_size = -mf->_mp_size;
+    }
+}
+
+/* Subtract two limbs (they have different sign) and decide the sign via g. */
+static void
+_fmpz_sub_mpn_1(fmpz_t f, const mp_limb_t * glimbs, mp_size_t gsz, mp_limb_t x)
+{
+    __mpz_struct * mf;
+    mp_limb_t * flimbs;
+    mp_size_t gabssz = FLINT_ABS(gsz);
+
+    /* If size of g is 1, we have a higher probability of the result being
+     * small. */
+    if (gabssz == 1)
+    {
+        if (x <= glimbs[0]) /* Result is zero or has the same sign as g */
+        {
+            x = glimbs[0] - x;
+L1:         if (x <= COEFF_MAX) /* Fits in small fmpz */
+            {
+                if (COEFF_IS_MPZ(*f))
+                    _fmpz_clear_mpz(*f);
+                *f = (gsz > 0) ? x : -x; /* With consideration of sign */
+            }
+            else /* Does not fit in small fmpz */
+            {
+                if (COEFF_IS_MPZ(*f))
+                    mf = COEFF_TO_PTR(*f);
+                else
+                {
+                    mf = _fmpz_new_mpz();
+                    *f = PTR_TO_COEFF(mf);
+                }
+                mf->_mp_d[0] = x;
+                mf->_mp_size = gsz; /* Sign of f is the same as for g */
+            }
+        }
+        else /* |x| > |g|, which implies f has opposite sign of g */
+        {
+            /* Set x to the absolute value of |g - x|. By switching sign of
+             * gsz, we can reuse the code above. */
+            x -= glimbs[0];
+            gsz = -gsz;
+            goto L1;
+        }
+        return;
+    }
+
+    /* As g has more than one limb, it is a very high probability that result
+     * does not fit inside small fmpz. */
+    if (COEFF_IS_MPZ(*f))
+        mf = COEFF_TO_PTR(*f);
+    else
+    {
+        mf = _fmpz_new_mpz();
+        *f = PTR_TO_COEFF(mf);
+    }
+    flimbs = mf->_mp_d;
+
+    if (gabssz == 2)
+    {
+        /* Special case. Can result in a small fmpz, but as |g| > |x| the sign
+         * cannot change. */
+        sub_ddmmss(flimbs[1], flimbs[0], glimbs[1], glimbs[0], 0, x);
+        if (flimbs[1] != 0)
+        {
+            /* Most likely: upper limb not zero, so we just have set the sign
+             * of f to g's. */
+            mf->_mp_size = gsz;
+        }
+        else if (flimbs[0] > COEFF_MAX)
+        {
+            /* Still very likely: Upper limb is zero but lower limb does not
+             * fit inside a small fmpz. Sign is the same as for g, but the
+             * absolute value of the size is one. */
+            mf->_mp_size = (gsz > 0) ? 1 : -1;
+        }
+        else
+        {
+            /* Upper limb is zero and lower limb fits inside a small fmpz.
+             * Therefore we set f to +/- flimbs[0] and clear the mpz associated
+             * to f. */
+            slong tmp = flimbs[0]; /* We will clear this mpz, so save first. */
+            _fmpz_clear_mpz(*f);
+            *f = (gsz > 0) ? tmp : -tmp;
+        }
+    }
+    else
+    {
+        /* As the absolute value of g's size is larger than 2, the result won't
+         * fit inside a small fmpz. */
+        if (mf->_mp_alloc < gabssz) /* Ensure result fits */
+        {
+            /* The allocation size of g is always larger than the absolute value
+             * of g. Therefore, if f's allocation size is smaller than g's
+             * size, they cannot be aliased. */
+            flimbs = _mpz_realloc(mf, gabssz);
+        }
+
+        mpn_sub_1(flimbs, glimbs, gabssz, x); /* Subtract via GMP */
+
+        /* If last limb is zero, we have to set f's absolute size to one less
+         * than g's. */
+        mf->_mp_size = gabssz - (flimbs[gabssz - 1] == 0);
+        if (gsz < 0) /* If g is negative, then f is negative as well. */
+            mf->_mp_size = -mf->_mp_size;
+    }
+}
+
+void
+fmpz_sub_ui_old(fmpz_t f, const fmpz_t g, ulong x)
+{
+    __mpz_struct * mf;
+    slong g1 = *g;
+    slong f1 = *f;
+
+    if (!COEFF_IS_MPZ(g1))  /* g is small */
+    {
+        mp_size_t sz = -2;
+        if (g1 <= 0)
+        {
+            /* "add" with jump if carry */
+            g1 = x - g1; /* g1 = x + |g| */
+            if (((ulong) g1) < x)
+                goto carry;
+
+            if (((ulong) g1) <= COEFF_MAX)
+            {
+                if (COEFF_IS_MPZ(f1))
+                    _fmpz_clear_mpz(f1);
+                *f = -g1;
+                return;
+            }
+nocarry:    sz = -1; /* No carry, but result is not a small fmpz */
+carry:      if (COEFF_IS_MPZ(f1))
+                mf = COEFF_TO_PTR(f1);
+            else
+            {
+                mf = _fmpz_new_mpz();
+                *f = PTR_TO_COEFF(mf);
+            }
+            mf->_mp_size = sz;
+            mf->_mp_d[0] = g1;
+            mf->_mp_d[1] = 1; /* Set carry (not used if sz = -1) */
+        }
+        else
+        {
+            g1 = x - g1; /* -(g - x) */
+            if (((slong) x) >= 0 && g1 <= COEFF_MAX)
+            {
+                /* If x > 0 does not have its top bit set
+                 * and 0 < g <= COEFF_MAX, we can interpret x - g as a slong.
+                 * So if the result in g1 is smaller than COEFF_MAX, it is a
+                 * small fmpz. */
+                if (COEFF_IS_MPZ(f1))
+                    _fmpz_clear_mpz(f1);
+                *f = -g1; /* g - x = -(x - g) */
+                return;
+            }
+            else
+            {
+                /* 1) If top bit is set in x, the result is going to be negative
+                 *    but will be larger than COEFF_MAX since
+                 *
+                 *          x - g  >=  2^63 - (2^62 - 1)  =  2^62 + 1.
+                 *
+                 *    However, it will be contained in one limb since g > 0.
+                 *
+                 * 2) If top bit is not set, then result is smaller than
+                 *    COEFF_MIN, and so it cannot be a small fmpz. However, it
+                 *    must fit in one limb since
+                 *
+                 *          x - g  <=  (2^63 - 1) - 1  =  2^63 - 2,
+                 *
+                 *    which is contained in one limb. */
+
+                goto nocarry;
+            }
+        }
+    }
+    else
+    {
+        __mpz_struct * mg = COEFF_TO_PTR(g1);
+        mp_size_t gsz = mg->_mp_size;
+        mp_limb_t * glimbs = mg->_mp_d;
+
+        if (gsz > 0)
+            _fmpz_sub_mpn_1(f, glimbs, gsz, x);
+        else
+            _fmpz_add_mpn_1(f, glimbs, gsz, x);
+    }
+}
+
+#else
 
 void fmpz_add_ui_old(fmpz_t f, const fmpz_t g, ulong x)
 {
@@ -75,126 +404,159 @@ fmpz_sub_ui_old(fmpz_t f, const fmpz_t g, ulong x)
     }
 }
 
+#endif
+
 void
 sample_add_new(void * arg, ulong count)
 {
-    fmpz_t res, a;
-    ulong ix, jx, b;
+    fmpz *res, *a;
+    ulong *b;
+    ulong ix, jx;
     int bits = *((int *) arg);
 
     FLINT_TEST_INIT(state);
 
-    fmpz_init(res);
-    fmpz_init(a);
+    res = _fmpz_vec_init(ntests);
+    a = _fmpz_vec_init(ntests);
+    b = flint_malloc(sizeof(mp_limb_t) * ntests);
    
-    for (ix = 0; ix < 100 * count; ix++)
+    for (ix = 0; ix < 10 * count; ix++)
     {
-        fmpz_randtest(a, state, bits);
-        b = n_randtest(state);
+        for (jx = 0; jx < ntests; jx++)
+        {
+            fmpz_randtest(a + jx, state, bits);
+            fmpz_randtest(res + jx, state, bits);
+            b[jx] = n_randtest(state);
+        }
 
         prof_start();
         for (jx = 0; jx < ntests; jx++)
-            fmpz_add_ui(res, a, b);
+            fmpz_add_ui(res + jx, a + jx, b[jx]);
         prof_stop();
     }
 
+    _fmpz_vec_clear(res, ntests);
+    _fmpz_vec_clear(a, ntests);
+    flint_free(b);
     flint_randclear(state);
-    fmpz_clear(res);
-    fmpz_clear(a);
 }
 
 void
 sample_add_old(void * arg, ulong count)
 {
-    fmpz_t res, a;
-    ulong ix, jx, b;
+    fmpz *res, *a;
+    ulong *b;
+    ulong ix, jx;
     int bits = *((int *) arg);
 
     FLINT_TEST_INIT(state);
 
-    fmpz_init(res);
-    fmpz_init(a);
+    res = _fmpz_vec_init(ntests);
+    a = _fmpz_vec_init(ntests);
+    b = flint_malloc(sizeof(mp_limb_t) * ntests);
    
-    for (ix = 0; ix < 100 * count; ix++)
+    for (ix = 0; ix < 10 * count; ix++)
     {
-        fmpz_randtest(a, state, bits);
-        b = n_randtest(state);
+        for (jx = 0; jx < ntests; jx++)
+        {
+            fmpz_randtest(a + jx, state, bits);
+            fmpz_randtest(res + jx, state, bits);
+            b[jx] = n_randtest(state);
+        }
 
         prof_start();
         for (jx = 0; jx < ntests; jx++)
-            fmpz_add_ui_old(res, a, b);
+            fmpz_add_ui_old(res + jx, a + jx, b[jx]);
         prof_stop();
     }
 
+    _fmpz_vec_clear(res, ntests);
+    _fmpz_vec_clear(a, ntests);
+    flint_free(b);
     flint_randclear(state);
-    fmpz_clear(res);
-    fmpz_clear(a);
 }
 
 void
 sample_sub_new(void * arg, ulong count)
 {
-    fmpz_t res, a;
-    ulong ix, jx, b;
+    fmpz *res, *a;
+    ulong *b;
+    ulong ix, jx;
     int bits = *((int *) arg);
 
     FLINT_TEST_INIT(state);
 
-    fmpz_init(res);
-    fmpz_init(a);
+    res = _fmpz_vec_init(ntests);
+    a = _fmpz_vec_init(ntests);
+    b = flint_malloc(sizeof(mp_limb_t) * ntests);
    
-    for (ix = 0; ix < 100 * count; ix++)
+    for (ix = 0; ix < 10 * count; ix++)
     {
-        fmpz_randtest(a, state, bits);
-        b = n_randtest(state);
+        for (jx = 0; jx < ntests; jx++)
+        {
+            fmpz_randtest(a + jx, state, bits);
+            fmpz_randtest(res + jx, state, bits);
+            b[jx] = n_randtest(state);
+        }
 
         prof_start();
         for (jx = 0; jx < ntests; jx++)
-            fmpz_sub_ui(res, a, b);
+            fmpz_sub_ui(res + jx, a + jx, b[jx]);
         prof_stop();
     }
 
+    _fmpz_vec_clear(res, ntests);
+    _fmpz_vec_clear(a, ntests);
+    flint_free(b);
     flint_randclear(state);
-    fmpz_clear(res);
-    fmpz_clear(a);
 }
 
 void
 sample_sub_old(void * arg, ulong count)
 {
-    fmpz_t res, a;
-    ulong ix, jx, b;
+    fmpz *res, *a;
+    ulong *b;
+    ulong ix, jx;
     int bits = *((int *) arg);
 
     FLINT_TEST_INIT(state);
 
-    fmpz_init(res);
-    fmpz_init(a);
+    res = _fmpz_vec_init(ntests);
+    a = _fmpz_vec_init(ntests);
+    b = flint_malloc(sizeof(mp_limb_t) * ntests);
    
-    for (ix = 0; ix < 100 * count; ix++)
+    for (ix = 0; ix < 10 * count; ix++)
     {
-        fmpz_randtest(a, state, bits);
-        b = n_randtest(state);
+        for (jx = 0; jx < ntests; jx++)
+        {
+            fmpz_randtest(a + jx, state, bits);
+            fmpz_randtest(res + jx, state, bits);
+            b[jx] = n_randtest(state);
+        }
 
         prof_start();
         for (jx = 0; jx < ntests; jx++)
-            fmpz_sub_ui_old(res, a, b);
+            fmpz_sub_ui_old(res + jx, a + jx, b[jx]);
         prof_stop();
     }
 
+    _fmpz_vec_clear(res, ntests);
+    _fmpz_vec_clear(a, ntests);
+    flint_free(b);
     flint_randclear(state);
-    fmpz_clear(res);
-    fmpz_clear(a);
 }
+
+
+slong sizes[] = { 10, 30, 60, 62, 64, 66, 80, 128, 160, 256, 512, 1024, 4096, 0 };
 
 int
 main(void)
 {
     double minnew, maxnew, minold, maxold;
-    int bits;
+    int i, bits;
 
     flint_printf("ADD\n");
-    for (bits = 5; bits <= 150; bits += 5)
+    for (i = 0; (bits = sizes[i]) != 0; i++)
     {
         prof_repeat(&minnew, &maxnew, sample_add_new, &bits);
         prof_repeat(&minold, &maxold, sample_add_old, &bits);
@@ -204,7 +566,7 @@ main(void)
     }
 
     flint_printf("\nSUB\n");
-    for (bits = 5; bits <= 150; bits += 5)
+    for (i = 0; (bits = sizes[i]) != 0; i++)
     {
         prof_repeat(&minnew, &maxnew, sample_sub_new, &bits);
         prof_repeat(&minold, &maxold, sample_sub_old, &bits);

--- a/fmpz/profile/p-crt.c
+++ b/fmpz/profile/p-crt.c
@@ -1,5 +1,5 @@
-#include "flint/fmpz.h"
-#include "flint/profiler.h"
+#include "fmpz.h"
+#include "profiler.h"
 
 void
 _fmpz_crt_combine(fmpz_t r1r2, fmpz_t m1m2, const fmpz_t r1, const fmpz_t m1, const fmpz_t r2, const fmpz_t m2)

--- a/fmpz/profile/p-div_qr.c
+++ b/fmpz/profile/p-div_qr.c
@@ -9,10 +9,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint/flint.h"
-#include "flint/fmpz.h"
-#include "flint/fmpz_vec.h"
-#include "flint/profiler.h"
+#include "flint.h"
+#include "fmpz.h"
+#include "fmpz_vec.h"
+#include "profiler.h"
 
 void sample_ndiv_qr(void * arg, ulong count)
 {

--- a/fmpz/profile/p-fmma.c
+++ b/fmpz/profile/p-fmma.c
@@ -9,9 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint/flint.h"
-#include "flint/fmpz.h"
-#include "flint/profiler.h"
+#include "flint.h"
+#include "fmpz.h"
+#include "profiler.h"
 
 void
 fmpz_fmma_old(fmpz_t f, const fmpz_t a, const fmpz_t b,

--- a/fmpz/profile/p-gcd.c
+++ b/fmpz/profile/p-gcd.c
@@ -11,10 +11,10 @@
 */
 
 #include <gmp.h>
-#include "flint/flint.h"
-#include "flint/ulong_extras.h"
-#include "flint/fmpz.h"
-#include "flint/profiler.h"
+#include "flint.h"
+#include "ulong_extras.h"
+#include "fmpz.h"
+#include "profiler.h"
 
 typedef struct
 {

--- a/fmpz/profile/p-gcd3.c
+++ b/fmpz/profile/p-gcd3.c
@@ -11,8 +11,8 @@
 */
 
 #include <gmp.h>
-#include "flint/fmpz.h"
-#include "flint/profiler.h"
+#include "fmpz.h"
+#include "profiler.h"
 
 typedef struct
 {

--- a/fmpz/profile/p-xgcd.c
+++ b/fmpz/profile/p-xgcd.c
@@ -9,9 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint/flint.h"
-#include "flint/fmpz.h"
-#include "flint/profiler.h"
+#include "flint.h"
+#include "fmpz.h"
+#include "profiler.h"
 
 void sample_xgcd_small(void * arg, ulong count)
 {

--- a/fmpz/submul.c
+++ b/fmpz/submul.c
@@ -14,6 +14,10 @@
 #include "ulong_extras.h"
 #include "fmpz.h"
 
+/* defined in addmul.c */
+void
+_flint_mpz_addmul_large(mpz_ptr z, mpz_srcptr x, mpz_srcptr y, int negate);
+
 void
 fmpz_submul(fmpz_t f, const fmpz_t g, const fmpz_t h)
 {
@@ -38,7 +42,7 @@ fmpz_submul(fmpz_t f, const fmpz_t g, const fmpz_t h)
         else                    /* both g and h are large */
         {
             __mpz_struct * mf = _fmpz_promote_val(f);
-            mpz_submul(mf, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
+            _flint_mpz_addmul_large(mf, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2), 1);
             _fmpz_demote_val(f);    /* cancellation may have occurred */
         }
     }

--- a/fmpz_poly/mul_KS.c
+++ b/fmpz_poly/mul_KS.c
@@ -83,25 +83,12 @@ _fmpz_poly_mul_KS(fmpz * res, const fmpz * poly1, slong len1,
 
     arr3 = (mp_limb_t *) flint_malloc((limbs1 + limbs2) * sizeof(mp_limb_t));
 
-    if (limbs1 == limbs2)
-    {
-       if (limbs1 < 2000)
-          mpn_mul_n(arr3, arr1, arr2, limbs1);
-       else
-          flint_mpn_mul_fft_main(arr3, arr1, limbs1, arr2, limbs2);
-    } else if (limbs1 > limbs2)
-    {
-       if (limbs2 < 1000)
-          mpn_mul(arr3, arr1, limbs1, arr2, limbs2);
-       else
-          flint_mpn_mul_fft_main(arr3, arr1, limbs1, arr2, limbs2);
-    } else
-    {
-       if (limbs1 < 1000)
-          mpn_mul(arr3, arr2, limbs2, arr1, limbs1);
-       else
-          flint_mpn_mul_fft_main(arr3, arr2, limbs2, arr1, limbs1);
-    }
+    if (arr1 == arr2 && limbs1 == limbs2)
+        flint_mpn_sqr(arr3, arr1, limbs1);
+    else if (limbs1 > limbs2)
+        flint_mpn_mul(arr3, arr1, limbs1, arr2, limbs2);
+    else
+        flint_mpn_mul(arr3, arr2, limbs2, arr1, limbs1);
 
     if (sign)
         _fmpz_poly_bit_unpack(res, len1 + len2 - 1, arr3, bits, neg1 ^ neg2);

--- a/fmpz_poly/mullow_KS.c
+++ b/fmpz_poly/mullow_KS.c
@@ -90,25 +90,12 @@ _fmpz_poly_mullow_KS(fmpz * res, const fmpz * poly1, slong len1,
 
     arr3 = (mp_ptr) flint_malloc((limbs1 + limbs2) * sizeof(mp_limb_t));
 
-    if (limbs1 == limbs2)
-    {
-       if (limbs1 < 2000)
-          mpn_mul_n(arr3, arr1, arr2, limbs1);
-       else
-          flint_mpn_mul_fft_main(arr3, arr1, limbs1, arr2, limbs2);
-    } else if (limbs1 > limbs2)
-    {
-       if (limbs2 < 1000)
-          mpn_mul(arr3, arr1, limbs1, arr2, limbs2);
-       else
-          flint_mpn_mul_fft_main(arr3, arr1, limbs1, arr2, limbs2);
-    } else
-    {
-       if (limbs1 < 1000)
-          mpn_mul(arr3, arr2, limbs2, arr1, limbs1);
-       else
-          flint_mpn_mul_fft_main(arr3, arr2, limbs2, arr1, limbs1);
-    }
+    if (arr1 == arr2 && limbs1 == limbs2)
+        flint_mpn_sqr(arr3, arr1, limbs1);
+    else if (limbs1 > limbs2)
+          flint_mpn_mul(arr3, arr1, limbs1, arr2, limbs2);
+    else
+          flint_mpn_mul(arr3, arr2, limbs2, arr1, limbs1);
     
     if (sign)
         _fmpz_poly_bit_unpack(res, n, arr3, bits, neg1 ^ neg2);

--- a/fmpz_poly/sqr_KS.c
+++ b/fmpz_poly/sqr_KS.c
@@ -16,6 +16,7 @@
 #include "fmpz.h"
 #include "fmpz_vec.h"
 #include "fmpz_poly.h"
+#include "mpn_extras.h"
 
 void
 _fmpz_poly_sqr_KS(fmpz *rop, const fmpz *op, slong len)

--- a/fmpz_poly/sqr_KS.c
+++ b/fmpz_poly/sqr_KS.c
@@ -54,7 +54,7 @@ _fmpz_poly_sqr_KS(fmpz *rop, const fmpz *op, slong len)
 
     arr3 = (mp_limb_t *) flint_malloc((2 * limbs) * sizeof(mp_limb_t));
 
-    mpn_sqr(arr3, arr, limbs);
+    flint_mpn_sqr(arr3, arr, limbs);
 
     if (sign)
         _fmpz_poly_bit_unpack(rop, 2 * len - 1, arr3, bits, 0);

--- a/fmpz_poly/sqrlow_KS.c
+++ b/fmpz_poly/sqrlow_KS.c
@@ -16,6 +16,7 @@
 #include "fmpz.h"
 #include "fmpz_vec.h"
 #include "fmpz_poly.h"
+#include "mpn_extras.h"
 
 void _fmpz_poly_sqrlow_KS(fmpz * res, const fmpz * poly, slong len, slong n)
 {

--- a/fmpz_poly/sqrlow_KS.c
+++ b/fmpz_poly/sqrlow_KS.c
@@ -57,7 +57,7 @@ void _fmpz_poly_sqrlow_KS(fmpz * res, const fmpz * poly, slong len, slong n)
 
     _fmpz_poly_bit_pack(arr_in, poly, len, bits, neg);
 
-    mpn_sqr(arr_out, arr_in, limbs);
+    flint_mpn_sqr(arr_out, arr_in, limbs);
 
     if (sign)
         _fmpz_poly_bit_unpack(res, n, arr_out, bits, 0);

--- a/mpn_extras.h
+++ b/mpn_extras.h
@@ -73,7 +73,7 @@
 #define FLINT_FFT_MUL_THRESHOLD 32000
 
 /* Defined in fft.h */
-void flint_mpn_mul_fft_main(mp_ptr r1, mp_srcptr i1, mp_size_t n1,
+FLINT_DLL void flint_mpn_mul_fft_main(mp_ptr r1, mp_srcptr i1, mp_size_t n1,
                         mp_srcptr i2, mp_size_t n2);
 
 MPN_EXTRAS_INLINE mp_limb_t

--- a/mpn_extras.h
+++ b/mpn_extras.h
@@ -47,6 +47,65 @@
 
 #define BITS_TO_LIMBS(b) (((b) + GMP_NUMB_BITS - 1) / GMP_NUMB_BITS)
 
+#define flint_mpn_mul_2x1(r2, r1, r0, a1, a0, b0)           \
+    do {                                                    \
+        mp_limb_t t1;                                       \
+        umul_ppmm(r1, r0, a0, b0);                          \
+        umul_ppmm(r2, t1, a1, b0);                          \
+        add_ssaaaa(r2, r1, r2, r1, 0, t1);                  \
+    } while (0)
+
+#define flint_mpn_mul_2x2(r3, r2, r1, r0, a1, a0, b1, b0)   \
+    do {                                                    \
+        mp_limb_t t1, t2, t3;                               \
+        umul_ppmm(r1, r0, a0, b0);                          \
+        umul_ppmm(r2, t1, a1, b0);                          \
+        add_ssaaaa(r2, r1, r2, r1, 0, t1);                  \
+        umul_ppmm(t1, t2, a0, b1);                          \
+        umul_ppmm(r3, t3, a1, b1);                          \
+        add_ssaaaa(r3, t1, r3, t1, 0, t3);                  \
+        add_ssaaaa(r2, r1, r2, r1, t1, t2);                 \
+        r3 += r2 < t1;                                      \
+    } while (0)
+
+/* FLINT's FFT can beat GMP below this threshold but apparently
+   not consistently. Something needs retuning? */
+#define FLINT_FFT_MUL_THRESHOLD 32000
+
+/* Defined in fft.h */
+void flint_mpn_mul_fft_main(mp_ptr r1, mp_srcptr i1, mp_size_t n1,
+                        mp_srcptr i2, mp_size_t n2);
+
+MPN_EXTRAS_INLINE mp_limb_t
+flint_mpn_mul(mp_ptr z, mp_srcptr x, mp_size_t xn, mp_srcptr y, mp_size_t yn)
+{
+    if (yn < FLINT_FFT_MUL_THRESHOLD)
+        return mpn_mul(z, x, xn, y, yn);
+    else
+    {
+        flint_mpn_mul_fft_main(z, x, xn, y, yn);
+        return z[xn + yn - 1];
+    }
+}
+
+MPN_EXTRAS_INLINE void
+flint_mpn_mul_n(mp_ptr z, mp_srcptr x, mp_srcptr y, mp_size_t n)
+{
+    if (n < FLINT_FFT_MUL_THRESHOLD)
+        mpn_mul_n(z, x, y, n);
+    else
+        flint_mpn_mul_fft_main(z, x, n, y, n);
+}
+
+MPN_EXTRAS_INLINE void
+flint_mpn_sqr(mp_ptr z, mp_srcptr x, mp_size_t n)
+{
+    if (n < FLINT_FFT_MUL_THRESHOLD)
+        mpn_sqr(z, x, n);
+    else
+        flint_mpn_mul_fft_main(z, x, n, x, n);
+}
+
 /*
     return the high limb of a two limb left shift by n < GMP_LIMB_BITS bits.
     Note: if GMP_NAIL_BITS != 0, the rest of flint is already broken anyways.

--- a/nmod_poly/mul_KS.c
+++ b/nmod_poly/mul_KS.c
@@ -15,6 +15,7 @@
 #include "flint.h"
 #include "nmod_vec.h"
 #include "nmod_poly.h"
+#include "mpn_extras.h"
 
 void
 _nmod_poly_mul_KS(mp_ptr out, mp_srcptr in1, slong len1,
@@ -59,9 +60,9 @@ _nmod_poly_mul_KS(mp_ptr out, mp_srcptr in1, slong len1,
         _nmod_poly_bit_pack(mpn2, in2, len2, bits);
 
     if (squaring)
-        mpn_sqr(res, mpn1, limbs1);
+        flint_mpn_sqr(res, mpn1, limbs1);
     else
-        mpn_mul(res, mpn1, limbs1, mpn2, limbs2);
+        flint_mpn_mul(res, mpn1, limbs1, mpn2, limbs2);
 
     _nmod_poly_bit_unpack(out, len_out, res, bits, mod);
 

--- a/nmod_poly/mul_KS2.c
+++ b/nmod_poly/mul_KS2.c
@@ -15,6 +15,7 @@
 #include "flint.h"
 #include "nmod_vec.h"
 #include "nmod_poly.h"
+#include "mpn_extras.h"
 
 /*
    Multiplication/squaring using Kronecker substitution at 2^b and -2^b.
@@ -136,8 +137,8 @@ _nmod_poly_mul_KS2(mp_ptr res, mp_srcptr op1, slong n1,
          compute |h(-B)| = |f1(-B)| * |f2(-B)|
          v3m_neg is set if h(-B) is negative
       */
-      mpn_mul(v3m, v1m, k1, v2m, k2);
-      mpn_mul(v3p, v1p, k1, v2p, k2);
+      flint_mpn_mul(v3m, v1m, k1, v2m, k2);
+      flint_mpn_mul(v3p, v1p, k1, v2p, k2);
    }
    else
    {
@@ -158,8 +159,8 @@ _nmod_poly_mul_KS2(mp_ptr res, mp_srcptr op1, slong n1,
          compute h(-B) = f1(-B)^2
          v3m_neg is cleared (since f1(-B)^2 is never negative)
       */
-      mpn_sqr(v3m, v1m, k1);
-      mpn_sqr(v3p, v1p, k1);
+      flint_mpn_sqr(v3m, v1m, k1);
+      flint_mpn_sqr(v3p, v1p, k1);
       v3m_neg = 0;
    }
    

--- a/nmod_poly/mul_KS4.c
+++ b/nmod_poly/mul_KS4.c
@@ -15,6 +15,7 @@
 #include "flint.h"
 #include "nmod_vec.h"
 #include "nmod_poly.h"
+#include "mpn_extras.h"
 
 /*
    Multiplication/squaring using Kronecker substitution at 2^b, -2^b,
@@ -170,8 +171,8 @@ _nmod_poly_mul_KS4(mp_ptr res, mp_srcptr op1, slong n1,
             and |h(-B)| = |f1(-B)| * |f2(-B)|
          hn_neg is set if h(-B) is negative
       */
-      mpn_mul(v3pn, v1pn, k1, v2pn, k2);
-      mpn_mul(v3mn, v1mn, k1, v2mn, k2);
+      flint_mpn_mul(v3pn, v1pn, k1, v2pn, k2);
+      flint_mpn_mul(v3mn, v1mn, k1, v2mn, k2);
    }
    else
    {
@@ -193,8 +194,8 @@ _nmod_poly_mul_KS4(mp_ptr res, mp_srcptr op1, slong n1,
             and h(-B) = |f1(-B)|^2
          hn_neg is cleared since h(-B) is never negative
       */
-      mpn_sqr(v3pn, v1pn, k1);
-      mpn_sqr(v3mn, v1mn, k1);
+      flint_mpn_sqr(v3pn, v1pn, k1);
+      flint_mpn_sqr(v3mn, v1mn, k1);
       v3m_neg = 0;
    }
 
@@ -270,8 +271,8 @@ _nmod_poly_mul_KS4(mp_ptr res, mp_srcptr op1, slong n1,
                          |B^(n1-1) * f1(-1/B)| * |B^(n2-1) * f2(-1/B)|
          hr_neg is set if h(-1/B) is negative
       */
-      mpn_mul(v3pr, v1pr, k1, v2pr, k2);
-      mpn_mul(v3mr, v1mr, k1, v2mr, k2);
+      flint_mpn_mul(v3pr, v1pr, k1, v2pr, k2);
+      flint_mpn_mul(v3mr, v1mr, k1, v2mr, k2);
    }
    else
    {
@@ -295,8 +296,8 @@ _nmod_poly_mul_KS4(mp_ptr res, mp_srcptr op1, slong n1,
              and B^(n3-1) * h(-1/B) = |B^(n1-1) * f1(-1/B)|^2
          hr_neg is cleared since h(-1/B) is never negative
       */
-      mpn_sqr(v3pr, v1pr, k1);
-      mpn_sqr(v3mr, v1mr, k1);
+      flint_mpn_sqr(v3pr, v1pr, k1);
+      flint_mpn_sqr(v3mr, v1mr, k1);
       v3m_neg = 0;
    }
 

--- a/nmod_poly/mullow_KS.c
+++ b/nmod_poly/mullow_KS.c
@@ -15,6 +15,7 @@
 #include "flint.h"
 #include "nmod_vec.h"
 #include "nmod_poly.h"
+#include "mpn_extras.h"
 
 void
 _nmod_poly_mullow_KS(mp_ptr out, mp_srcptr in1, slong len1,
@@ -61,9 +62,9 @@ _nmod_poly_mullow_KS(mp_ptr out, mp_srcptr in1, slong len1,
         _nmod_poly_bit_pack(mpn2, in2, len2, bits);
 
     if (squaring)
-        mpn_sqr(res, mpn1, limbs1);
+        flint_mpn_sqr(res, mpn1, limbs1);
     else
-        mpn_mul(res, mpn1, limbs1, mpn2, limbs2);
+        flint_mpn_mul(res, mpn1, limbs1, mpn2, limbs2);
 
     _nmod_poly_bit_unpack(out, n, res, bits, mod);
     

--- a/profiler.h
+++ b/profiler.h
@@ -234,6 +234,12 @@ FLINT_DLL void prof_repeat(double* min, double* max, profile_target_t target, vo
         TIMEIT_PRINT(__timer, __reps) \
     } while (0);
 
+#define TIMEIT_STOP_VALUES(tcpu, twall) \
+        TIMEIT_END_REPEAT(__timer, __reps) \
+        (tcpu) = __timer->cpu*0.001 / __reps; \
+        (twall) = __timer->wall*0.001 / __reps; \
+    } while (0);
+
 #define TIMEIT_ONCE_START \
     do \
     { \


### PR DESCRIPTION
This needs more profiling.

fmpz_poly_mul_KS had a cutoff at 1000 limbs for using the FLINT FFT which looks too low. I can't get a consistent speedup over mpn_mul below 32000 limbs on my machine. Perhaps because the FFT is missing assembly optimizations without MPIR? Anyway, this puts the FFT threshold in one obvious place (mpn_extras.h), where we can easily replace the SS-FFT with Dan's FFT when that's available.

I haven't profiled fmpz_mul, fmpz_addmul and fmpz_submul carefully at small sizes. There could be some GMP tricks that I'm missing.
