### PR TITLE
Fix mistakes in the documentation

### DIFF
--- a/doc/source/building.rst
+++ b/doc/source/building.rst
@@ -114,7 +114,7 @@ tree simply type:
 
 GNU make or CMake is required to build FLINT. For GNU make, this is simply
 ``make`` on Linux, Darwin, MinGW and Cygwin systems. However, on some unixes
-the command is ``gmake``. For CMake, this is ``cmake``, which which may need
+the command is ``gmake``. For CMake, this is ``cmake``, which may need
 to be installed with your package manager.
 
 If you wish to install FLINT with GNU make, simply type:
@@ -172,7 +172,7 @@ The FLINT custom make system responds to the standard commands
     make distclean
     make install
 
-If your system supports parallel builds, FLINT will build in parallel, e.g:
+If your system supports parallel builds, FLINT will build in parallel, e.g.:
 
 .. code-block:: bash
 
@@ -185,7 +185,7 @@ Testing a single module or file
 
 If you wish to simply check a single module of FLINT you can pass the option
 ``MOD=modname`` to ``make check``. You can also pass a list of module names in
-inverted commas, e.g:
+inverted commas, e.g.:
 
 .. code-block:: bash
 
@@ -235,7 +235,7 @@ Visual Studio 2015 Community (or higher version) and:
 - an installed version of Python Tools for Visual Studio
   <https://github.com/Microsoft/PTVS>
 
-Obtain FLINT2 by cloning it using GIT from Brian Gladman's repository:
+Obtain FLINT2 by cloning it using Git from Brian Gladman's repository:
 
   ``git@github.com:BrianGladman/flint.git``
 

--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -41,7 +41,7 @@ The current example programs are:
   ``build/examples/stirling_matrix 10`` does this with 10 by 10 matrices.
 
 - ``fmpz_poly_factor_zassenhaus`` Demonstrates the factorisation of a small
-  polynomial. A larger polynomials is also provided on disk and a small
+  polynomial. A larger polynomial is also provided on disk and a small
   (obvious) change to the example program will read this file instead of
   using the hard coded polynomial.
 

--- a/doc/source/fmpz.rst
+++ b/doc/source/fmpz.rst
@@ -8,7 +8,7 @@ Types, macros and constants
 
 .. type:: fmpz
 
-   an ``fmpz`` is implemented as an `slong`. When its second most significant
+   an ``fmpz`` is implemented as an ``slong``. When its second most significant
    bit is `0` the ``fmpz`` represents an ordinary ``slong`` integer whose
    absolute value is at most ``FLINT_BITS - 2`` bits.
 
@@ -20,7 +20,7 @@ Types, macros and constants
 .. type:: fmpz_t
 
    An array of length 1 of ``fmpz``'s. This is used to pass ``fmpz``'s around by
-   reference without fuss, similar to the way ``mpz_t`` work.
+   reference without fuss, similar to the way ``mpz_t`` works.
 
 .. macro:: COEFF_MAX
  
@@ -96,7 +96,7 @@ Memory management
 
 .. function:: void fmpz_init(fmpz_t f)
 
-    A small ``fmpz_t`` is initialised, i.e.\ just a ``slong``.  
+    A small ``fmpz_t`` is initialised, i.e. just a ``slong``.  
     The value is set to zero.
 
 .. function:: void fmpz_init2(fmpz_t f, ulong limbs)
@@ -105,7 +105,7 @@ Memory management
     number of limbs.
 
     If ``limbs`` is zero then a small ``fmpz_t`` is allocated, 
-    i.e.\ just a ``slong``.  The value is also set to zero.  It is 
+    i.e. just a ``slong``.  The value is also set to zero.  It is 
     not necessary to call this function except to save time.  A call 
     to ``fmpz_init`` will do just fine.
 
@@ -237,7 +237,7 @@ Conversion
 .. function:: double fmpz_get_d_2exp(slong * exp, const fmpz_t f)
 
     Returns `f` as a normalized ``double`` along with a `2`-exponent 
-    ``exp``, i.e.\ if `r` is the return value then `f = r 2^{exp}`, 
+    ``exp``, i.e. if `r` is the return value then `f = r 2^{exp}`, 
     to within 1 ULP.
 
 .. function:: void fmpz_get_mpz(mpz_t x, const fmpz_t f)
@@ -316,7 +316,7 @@ Conversion
     as a signed two's complement integer with ``n * FLINT_BITS`` bits.
     It is assumed that ``n > 0``. The function operates as a call to
     :func:`fmpz_set_ui_array` followed by a symmetric remainder modulo
-    `2^(n*FLINT\_BITS)`.
+    `2^{n\cdot FLINT\_BITS}`.
 
 .. function:: void fmpz_get_ui_array(ulong * out, slong n, const fmpz_t in)
 
@@ -465,7 +465,7 @@ Input and output
     
 .. function:: int fmpz_print(fmpz_t x)
 
-    Prints the value `x` to ``stdout``, without a carriage return(CR).
+    Prints the value `x` to ``stdout``, without a carriage return (CR).
     The value is printed as either `0`, the decimal digits of a 
     positive integer, or a minus sign followed by the digits of 
     a negative integer.
@@ -479,7 +479,7 @@ Input and output
 
 .. function:: int fmpz_fprint(FILE * file, fmpz_t x)
 
-    Prints the value `x` to ``file``, without a carriage return(CR).
+    Prints the value `x` to ``file``, without a carriage return (CR).
     The value is printed as either `0`, the decimal digits of a 
     positive integer, or a minus sign followed by the digits of 
     a negative integer.
@@ -505,7 +505,7 @@ Input and output
     In case of failure, return 0.
 
     The output of this can also be read by ``mpz_inp_raw`` from GMP >= 2, 
-    Since this function calls the ``mpz_inp_raw`` function in library gmp.
+    since this function calls the ``mpz_inp_raw`` function in library gmp.
 
 
 
@@ -772,13 +772,13 @@ Basic arithmetic
 .. function:: void fmpz_divexact_ui(fmpz_t f, const fmpz_t g, ulong h)
 
     Sets `f` to the quotient of `g` and `h`, assuming that the
-    division is exact, i.e.\ `g` is a multiple of `h`.  If `h` 
+    division is exact, i.e. `g` is a multiple of `h`.  If `h` 
     is `0` an exception is raised.
 
 .. function:: void fmpz_divexact2_uiui(fmpz_t f, const fmpz_t g, ulong x, ulong y)
 
     Sets `f` to the quotient of `g` and `h = x \times y`, assuming that
-    the division is exact, i.e.\ `g` is a multiple of `h`.
+    the division is exact, i.e. `g` is a multiple of `h`.
     If `x` or `y` is `0` an exception is raised.
 
 .. function:: int fmpz_divisible(const fmpz_t f, const fmpz_t g)
@@ -937,12 +937,12 @@ Basic arithmetic
 
 .. function:: void fmpz_mul_tdiv_q_2exp(fmpz_t f, const fmpz_t g, const fmpz_t h, ulong exp)
 
-    Sets `f` to the product `g` and `h` divided by ``2^exp``, rounding
+    Sets `f` to the product of `g` and `h` divided by ``2^exp``, rounding
     down towards zero.
 
 .. function:: void fmpz_mul_si_tdiv_q_2exp(fmpz_t f, const fmpz_t g, slong x, ulong exp)
 
-    Sets `f` to the product `g` and `x` divided by ``2^exp``, rounding
+    Sets `f` to the product of `g` and `x` divided by ``2^exp``, rounding
     down towards zero.
 
 
@@ -1088,7 +1088,7 @@ Modular arithmetic
 
 .. function:: void fmpz_divides_mod_list(fmpz_t xstart, fmpz_t xstride, fmpz_t xlength, const fmpz_t a, const fmpz_t b, const fmpz_t n)
 
-    Set `xstart`, `xstride`, and `xlength` so that the solution set for x modulo `n` in `a x = b mod n` is exactly `\{xstart + xstride i | 0 \le i < xlength\}`.
+    Set `xstart`, `xstride`, and `xlength` so that the solution set for `x` modulo `n` in `a x = b \bmod n` is exactly `\{xstart + xstride\,i \mid 0 \le i < xlength\}`.
     This function essentially gives a list of possibilities for the fraction `a/b` modulo `n`.
     The outputs may not be aliased, and `n` should be positive.
 
@@ -1196,7 +1196,7 @@ The ``fmpz_multi_crt`` class is similar to ``fmpz_multi_CRT_ui`` except that it 
     Uses the Chinese Remainder Theorem to compute the unique integer
     `0 \le x < M` (if sign = 0) or `-M/2 < x \le M/2` (if sign = 1)
     congruent to `r_1` modulo `m_1` and `r_2` modulo `m_2`,
-    where where `M = m_1 \times m_2`. The result `x` is stored in ``out``.
+    where `M = m_1 \times m_2`. The result `x` is stored in ``out``.
 
     It is assumed that `m_1` and `m_2` are positive integers greater
     than `1` and coprime.
@@ -1209,7 +1209,7 @@ The ``fmpz_multi_crt`` class is similar to ``fmpz_multi_CRT_ui`` except that it 
     Use the Chinese Remainder Theorem to set ``out`` to the unique value
     `0 \le x < M` (if sign = 0) or `-M/2 < x \le M/2` (if sign = 1)
     congruent to `r_1` modulo `m_1` and `r_2` modulo `m_2`,
-    where where `M = m_1 \times m_2`.
+    where `M = m_1 \times m_2`.
 
     It is assumed that `m_1` and `m_2` are positive integers greater
     than `1` and coprime.
@@ -1384,7 +1384,7 @@ Primality testing
     or it returns `1` if all factors of `n` are `1 \pmod{F}`. Also in
     that case, `R` is set to `(n - 1)/F`.
 
-    N.B: a return value of `1` only proves `n` prime if `F \ge \sqrt{n}`.
+    NB: a return value of `1` only proves `n` prime if `F \ge \sqrt{n}`.
 
     The function does not compute which primes divide `n - 1`. Instead,
     these must be supplied as an array ``pm1`` of length ``num_pm1``.
@@ -1421,7 +1421,7 @@ Primality testing
     or it returns `1` if all factors of `n` are `\pm 1 \pmod{F}`. Also in
     that case, `R` is set to `(n + 1)/F`.
 
-    N.B: a return value of `1` only proves `n` prime if 
+    NB: a return value of `1` only proves `n` prime if 
     `F > \sqrt{n} + 1`.
 
     The function does not compute which primes divide `n + 1`. Instead,
@@ -1538,7 +1538,7 @@ Primality testing
     If ``proved`` is nonzero, then the integer returned is
     guaranteed to actually be prime. Otherwise if `n` fits in
     ``FLINT_BITS - 3`` bits ``n_nextprime`` is called, and if not then
-    the GMP ``mpz_nextprime`` function is called. Up to an including
+    the GMP ``mpz_nextprime`` function is called. Up to and including
     GMP 6.1.2 this used Miller-Rabin iterations, and thereafter uses
     a BPSW test.
     

--- a/doc/source/fmpz_factor.rst
+++ b/doc/source/fmpz_factor.rst
@@ -153,7 +153,7 @@ A separate ``int`` field holds the sign, which may be `-1`, `0` or `1`.
 
     Pollard Rho algorithm for integer factorization. Assumes that the `n` is
     not prime. ``factor`` is set as the factor if found. Takes as input the initial
-    value `y`, to start polynomial evaluation and `a`, the constant of the polynomial
+    value `y`, to start polynomial evaluation, and `a`, the constant of the polynomial
     used. It is not assured that the factor found will be prime. Does not compute 
     the complete factorization, just one factor. Returns the number of limbs of 
     factor if factorization is successful (non trivial factor is found), else returns 0. 

--- a/doc/source/fmpz_mat.rst
+++ b/doc/source/fmpz_mat.rst
@@ -178,9 +178,9 @@ Random matrix generation
     Sets a square matrix ``mat`` to a random *ajtai* matrix. 
     The diagonal entries `(i, i)` are set to a random entry in the range 
     `[1, 2^{b-1}]` inclusive where `b = \lfloor(2 r - i)^\alpha\rfloor` for some 
-    double parameter~`\alpha`. The entries below the diagonal in column~`i` 
+    double parameter `\alpha`. The entries below the diagonal in column `i` 
     are set to a random entry in the range `(-2^b + 1, 2^b - 1)` whilst the 
-    entries to the right of the diagonal in row~`i` are set to zero. 
+    entries to the right of the diagonal in row `i` are set to zero. 
 
 .. function:: int fmpz_mat_randpermdiag(fmpz_mat_t mat, flint_rand_t state, const fmpz * diag, slong n)
 
@@ -237,7 +237,7 @@ Input and output
 .. function:: int fmpz_mat_fprint_pretty(FILE * file, const fmpz_mat_t mat)
 
     Prints the given matrix to the stream ``file``.  The format is an 
-    opening square bracket then on each line a row of the matrix, followed 
+    opening square bracket, then on each line a row of the matrix, followed 
     by a closing square bracket. Each row is written as an opening square 
     bracket followed by a space separated list of coefficients followed 
     by a closing square bracket.
@@ -337,14 +337,14 @@ Concatenate
 .. function:: void fmpz_mat_concat_vertical(fmpz_mat_t res, const fmpz_mat_t mat1, const fmpz_mat_t mat2)
 
     Sets ``res`` to vertical concatenation of (``mat1``, ``mat2``)
-    in that order. Matrix dimensions : ``mat1`` : `m \times n`,
-    ``mat2`` : `k \times n`, ``res`` : `(m + k) \times n`.
+    in that order. Matrix dimensions: ``mat1``: `m \times n`,
+    ``mat2``: `k \times n`, ``res``: `(m + k) \times n`.
 
 .. function:: void fmpz_mat_concat_horizontal(fmpz_mat_t res, const fmpz_mat_t mat1, const fmpz_mat_t mat2)
 
     Sets ``res`` to horizontal concatenation of (``mat1``, ``mat2``)
-    in that order. Matrix dimensions : ``mat1`` : `m \times n`,
-    ``mat2`` : `m \times k`, ``res``  : `m \times (n + k)`.
+    in that order. Matrix dimensions: ``mat1``: `m \times n`,
+    ``mat2``: `m \times k`, ``res``: `m \times (n + k)`.
 
 
 Modular reduction and reconstruction
@@ -386,7 +386,7 @@ Modular reduction and reconstruction
 
     This function is provided for convenience purposes.
     For reducing or reconstructing multiple integer matrices over the same
-    set of moduli, it is faster to use\\ ``fmpz_mat_multi_mod_precomp``.
+    set of moduli, it is faster to use ``fmpz_mat_multi_mod_precomp``.
 
 .. function:: void fmpz_mat_multi_CRT_ui_precomp(fmpz_mat_t mat, nmod_mat_t * const residues, slong nres, fmpz_comb_t comb, fmpz_comb_temp_t temp, int sign)
 
@@ -555,9 +555,9 @@ Matrix multiplication
 
     Sets ``B`` to the square of the matrix ``A``, which must be
     a square matrix. Aliasing is allowed.
-    The bodrato algorithm is described in [Bodrato2010]_.
+    The Bodrato algorithm is described in [Bodrato2010]_.
     It is highly efficient for squaring matrices which satisfy both the 
-    following conditions  : (a) large elements  (b) dimensions less than 150.
+    following conditions: (a) large elements,  (b) dimensions less than 150.
 
 
 .. function:: void fmpz_mat_pow(fmpz_mat_t B, const fmpz_mat_t A, ulong e)
@@ -570,27 +570,27 @@ Matrix multiplication
 
     This internal function sets `C` to the matrix product `C = A B` computed
     using classical matrix algorithm assuming that all entries of `A` and `B`
-    are small, that is, have bits ` \le FLINT\_BITS - 2`. No aliasing is allowed.
+    are small, that is, have bits `\le FLINT\_BITS - 2`. No aliasing is allowed.
 
 .. function:: void _fmpz_mat_mul_double_word(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B)
 
     This function is only for internal use and assumes that either:
-        - the entries of `A` and `B` are all nonnegative and strictly less than `2^{2*FLINT_BITS}`, or
-        - the entries of `A` and `B` are all strictly less than `2^{2*FLINT_BITS - 1}` in absolute value.
+        - the entries of `A` and `B` are all nonnegative and strictly less than `2^{2*FLINT\_BITS}`, or
+        - the entries of `A` and `B` are all strictly less than `2^{2*FLINT\_BITS - 1}` in absolute value.
 
 .. function:: void fmpz_mat_mul_fmpz_vec(fmpz * c, const fmpz_mat_t A, const fmpz * b, slong blen)
               void fmpz_mat_mul_fmpz_vec_ptr(fmpz * const * c, const fmpz_mat_t A, const fmpz * const * b, slong blen)
 
     Compute a matrix-vector product of ``A`` and ``(b, blen)`` and store the result in ``c``.
     The vector ``(b, blen)`` is either truncated or zero-extended to the number of columns of ``A``.
-    The number entries written to ``c`` is always equal to the number of rows of ``A``.
+    The number of entries written to ``c`` is always equal to the number of rows of ``A``.
 
 .. function:: void fmpz_mat_fmpz_vec_mul(fmpz * c, const fmpz * a, slong alen, const fmpz_mat_t B)
               void fmpz_mat_fmpz_vec_mul_ptr(fmpz * const * c, const fmpz * const * a, slong alen, const fmpz_mat_t B)
 
-    Compute a vector-matrix product of ``(a, alen)`` and ``B`` and and store the result in ``c``.
+    Compute a vector-matrix product of ``(a, alen)`` and ``B`` and store the result in ``c``.
     The vector ``(a, alen)`` is either truncated or zero-extended to the number of rows of ``B``.
-    The number entries written to ``c`` is always equal to the number of columns of ``B``.
+    The number of entries written to ``c`` is always equal to the number of columns of ``B``.
 
 
 Inverse
@@ -718,7 +718,8 @@ Determinant
     `|\det(A)| \le \prod \|a_i\|_2` where the product is taken
     over the rows `a_i` of `A`.
 
-void fmpz_mat_det_bound_nonzero(fmpz_t bound, const fmpz_mat_t A)
+.. function:: void fmpz_mat_det_bound_nonzero(fmpz_t bound, const fmpz_mat_t A)
+
     As per ``fmpz_mat_det_bound()`` but excludes zero columns. For use with
     non-square matrices.
 
@@ -799,7 +800,7 @@ Minimal polynomial
 .. function:: void fmpz_mat_minpoly_modular(fmpz_poly_t cp, const fmpz_mat_t mat)
 
     Computes the minimal polynomial of an `n \times n` square matrix.
-    Uses a modular method based on an average time `O~(n^3)`, worst case
+    Uses a modular method based on an average time `O(n^3)`, worst case
     `O(n^4)` method over `\mathbb{Z}/n\mathbb{Z}`.
 
 .. function:: slong _fmpz_mat_minpoly(fmpz * cp, const fmpz_mat_t mat)
@@ -997,7 +998,7 @@ Row reduction
     ``stop_row`` (exclusive) such that column `c` in ``mat`` has
     a nonzero entry on row `r`, or returns -1 if no such entry exists.
 
-    This implementation simply chooses the first nonzero entry from
+    This implementation simply chooses the first nonzero entry
     it encounters. This is likely to be a nearly optimal choice if all
     entries in the matrix have roughly the same size, but can lead to
     unnecessary coefficient growth if the entries vary in size.
@@ -1125,7 +1126,7 @@ Nullspace
     In general, the entries in `B` will not be minimal: in particular,
     the pivot entries in `B` will generally differ from unity.
     `B` must be allocated with sufficient space to represent the result
-    (at most `n \times n` where `n` is the number of column of `A`).
+    (at most `n \times n` where `n` is the number of columns of `A`).
 
 
 
@@ -1384,7 +1385,7 @@ Classical LLL
 .. function:: void fmpz_mat_lll_original(fmpz_mat_t A, const fmpq_t delta, const fmpq_t eta)
 
     Takes a basis `x_1, x_2, \ldots, x_m` of the lattice `L \subset R^n` (as
-    the rows of a `m \times n` matrix ``A``). The output is an (``delta``,
+    the rows of a `m \times n` matrix ``A``). The output is a (``delta``,
     ``eta``)-reduced basis `y_1, y_2, \ldots, y_m` of the lattice `L` (as
     the rows of the same `m \times n` matrix ``A``).
 

--- a/doc/source/fmpz_vec.rst
+++ b/doc/source/fmpz_vec.rst
@@ -72,7 +72,7 @@ Bit sizes and norms
 .. function:: slong _fmpz_vec_height_index(const fmpz * vec, slong len)
 
     Returns the index of an entry of maximum absolute value in the vector.
-    The the length must be at least 1.
+    The length must be at least 1.
 
 
 Input and output
@@ -424,4 +424,4 @@ Dot product
 .. function:: void _fmpz_vec_dot_ptr(fmpz_t res, const fmpz * vec1, fmpz ** const vec2, slong offset, slong len)
 
     Sets ``res`` to the dot product of ``len`` values at ``vec1`` and the
-    ``len`` values ``vec2[i] + offset`` for ``0 \leq i < len``.
+    ``len`` values ``vec2[i] + offset`` for `0 \leq i < len`.

--- a/doc/source/introduction.rst
+++ b/doc/source/introduction.rst
@@ -15,7 +15,7 @@ integers, rationals, `p`-adics, finite fields, etc., and linear algebra and
 univariate and multivariate polynomials over most of these rings.
 
 FLINT also has some multithreading capabilities. To this end, the library is
-threadsafe, with few exceptions noted in the appropriate place and a number of
+threadsafe, with few exceptions noted in the appropriate place, and a number of
 key functions have multithreaded implementations.
 
 Maintainers and Authors

--- a/doc/source/memory.rst
+++ b/doc/source/memory.rst
@@ -54,7 +54,7 @@ allocate two different arrays.
        mp_ptr a, b;
        TMP_INIT;
     
-       /* arbitrary code*/
+       /* arbitrary code */
     
        TMP_START; /* we are about to do some allocation */
     

--- a/doc/source/mpoly.rst
+++ b/doc/source/mpoly.rst
@@ -8,10 +8,10 @@
     number of variables in the polynomial ring.
     The element of this exponent vector at index `0`
     corresponds to the most significant variable in the monomial ordering.
-    For example, if the polynomial is `7*x^2*y+8*y*z+9` and the variables are
-    ordered so that `x>y>z`, the degree function will return `{2,1,1}`.
+    For example, if the polynomial is `7\cdot x^2\cdot y+8\cdot y\cdot z+9` and the variables are
+    ordered so that `x>y>z`, the degree function will return `\{2,1,1\}`.
     Similarly, the exponent vector of the `0`-index term of this polynomial is
-    `{2,1,0}`, while the `2`-index term has exponent vector `{0,0,0}` and
+    `\{2,1,0\}`, while the `2`-index term has exponent vector `\{0,0,0\}` and
     coefficient `9`.
 
 
@@ -27,7 +27,7 @@ Orderings
           mpoly_ctx_t
 
      An mpoly_ctx_struct is a structure holding information about the number of
-     variables and the term ordering of an multivariate polynomial.
+     variables and the term ordering of a multivariate polynomial.
 
 .. function:: void mpoly_ctx_init(mpoly_ctx_t ctx, slong nvars, const ordering_t ord)
 
@@ -35,7 +35,7 @@ Orderings
 
 .. function:: void mpoly_ctx_clear(mpoly_ctx_t mctx)
 
-    Clean up any spaced used by a context object.
+    Clean up any space used by a context object.
 
 .. function:: ordering_t mpoly_ordering_randtest(flint_rand_t state)
 
@@ -143,8 +143,8 @@ Monomial comparison
 
 .. function:: int mpoly_monomial_cmp(const ulong * exp2, const ulong * exp3, slong N, const ulong * cmpmask)
 
-    Return `1` if ``(exp2, N)`` is greater than, `0` if it is equal and
-    `-1` if it is less than, ``(exp3, N)``.
+    Return `1` if ``(exp2, N)`` is greater than, `0` if it is equal to and
+    `-1` if it is less than ``(exp3, N)``.
 
 
 Monomial divisibility
@@ -173,7 +173,7 @@ Monomial divisibility
 
     Return 1 if the monomial ``e2`` divides the monomial ``e1``, where
     the monomials are stored using factorial representation. The array
-    ``(prods, num)`` should consist of `1`, `b_1`, `b_1\times b_2, \ldots`,
+    ``(prods, num)`` should consist of `1`, `b_1, b_1\times b_2, \ldots`,
     where the `b_i` are the bases of the factorial number representation.
 
 
@@ -221,11 +221,11 @@ Basic manipulation
 .. function:: int mpoly_monomial_exists(slong * index, const ulong * poly_exps, const ulong * exp, slong len, slong N, const ulong * cmpmask)
 
     Returns true if the given exponent vector ``exp`` exists in the array of
-    exponent vectors ``(poly_exps, len)``, otherwise, return false. If the
+    exponent vectors ``(poly_exps, len)``, otherwise, returns false. If the
     exponent vector is found, its index into the array of exponent vectors is
     returned. Otherwise, ``index`` is set to the index where this exponent
     could be inserted to preserve the ordering. The index can be in the range
-    ``[0, len]```.
+    ``[0, len]``.
 
 .. function:: void mpoly_search_monomials( slong ** e_ind, ulong * e, slong * e_score, slong * t1, slong * t2, slong *t3, slong lower, slong upper, const ulong * a, slong a_len, const ulong * b, slong b_len, slong N, const ulong * cmpmask)
 
@@ -235,9 +235,9 @@ Basic manipulation
     ``lower`` and ``upper``. This number is stored in ``e_store``. If
     no such monomial exists, one is chosen so that the number of monomials is as
     close as possible. This function assumes that ``1`` is the smallest
-    monomial and needs three arrays ``t1``, ``t1``, and ``t3`` of the
+    monomial and needs three arrays ``t1``, ``t2``, and ``t3`` of the
     size as ``a`` for workspace. The parameter ``e_ind`` is set to one
-    of ``t1``, ``t1``, and ``t3`` and gives the locations of the
+    of ``t1``, ``t2``, and ``t3`` and gives the locations of the
     monomials in ``a`` X ``b``.
 
 
@@ -319,7 +319,7 @@ Packing and unpacking monomials
 
     Convert an array of length ``len`` of exponents ``exps2`` packed
     using bits ``bits2`` into an array ``exps1`` using bits ``bits1``.
-    No checking is done to unsure that the result fits into bits ``bits1``.
+    No checking is done to ensure that the result fits into bits ``bits1``.
  
 .. function:: void mpoly_pack_monomials_tight(ulong * exp1, const ulong * exp2, slong len, const slong * mults, slong num, slong extra, slong bits)
 

--- a/doc/source/profiler.rst
+++ b/doc/source/profiler.rst
@@ -108,7 +108,7 @@ Framework for repeatedly sampling a single target
         
         flint_printf("Min time is %lf.3s, max time is %lf.3s\n", min, max);
 
-    If either of the first two parameters to ``prof_repeat`` are 
+    If either of the first two parameters to ``prof_repeat`` is 
     ``NULL``, that value is not stored.
 
     One may set the minimum time in microseconds for a timing run by 

--- a/doc/source/thread_pool.rst
+++ b/doc/source/thread_pool.rst
@@ -19,7 +19,7 @@ Thread pool
 
     Initialise ``T`` and create ``size`` sleeping
     threads that are available to work.
-    If ``size \le 0`` no threads are created and future calls to
+    If `size \le 0` no threads are created and future calls to
     :func:`thread_pool_request` will return `0` (unless
     :func:`thread_pool_set_size` has been called).
 

--- a/doc/source/ulong_extras.rst
+++ b/doc/source/ulong_extras.rst
@@ -225,7 +225,7 @@ Basic arithmetic with precomputed inverses
     no restrictions on `a` and the only restriction on `n` is that it be
     nonzero. 
 
-    This uses the algorithm of Granlund and M\"oller [GraMol2010]_. First
+    This uses the algorithm of Granlund and Möller [GraMol2010]_. First
     `n` is normalised and `a` is shifted into two limbs to compensate. Then
     their algorithm is applied verbatim and the remainder shifted back.
 
@@ -235,7 +235,7 @@ Basic arithmetic with precomputed inverses
     `n` computed by :func:`n_preinvert_limb`. There are no restrictions on `a`
     and the only restriction on `n` is that it be nonzero. 
 
-    This uses the algorithm of Granlund and M\"oller [GraMol2010]_. First
+    This uses the algorithm of Granlund and Möller [GraMol2010]_. First
     `n` is normalised and `a` is shifted into two limbs to compensate. Then
     their algorithm is applied verbatim.
 
@@ -245,7 +245,7 @@ Basic arithmetic with precomputed inverses
     :func:`n_preinvert_limb()`. There are no restrictions on `a` and the only
     restriction on `n` is that it be nonzero. 
 
-    This uses the algorithm of Granlund and M\"oller [GraMol2010]_. First
+    This uses the algorithm of Granlund and Möller [GraMol2010]_. First
     `n` is normalised and `a` is shifted into two limbs to compensate. Then
     their algorithm is applied verbatim and the result shifted back.
 
@@ -272,7 +272,7 @@ Basic arithmetic with precomputed inverses
 
     The new version reduces the top limb modulo `n` as per 
     :func:`n_mod2_preinv` and then the algorithm of Granlund and 
-    M\"oller [GraMol2010]_ is used again to reduce modulo `n`.
+    Möller [GraMol2010]_ is used again to reduce modulo `n`.
 
 .. function:: ulong n_lll_mod_preinv(ulong a_hi, ulong a_mi, ulong a_lo, ulong n, ulong ninv)
 
@@ -282,7 +282,7 @@ Basic arithmetic with precomputed inverses
     restrictions on `n`.
 
     This function uses the algorithm of Granlund and 
-    M\"oller [GraMol2010]_ to first reduce the top two limbs 
+    Möller [GraMol2010]_ to first reduce the top two limbs 
     modulo `n`, then does the same on the bottom two limbs.
 
 
@@ -336,7 +336,7 @@ Basic arithmetic with precomputed inverses
     ``norm`` will shift the product right by this many bits before
     reducing it.
 
-    The algorithm used is that of Granlund and M\"oller [GraMol2010]_.
+    The algorithm used is that of Granlund and Möller [GraMol2010]_.
 
 
 

--- a/doc/source/ulong_extras.rst
+++ b/doc/source/ulong_extras.rst
@@ -134,11 +134,11 @@ Basic arithmetic with precomputed inverses
 
         invxl = (B^2 - B*x - 1)/x = (B^2 - 1)/x - B
 
-    Note that `x` must be normalised, i.e.\ with msb set. This inverse 
+    Note that `x` must be normalised, i.e. with msb set. This inverse 
     makes use of the following theorem of Torbjorn Granlund and Peter 
     Montgomery~[Lemma~8.1][GraMon1994]_:
 
-    Let `d` be normalised, `d < B`, i.e.\ it fits in a word, and suppose 
+    Let `d` be normalised, `d < B`, i.e. it fits in a word, and suppose 
     that `m d < B^2 \leq (m+1) d`. Let `0 \leq n \leq B d - 1`.  Write 
     `n = n_2 B + n_1 B/2 + n_0` with `n_1 = 0` or `1` and `n_0 < B/2`. 
     Suppose `q_1 B + q_0 = n_2 B + (n_2 + n_1) (m - B) + n_1 (d-B/2) + n_0`
@@ -153,7 +153,7 @@ Basic arithmetic with precomputed inverses
     all these terms contributes at most `1` to `q_1`. We are left with 
     `n_2 B + n_2 (m-B)`. But note that `(m-B)` is precisely our precomputed 
     inverse ``invxl``. If we write `q_1 B + q_0 = n_2 B + n_2 (m-B)`, 
-    then from the theorem, we have `0 \leq n - q_1 d < 3 d`, i.e.\ the 
+    then from the theorem, we have `0 \leq n - q_1 d < 3 d`, i.e. the 
     quotient is out by at most `2` and is always either correct or too small.
 
 .. function:: ulong n_preinvert_limb(ulong n)
@@ -193,7 +193,7 @@ Basic arithmetic with precomputed inverses
     exact quotient, we have rounded down by less than `1` plus half a 
     place. But as the product is less than `n` and `n` is less than `2^{53}`,
     half a place is less than `1`, thus we are out by less than `2` from 
-    the exact quotient, i.e.\ the quotient we have computed is the 
+    the exact quotient, i.e. the quotient we have computed is the 
     quotient we are after or one too small. That leaves only the case 
     where we had to round up to the nearest place which happened to 
     be an integer, so that truncating to an integer didn't change 
@@ -336,7 +336,7 @@ Basic arithmetic with precomputed inverses
     ``norm`` will shift the product right by this many bits before
     reducing it.
 
-    The algorithm use is that of Granlund and M\"oller [GraMol2010]_.
+    The algorithm used is that of Granlund and M\"oller [GraMol2010]_.
 
 
 
@@ -398,7 +398,7 @@ Jacobi and Kronecker symbols
 
 .. function:: int n_jacobi(mp_limb_signed_t x, ulong y)
 
-    Computes the Jacobi symbol `\left(\frac{x}{y}\right)` for any x and odd `y`.
+    Computes the Jacobi symbol `\left(\frac{x}{y}\right)` for any `x` and odd `y`.
 
 .. function:: int n_jacobi_unsigned(ulong x, ulong y)
 
@@ -448,7 +448,7 @@ Modular Arithmetic
 .. function:: ulong n_powmod(ulong a, mp_limb_signed_t exp, ulong n)
 
     Returns ``a^exp`` modulo `n`. We require ``n < 2^FLINT_D_BITS`` 
-    and `0 \leq a < n`. There are no restrictions on ``exp``, i.e.\ 
+    and `0 \leq a < n`. There are no restrictions on ``exp``, i.e. 
     it can be negative.
 
     This is implemented by precomputing an inverse and calling the 
@@ -458,7 +458,7 @@ Modular Arithmetic
 
     Returns ``(a^exp) % n`` given a precomputed inverse of `n` computed 
     by :func:`n_preinvert_limb`. We require `0 \leq a < n`, but there are no 
-    restrictions on `n` or on ``exp``, i.e.\ it can be negative.
+    restrictions on `n` or on ``exp``, i.e. it can be negative.
 
     This is implemented as a standard binary powering algorithm using
     repeated squaring and reducing modulo `n` at each step.
@@ -469,7 +469,7 @@ Modular Arithmetic
 .. function:: ulong n_powmod2(ulong a, mp_limb_signed_t exp, ulong n)
 
     Returns ``(a^exp) % n``. We require `0 \leq a < n`, but there are 
-    no restrictions on `n` or on ``exp``, i.e.\ it can be negative.
+    no restrictions on `n` or on ``exp``, i.e. it can be negative.
 
     This is implemented by precomputing an inverse limb and calling the 
     ``preinv`` version of this function.
@@ -551,7 +551,7 @@ Modular Arithmetic
 .. function:: mp_limb_t n_mulmod_precomp_shoup(mp_limb_t w, mp_limb_t p)
 
     Returns `w'`, scaled approximation of `w / p`. `w'`  is equal to the integer 
-    part of `w * 2^{\mathtt{FLINT\_BITS}} / p`.
+    part of `w \cdot 2^{\mathtt{FLINT\_BITS}} / p`.
 
 
 Divisibility testing
@@ -560,7 +560,7 @@ Divisibility testing
 .. function:: int n_divides(mp_limb_t * q, mp_limb_t n, mp_limb_t p)
 
    Returns ``1`` if ``p`` divides ``n`` and sets ``q`` to the quotient,
-   otherwise return ``0`` and sets ``q`` to ``0``.
+   otherwise returns ``0`` and sets ``q`` to ``0``.
 
 Prime number generation and counting
 --------------------------------------------------------------------------------
@@ -631,12 +631,12 @@ Prime number generation and counting
 .. function:: ulong n_nextprime(ulong n, int proved)
 
     Returns the next prime after `n`. Assumes the result will fit in an
-    ``ulong``. If proved is `0`, i.e.\ false, the prime is not 
+    ``ulong``. If proved is `0`, i.e. false, the prime is not 
     proven prime, otherwise it is.
 
 .. function:: ulong n_prime_pi(ulong n)
 
-    Returns the value of the prime counting function `\pi(n)`, i.e.\ the
+    Returns the value of the prime counting function `\pi(n)`, i.e. the
     number of primes less than or equal to `n`. The invariant
     ``n_prime_pi(n_nth_prime(n)) == n``.
 
@@ -670,7 +670,7 @@ Prime number generation and counting
 
 .. function:: void n_nth_prime_bounds(ulong *lo, ulong *hi, ulong n)
 
-    Calculates lower and upper bounds for the  `n` th prime number `p_n` ,
+    Calculates lower and upper bounds for the  `n`th prime number `p_n` ,
     ``lo <= p_n <= hi``. If ``lo`` and ``hi`` point to the same 
     location, the high value will be stored. Note that this function will 
     overflow for sufficiently large `n`.
@@ -795,7 +795,7 @@ Primality testing
     `a` to be reduced modulo `n` and not `0` and `n` to be odd.
 
     If we write `n - 1 = 2^s d` where `d` is odd then `n` is a strong 
-    probable prime to the base `a`, i.e.\ an `a`-SPRP, if either 
+    probable prime to the base `a`, i.e. an `a`-SPRP, if either 
     `a^d = 1 \pmod n` or `(a^d)^{2^r} = -1 \pmod n` for some `r` less 
     than `s`.
 
@@ -844,8 +844,8 @@ Primality testing
 
     This implementation makes use of a weakening of the usual Baillie-PSW
     test given in  [Chen2003]_, namely replacing the Lucas test with a
-    Fibonacci test when `n \equiv 2, 3 \pmod{5}`, (see also the comment on 
-    page 143 of [CraPom2005]_) regarding Fibonacci pseudoprimes.
+    Fibonacci test when `n \equiv 2, 3 \pmod{5}` (see also the comment on 
+    page 143 of [CraPom2005]_), regarding Fibonacci pseudoprimes.
 
     There are no known counterexamples to this being a primality test.
 
@@ -885,7 +885,7 @@ Chinese remaindering
 
 .. function:: ulong n_CRT(ulong r1, ulong m1, ulong r2, ulong m2)
 
-    Use the Chinese Remainder Theorem to set return the unique value
+    Use the Chinese Remainder Theorem to return the unique value
     `0 \le x < M` congruent to `r_1` modulo `m_1` and `r_2` modulo `m_2`,
     where `M = m_1 \times m_2` is assumed to fit a ulong.
 
@@ -910,7 +910,7 @@ Square root and perfect power testing
     We also have to be careful when the square of this too large 
     value causes an overflow. The same assumptions hold for a single 
     precision float provided the square root itself can be represented 
-    in a single float, i.e.\ for `a < 281474976710656 = 2^{46}`.
+    in a single float, i.e. for `a < 281474976710656 = 2^{46}`.
 
 .. function:: ulong n_sqrtrem(ulong * r, ulong a)
 
@@ -966,7 +966,7 @@ Square root and perfect power testing
     This function uses the Newton iteration method to calculate the nth root of
     a number.
     First approximation is calculated by an algorithm mentioned in this 
-    article :  https://en.wikipedia.org/wiki/Fast_inverse_square_root . 
+    article:  https://en.wikipedia.org/wiki/Fast_inverse_square_root . 
     Instead of the inverse square root, the nth root is calculated.
     
     Returns the integer part of ``n ^ 1/root``. Remainder is set as
@@ -976,12 +976,12 @@ Square root and perfect power testing
     
     This function returns the integer truncation of the cube root of `n`.
     First approximation is calculated by an algorithm mentioned in this 
-    article : https://en.wikipedia.org/wiki/Fast_inverse_square_root .
+    article: https://en.wikipedia.org/wiki/Fast_inverse_square_root .
     Instead of the inverse sqare root, the cube root is calculated.
     This functions uses different algorithms to calculate the cube root,
-    depending upon the size of `n`. For numbers greater than `2^46`, it uses
+    depending upon the size of `n`. For numbers greater than `2^{46}`, it uses
     :func:`n_cbrt_chebyshev_approx`. Otherwise, it makes use of the iteration, 
-    `x \leftarrow x - (x*x*x - a)*x/(2*x*x*x + a)` for getting a good estimate, 
+    `x \leftarrow x - (x\cdot x\cdot x - a)\cdot x/(2\cdot x\cdot x\cdot x + a)` for getting a good estimate, 
     as mentioned in the paper by W. Kahan [Kahan1991]_ .
 
 .. function:: ulong n_cbrt_newton_iteration(ulong n)
@@ -1000,8 +1000,8 @@ Square root and perfect power testing
     This function returns the integer truncation of the cube root of `n`.
     The number is first expressed in the form ``x * 2^exp``. This ensures
     `x` is in the range [0.5, 1]. Cube root of x is calculated using
-    Chebyshev's approximation polynomial for the function `y = x^1/3`. The
-    values of the coefficient are calculated from the python module mpmath, 
+    Chebyshev's approximation polynomial for the function `y = x^{1/3}`. The
+    values of the coefficient are calculated from the Python module mpmath, 
     http://mpmath.org, using the function chebyfit. x is multiplied 
     by ``2^exp`` and the cube root of 1, 2 or 4 (according to ``exp%3``).
 
@@ -1018,7 +1018,7 @@ Factorisation
 .. function:: int n_remove(ulong * n, ulong p)
 
     Removes the highest possible power of `p` from `n`, replacing
-    `n` with the quotient. The return value is that highest 
+    `n` with the quotient. The return value is the highest 
     power of `p` that divided `n`. Assumes `n` is not `0`.
 
     For `p = 2` trailing zeroes are counted. For other primes
@@ -1031,7 +1031,7 @@ Factorisation
 .. function:: int n_remove2_precomp(ulong * n, ulong p, double ppre)
 
     Removes the highest possible power of `p` from `n`, replacing
-    `n` with the quotient. The return value is that highest 
+    `n` with the quotient. The return value is the highest 
     power of `p` that divided `n`. Assumes `n` is not `0`. We require
     ``ppre`` to be set to a precomputed inverse of `p` computed 
     with :func:`n_precompute_inverse`.
@@ -1065,7 +1065,7 @@ Factorisation
     initialisation has not already been completed on factors.
 
     Once completed, ``num`` will contain the number of distinct 
-    prime factors found. The field `p` is an array of ``ulong``'s 
+    prime factors found. The field `p` is an array of ``ulong``s 
     containing the distinct prime factors, ``exp`` an array 
     containing the corresponding exponents.
 
@@ -1123,7 +1123,7 @@ Factorisation
 .. function:: ulong n_factor_SQUFOF(ulong n, ulong iters)
 
     Attempts to split `n` using the given number of iterations
-    of SQUFOF. Simply set ``iters`` to `` WORD(0)`` for maximum 
+    of SQUFOF. Simply set ``iters`` to ``WORD(0)`` for maximum 
     persistence.
 
     The version of SQUFOF implemented here is as described by Gower 
@@ -1145,7 +1145,7 @@ Factorisation
     Factors `n` with no restrictions on `n`. If the prime factors are 
     required to be checked with a primality test, one may set 
     ``proved`` to `1`, otherwise set it to `0`, and they will only be 
-    probable primes. N.B: at the present there is no difference because 
+    probable primes. NB: at the present there is no difference because 
     the probable prime tests have been exhaustively tested up to `2^{64}`.
 
     However, in future, this flag may produce and separately check
@@ -1183,7 +1183,7 @@ Factorisation
     initialisation has not already been completed on ``factors``.
 
     Once completed, ``num`` will contain the number of distinct 
-    prime factors found. The field `p` is an array of ``ulong``'s 
+    prime factors found. The field `p` is an array of ``ulong``s 
     containing the distinct prime factors, ``exp`` an array 
     containing the corresponding exponents.
 
@@ -1213,7 +1213,7 @@ Factorisation
     initialisation has not already been completed on ``factors``.
 
     On exit, ``num`` will contain the number of distinct prime factors 
-    found. The field `p` is an array of ``ulong``'s containing the 
+    found. The field `p` is an array of ``ulong``s containing the 
     distinct prime factors, ``exp`` an array containing the corresponding 
     exponents.
 
@@ -1249,13 +1249,13 @@ Factorisation
     Assumes that the `n` is not prime. `factor` is set as the factor if found. 
     It is not assured that the factor found will be prime. Does not compute the complete 
     factorization, just one factor. Returns 1 if factorization is successful 
-    (non trivial factor is found), else returns 0. Assumes `n` is normalized,
+    (non trivial factor is found), else returns 0. Assumes `n` is normalized
     (shifted by normbits bits), and takes as input a precomputed inverse of `n` as 
     computed by :func:`n_preinvert_limb`. `ai` and `xi` should also be shifted
     left by `normbits`.
 
     `ai` is the constant of the polynomial used, `xi` is the initial value. 
-    `max_iters` is the number of iterations tried in process of finding the 
+    `max\_iters` is the number of iterations tried in process of finding the 
     cycle.
 
     The algorithm used is a modification of the original Pollard Rho algorithm,
@@ -1270,7 +1270,7 @@ Factorisation
 
     If the algorithm fails to find a non trivial factor in one call, it tries again 
     (this time with a different set of random values). This process is repeated a 
-    maximum of `max_tries` times. 
+    maximum of `max\_tries` times. 
 
     Assumes `n` is not prime. `factor` is set as the factor found, if factorization
     is successful. In such a case, 1 is returned. Otherwise, 0 is returned. Factor
@@ -1356,8 +1356,8 @@ Primitive Roots and Discrete Logarithms
 
     Returns the discrete logarithm of `b` with  respect to `a` in the
     multiplicative subgroup of `\mathbb{Z}/n\mathbb{Z}` when `\mathbb{Z}/n\mathbb{Z}`
-    is cyclic That is,
-    it returns an number `x` such that `a^x = b \bmod n`.  The
+    is cyclic. That is,
+    it returns a number `x` such that `a^x = b \bmod n`.  The
     multiplicative subgroup is only cyclic when `n` is `2`, `4`,
     `p^k`, or `2p^k` where `p` is an odd prime and `k` is a positive
     integer.
@@ -1373,9 +1373,9 @@ Elliptic curve method for factorization of ``mp_limb_t``
     Sets the point `(x : z)` to two times `(x_0 : z_0)` modulo `n` according
     to the formula
 
-    ``x = (x_0 + z_0)^2 \cdot (x_0 - z_0)^2 \mod n,``
+    `x = (x_0 + z_0)^2 \cdot (x_0 - z_0)^2 \mod n,`
 
-    ``z = 4 x_0 z_0 \left((x_0 - z_0)^2 + 4a_{24}x_0z_0\right) \mod n.``
+    `z = 4 x_0 z_0 \left((x_0 - z_0)^2 + 4a_{24}x_0z_0\right) \mod n.`
 
     This group doubling is valid only for points expressed in
     Montgomery projective coordinates.
@@ -1405,7 +1405,7 @@ Elliptic curve method for factorization of ``mp_limb_t``
 
     Also selects the initial point `x_0`, and the value of `(a + 2)/4`, where `a`
     is a curve parameter. Sets `z_0` as `1` (shifted left by
-    ``n_ecm_inf->normbits``. All these are stored in the
+    ``n_ecm_inf->normbits``). All these are stored in the
     ``n_ecm_t`` struct.
 
     The curve selected is of Montgomery form, the points selected satisfy the
@@ -1413,7 +1413,7 @@ Elliptic curve method for factorization of ``mp_limb_t``
 
 .. function:: int n_factor_ecm_stage_I(mp_limb_t *f, const mp_limb_t *prime_array, mp_limb_t num, mp_limb_t B1, mp_limb_t n, n_ecm_t n_ecm_inf)
 
-    Stage\ I implementation of the ECM algorithm.
+    Stage I implementation of the ECM algorithm.
 
     ``f`` is set as the factor if found. ``num`` is number of prime numbers
     `<=` the bound ``B1``. ``prime_array`` is an array of first ``B1``
@@ -1423,7 +1423,7 @@ Elliptic curve method for factorization of ``mp_limb_t``
 
 .. function:: int n_factor_ecm_stage_II(mp_limb_t *f, mp_limb_t B1, mp_limb_t B2, mp_limb_t P, mp_limb_t n, n_ecm_t n_ecm_inf)
 
-    Stage\ II implementation of the ECM algorithm.
+    Stage II implementation of the ECM algorithm.
 
     ``f`` is set as the factor if found. ``B1``, ``B2`` are the two
     bounds. ``P`` is the primorial (approximately equal to `\sqrt{B2}`).
@@ -1436,16 +1436,16 @@ Elliptic curve method for factorization of ``mp_limb_t``
     Outer wrapper function for the ECM algorithm. It factors `n` which
     must fit into a ``mp_limb_t``.
 
-    The function calls stage\ I and\ II, and
-    the precomputations (builds ``prime_array`` for stage\ I,
-    ``GCD_table`` and ``prime_table`` for stage\ II).
+    The function calls stage I and II, and
+    the precomputations (builds ``prime_array`` for stage I,
+    ``GCD_table`` and ``prime_table`` for stage II).
 
     ``f`` is set as the factor if found. ``curves`` is the number of
     random curves being tried. ``B1``, ``B2`` are the two bounds or
-    stage\ I and stage\ II. `n` is the number being factored.
+    stage I and stage II. `n` is the number being factored.
 
-    If a factor is found in stage\ I, `1` is returned.
-    If a factor is found in stage\ II, `2` is returned.
+    If a factor is found in stage I, `1` is returned.
+    If a factor is found in stage II, `2` is returned.
     If a factor is found while selecting the curve, `-1` is returned.
     Otherwise `0` is returned.
 


### PR DESCRIPTION
I corrected some mistakes. Do check carefully whether I got everything right without distorting the meaning.

**Note:** `M\"oller` is shown as `M”oller` on the website. I am not sure how to solve this, perhaps `M{\"o}ller` will work?