### PR TITLE
Implement fmpq_mat_can_solve_dixon

### DIFF
--- a/doc/source/fmpq_mat.rst
+++ b/doc/source/fmpq_mat.rst
@@ -477,6 +477,19 @@ Nonsingular solving
     solution. The matrices can have any shape but must have the same number of
     rows.
 
+int fmpq_mat_can_solve_fmpz_mat_dixon(fmpq_mat_t X, const fmpz_mat_t A, const fmpz_mat_t B)
+
+    Returns `1` if ``AX = B`` has a solution and if so, sets ``X`` to one such
+    solution. The matrices can have any shape but must have the same number of
+    rows. The input matrices must have integer entries and `A` cannot be an
+    empty matrix.
+
+int fmpq_mat_can_solve_dixon(fmpq_mat_t X, const fmpq_mat_t A, const fmpq_mat_t B)
+
+    Returns `1` if ``AX = B`` has a solution and if so, sets ``X`` to one such
+    solution. The matrices can have any shape but must have the same number of
+    rows.
+
 .. function:: int fmpq_mat_can_solve(fmpq_mat_t X, const fmpq_mat_t A, const fmpq_mat_t B)
 
     Returns `1` if ``AX = B`` has a solution and if so, sets ``X`` to one such

--- a/fmpq_mat.h
+++ b/fmpq_mat.h
@@ -344,6 +344,12 @@ FLINT_DLL int fmpq_mat_can_solve_multi_mod(fmpq_mat_t X,
 FLINT_DLL int fmpq_mat_can_solve_fraction_free(fmpq_mat_t X,
                                         const fmpq_mat_t A, const fmpq_mat_t B);
 
+FLINT_DLL int fmpq_mat_can_solve_fmpz_mat_dixon(fmpq_mat_t X,
+                                        const fmpz_mat_t A, const fmpz_mat_t B);
+
+FLINT_DLL int fmpq_mat_can_solve_dixon(fmpq_mat_t X,
+                                        const fmpq_mat_t A, const fmpq_mat_t B);
+
 FLINT_DLL int fmpq_mat_solve_fmpz_mat(fmpq_mat_t X, const fmpz_mat_t A, const fmpz_mat_t B);
 FLINT_DLL int fmpq_mat_solve(fmpq_mat_t X, const fmpq_mat_t A, const fmpq_mat_t B);
 

--- a/fmpq_mat/can_solve_dixon.c
+++ b/fmpq_mat/can_solve_dixon.c
@@ -1,0 +1,159 @@
+/*
+    Copyright (C) 2022 William Hart
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpq_mat.h"
+
+/* Algorithm developed with Claus Fieker */
+
+int
+_fmpq_mat_check_solution_fmpz_mat(const fmpq_mat_t X, const fmpz_mat_t A, const fmpz_mat_t B);
+
+int
+fmpq_mat_can_solve_fmpz_mat_dixon(fmpq_mat_t X,
+                        const fmpz_mat_t A, const fmpz_mat_t B)
+{
+    mp_limb_t p;
+    fmpz_t tested;
+    nmod_mat_t Ap, LU;
+    int result = 0, success = 0;
+    slong * perm, * pivots;
+    slong i, j, k, col, rank;
+    fmpz_mat_t Arank, Brank;
+    fmpq_mat_t Xrank;
+    fmpz_t det_bound;
+
+    p = UWORD(1) << NMOD_MAT_OPTIMAL_MODULUS_BITS;
+    fmpz_init(det_bound);
+    fmpz_init(tested);
+    fmpz_one(tested);
+    nmod_mat_init(Ap, A->r, A->c, p);
+    nmod_mat_init(LU, A->r, A->c, p);
+    perm = flint_malloc(sizeof(slong)*A->r);
+    pivots = flint_malloc(sizeof(slong)*A->c); /* only first rank entries are meaningful */
+
+    fmpz_mat_det_bound(det_bound, A);
+
+    while (1)
+    {
+        p = n_nextprime(p, 0);
+        _nmod_mat_set_mod(Ap, p);
+        _nmod_mat_set_mod(LU, p);
+
+        fmpz_mat_get_nmod_mat(Ap, A);
+
+        nmod_mat_set(LU, Ap);
+
+        for (i = 0; i < A->r; i++)
+            perm[i] = i;
+
+        rank = nmod_mat_lu(perm, LU, 0);
+
+        col = 0;
+        for (i = 0; i < rank; i++)
+        {
+           while (nmod_mat_entry(LU, i, col) == 0)
+              col++;
+
+           pivots[i] = col;
+
+           col++;
+        }
+
+        fmpz_mat_init(Arank, rank, rank);
+        fmpz_mat_init(Brank, rank, B->c);
+        fmpq_mat_init(Xrank, rank, B->c);
+
+        for (i = 0; i < rank; i++)
+        {
+            k = 0;
+            for (j = 0; j < A->c; j++)
+            {
+                if (k < rank && j == pivots[k])
+                {
+                    fmpz_set(fmpz_mat_entry(Arank, i, k), fmpz_mat_entry(A, perm[i], j));
+                    k++;
+                }
+            }
+
+            for (j = 0; j < B->c; j++)
+                fmpz_set(fmpz_mat_entry(Brank, i, j), fmpz_mat_entry(B, perm[i], j));
+        }
+
+        success = fmpq_mat_solve_fmpz_mat_dixon(Xrank, Arank, Brank);
+
+        if (success)
+        {
+            fmpq_mat_zero(X); 
+
+            for (i = 0; i < rank; i++)
+            {
+                for (j = 0; j < B->c; j++)
+                    fmpq_set(fmpq_mat_entry(X, pivots[i], j), fmpq_mat_entry(Xrank, i, j));
+            }
+
+            result = _fmpq_mat_check_solution_fmpz_mat(X, A, B);
+        }
+ 
+        fmpz_mat_clear(Arank);
+        fmpz_mat_clear(Brank);
+        fmpq_mat_clear(Xrank);
+
+        if (result)
+            break;
+
+        fmpz_mul_ui(tested, tested, p);
+        if (fmpz_cmp(tested, det_bound) > 0)
+            break;
+    }
+
+    fmpz_clear(det_bound);
+    nmod_mat_clear(Ap);
+    nmod_mat_clear(LU);
+    fmpz_clear(tested);
+    flint_free(perm);
+    flint_free(pivots);
+
+    return result;
+}
+
+int
+fmpq_mat_can_solve_dixon(fmpq_mat_t X, const fmpq_mat_t A, const fmpq_mat_t B)
+{
+    fmpz_mat_t Anum;
+    fmpz_mat_t Bnum;
+    int success;
+
+    if (A->r == 0 || B->c == 0)
+    {
+        fmpq_mat_zero(X);
+
+        return 1;
+    }
+
+    if (A->c == 0)
+    {
+        fmpq_mat_zero(X);
+
+        return fmpq_mat_is_zero(B);
+    }
+
+    fmpz_mat_init(Anum, A->r, A->c);
+    fmpz_mat_init(Bnum, B->r, B->c);
+
+    fmpq_mat_get_fmpz_mat_rowwise_2(Anum, Bnum, NULL, A, B);
+    success = fmpq_mat_can_solve_fmpz_mat_dixon(X, Anum, Bnum);
+
+    fmpz_mat_clear(Anum);
+    fmpz_mat_clear(Bnum);
+
+    return success;
+}
+

--- a/fmpq_mat/solve_multi_mod.c
+++ b/fmpq_mat/solve_multi_mod.c
@@ -28,7 +28,7 @@ _fmpq_mat_check_solution_fmpz_mat(const fmpq_mat_t X, const fmpz_mat_t A, const 
 
     Xden = _fmpz_vec_init(X->c);
     fmpz_mat_init(Xclear, X->r, X->c);
-    fmpz_mat_init(AXclear, X->r, X->c);
+    fmpz_mat_init(AXclear, B->r, B->c);
     fmpz_init(t);
 
     fmpq_mat_get_fmpz_mat_colwise(Xclear, Xden, X);

--- a/fmpq_mat/test/t-can_solve_dixon.c
+++ b/fmpq_mat/test/t-can_solve_dixon.c
@@ -1,0 +1,158 @@
+/*
+    Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2022 William Hart
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <gmp.h>
+#include "flint.h"
+#include "fmpq.h"
+#include "fmpq_mat.h"
+
+int
+main(void)
+{
+    int i;
+    FLINT_TEST_INIT(state);
+    
+
+    flint_printf("can_solve_dixon....");
+    fflush(stdout);
+
+    /* Solve random systems */
+    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    {
+        fmpq_mat_t A, B, X, AX;
+        fmpz_mat_t M;
+        fmpz_t den;
+        int success;
+        slong n, m, k, bits;
+
+        n = n_randint(state, 10);
+        m = n_randint(state, 10);
+        k = n_randint(state, 10);
+
+        bits = 1 + n_randint(state, 100);
+
+        fmpz_init(den);
+
+        fmpq_mat_init(A, n, k);
+        fmpq_mat_init(B, n, m);
+        fmpq_mat_init(X, k, m);
+        fmpq_mat_init(AX, n, m);
+
+        fmpz_mat_init(M, n, k);
+
+        fmpz_mat_randrank(M, state, n_randint(state, FLINT_MIN(n, k) + 1), bits);
+        if (i % 2)
+            fmpz_mat_randops(M, state, n_randint(state, 2*n*k + 1));
+        fmpz_randtest_not_zero(den, state, bits);
+        fmpq_mat_init(A, n, k);
+        fmpq_mat_set_fmpz_mat_div_fmpz(A, M, den);
+        
+        fmpq_mat_randtest(B, state, bits);
+
+        success = fmpq_mat_can_solve_dixon(X, A, B);
+        fmpq_mat_mul(AX, A, X);
+
+        if (success && !fmpq_mat_equal(AX, B))
+        {
+            flint_printf("FAIL!\n");
+            flint_printf("success: %d\n", success);
+            flint_printf("A:\n");
+            fmpq_mat_print(A);
+            flint_printf("B:\n");
+            fmpq_mat_print(B);
+            flint_printf("X:\n");
+            fmpq_mat_print(X);
+            flint_printf("AX:\n");
+            fmpq_mat_print(AX);
+            fflush(stdout);
+            flint_abort();
+        }
+
+        fmpz_clear(den);
+        
+        fmpz_mat_clear(M);
+        fmpq_mat_clear(A);
+        fmpq_mat_clear(B);
+        fmpq_mat_clear(X);
+        fmpq_mat_clear(AX);
+    }
+
+    /* Solve random soluble systems */
+    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    {
+        fmpq_mat_t A, B, X, AX;
+        fmpz_mat_t M;
+        fmpz_t den;
+        int success;
+        slong n, m, k, bits;
+
+        n = n_randint(state, 10);
+        m = n_randint(state, 10);
+        k = n_randint(state, 10);
+
+        bits = 1 + n_randint(state, 300);
+
+        fmpz_init(den);
+
+        fmpq_mat_init(A, n, k);
+        fmpq_mat_init(B, n, m);
+        fmpq_mat_init(X, k, m);
+        fmpq_mat_init(AX, n, m);
+
+        fmpz_mat_init(M, n, k);
+
+        fmpz_mat_randrank(M, state, n_randint(state, FLINT_MIN(n, k) + 1), bits);
+        if (i % 2)
+            fmpz_mat_randops(M, state, n_randint(state, 2*m*n + 1));
+        fmpz_randtest_not_zero(den, state, bits);
+        fmpq_mat_init(A, n, k);
+        fmpq_mat_set_fmpz_mat_div_fmpz(A, M, den);
+        
+        fmpq_mat_randtest(X, state, bits);
+
+        fmpq_mat_mul(B, A, X);
+
+        success = fmpq_mat_can_solve_dixon(X, A, B);
+        fmpq_mat_mul(AX, A, X);
+
+        if (!success || !fmpq_mat_equal(AX, B))
+        {
+            flint_printf("FAIL!\n");
+            flint_printf("success: %d\n", success);
+            flint_printf("A:\n");
+            fmpq_mat_print(A);
+            flint_printf("B:\n");
+            fmpq_mat_print(B);
+            flint_printf("X:\n");
+            fmpq_mat_print(X);
+            flint_printf("AX:\n");
+            fmpq_mat_print(AX);
+            fflush(stdout);
+            flint_abort();
+        }
+
+        fmpz_clear(den);
+        
+        fmpz_mat_clear(M);
+        fmpq_mat_clear(A);
+        fmpq_mat_clear(B);
+        fmpq_mat_clear(X);
+        fmpq_mat_clear(AX);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+    
+    flint_printf("PASS\n");
+    return 0;
+}


### PR DESCRIPTION
@fredrik-johansson @tthsqe12

This implements can_solve using Dixon lifting to solve AX = B. The algorithm is as follows:

* Find Ap = A mod p for a prime p
* use LU to find the pivot columns of Ap, the rank of Ap and "rank" linearly independent rows of Ap (stored in perm)
* Construct a rank x rank matrix Arank from the entries of A found above giving a nonsingular matrix
* Construct a matrix Brank from B with the rank rows found above
* Solve Arank X = Brank using Dixon lifting
* Expand X back out to the full number of rows (note we can put zeros in rows that correspond to non-pivot columns of A)
* It may be that the prime p was bad or that the system is inconsistent in which case when we multiply things out we will not get a solution
* To tell if the prime was bad we try solving for different reductions mod different primes p. We do this up to a bound given by the determinant of A.

For the final point: A is not square, but we can throw away the linearly dependent rows of A and notionally add rows that have a 1 in a non-pivot column of A to make the matrix square (and nonsingular). The determinant of such a matrix gives a bound on the bad primes.

It's easy to see that our det_bound function when applied to A without such added rows gives an upper bound on the determinant of such a matrix. (Rows with a 1 in them do not contribute to the determinant bound as their norm is 1.)

Note that we did not rely on p not being bad when computing this bound. If we did not find a solution for enough primes p to exceed the bound, no solution exists.